### PR TITLE
Use an offset timing schedule to run PyTorch tests

### DIFF
--- a/examples/metrics/kustomization.yaml
+++ b/examples/metrics/kustomization.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 generatorOptions:

--- a/k8s/gen/pt-nightly-cifar-inline-convergence-v2-8.yaml
+++ b/k8s/gen/pt-nightly-cifar-inline-convergence-v2-8.yaml
@@ -84,4 +84,4 @@
               "pdName": "cifar-pd-central1-b"
               "readOnly": true
             "name": "cifar-pd"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-cifar-inline-convergence-v3-8.yaml
+++ b/k8s/gen/pt-nightly-cifar-inline-convergence-v3-8.yaml
@@ -84,4 +84,4 @@
               "pdName": "cifar-pd-central1-b"
               "readOnly": true
             "name": "cifar-pd"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-cifar-torchvision-convergence-v2-8.yaml
+++ b/k8s/gen/pt-nightly-cifar-torchvision-convergence-v2-8.yaml
@@ -85,4 +85,4 @@
               "pdName": "cifar-pd-central1-b"
               "readOnly": true
             "name": "cifar-pd"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-cifar-torchvision-convergence-v3-8.yaml
+++ b/k8s/gen/pt-nightly-cifar-torchvision-convergence-v3-8.yaml
@@ -85,4 +85,4 @@
               "pdName": "cifar-pd-central1-b"
               "readOnly": true
             "name": "cifar-pd"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-fairseq-transformer-convergence-v3-8.yaml
+++ b/k8s/gen/pt-nightly-fairseq-transformer-convergence-v3-8.yaml
@@ -114,4 +114,4 @@
               "pdName": "wmt18-en-de-pd-central1-b"
               "readOnly": true
             "name": "wmt18-pd"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 6 * * 1,6"

--- a/k8s/gen/pt-nightly-fairseq-transformer-functional-v3-8.yaml
+++ b/k8s/gen/pt-nightly-fairseq-transformer-functional-v3-8.yaml
@@ -112,4 +112,4 @@
               "pdName": "wmt18-en-de-pd-central1-b"
               "readOnly": true
             "name": "wmt18-pd"
-  "schedule": "0 8 * * *"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-mnist-convergence-v2-8.yaml
+++ b/k8s/gen/pt-nightly-mnist-convergence-v2-8.yaml
@@ -73,4 +73,4 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-mnist-convergence-v3-8.yaml
+++ b/k8s/gen/pt-nightly-mnist-convergence-v3-8.yaml
@@ -73,4 +73,4 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-python-operations-functional-v2-8.yaml
+++ b/k8s/gen/pt-nightly-python-operations-functional-v2-8.yaml
@@ -72,4 +72,4 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 8 * * *"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-python-operations-functional-v3-8.yaml
+++ b/k8s/gen/pt-nightly-python-operations-functional-v3-8.yaml
@@ -72,4 +72,4 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 8 * * *"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-resnet50-convergence-v3-8.yaml
+++ b/k8s/gen/pt-nightly-resnet50-convergence-v3-8.yaml
@@ -87,4 +87,4 @@
               "pdName": "imagenet-pd-central1-b"
               "readOnly": true
             "name": "imagenet-pd"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 6 * * 1,6"

--- a/k8s/gen/pt-nightly-resnet50-functional-v3-8.yaml
+++ b/k8s/gen/pt-nightly-resnet50-functional-v3-8.yaml
@@ -87,4 +87,4 @@
               "pdName": "imagenet-mini-pd-central1-b"
               "readOnly": true
             "name": "imagenet-mini-pd"
-  "schedule": "0 8 * * *"
+  "schedule": "0 14 * * *"

--- a/templates/pytorch/nightly/base.libsonnet
+++ b/templates/pytorch/nightly/base.libsonnet
@@ -13,11 +13,20 @@
 # limitations under the License.
 
 local base = import "../base.libsonnet";
+local mixins = import "../../mixins.libsonnet";
 
 {
   PyTorchTest:: base.PyTorchTest {
     frameworkPrefix: "pt-nightly",
     tpuVersion: "pytorch-nightly",
     imageTag: "nightly",
+  },
+  Functional:: mixins.Functional {
+    # Run at 6AM PST daily.
+    schedule: "0 14 * * *",
+  },
+  Convergence:: mixins.Convergence {
+    # Run at 22:00 PST on Monday and Thursday.
+    schedule: "0 6 * * 1,6",
   },
 }

--- a/templates/pytorch/nightly/cifar-inline.libsonnet
+++ b/templates/pytorch/nightly/cifar-inline.libsonnet
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 local base = import "base.libsonnet";
-local mixins = import "../../mixins.libsonnet";
 local timeouts = import "../../timeouts.libsonnet";
 local tpus = import "../../tpus.libsonnet";
 
@@ -54,7 +53,9 @@ local tpus = import "../../tpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = base.Convergence {
+    # Run at 6AM PST daily instead of 2x per week since convergence is fast.
+    schedule: "0 14 * * *",
     regressionTestConfig+: {
       metric_success_conditions+: {
         "Accuracy/test_final": {

--- a/templates/pytorch/nightly/cifar-torchvision.libsonnet
+++ b/templates/pytorch/nightly/cifar-torchvision.libsonnet
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 local base = import "base.libsonnet";
-local mixins = import "../../mixins.libsonnet";
 local timeouts = import "../../timeouts.libsonnet";
 local tpus = import "../../tpus.libsonnet";
 
@@ -55,7 +54,9 @@ local tpus = import "../../tpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = base.Convergence {
+    # Run at 6AM PST daily instead of 2x per week since convergence is fast.
+    schedule: "0 14 * * *",
     regressionTestConfig+: {
       metric_success_conditions+: {
         "Accuracy/test_final": {

--- a/templates/pytorch/nightly/fairseq-transformer.libsonnet
+++ b/templates/pytorch/nightly/fairseq-transformer.libsonnet
@@ -1,5 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 local base = import "base.libsonnet";
-local mixins = import "../../mixins.libsonnet";
 local timeouts = import "../../timeouts.libsonnet";
 local tpus = import "../../tpus.libsonnet";
 
@@ -69,7 +82,7 @@ local tpus = import "../../tpus.libsonnet";
       },
     },
   },
-  local functional = mixins.Functional {
+  local functional = base.Functional {
     command+: [
       "--max-epoch=1",
       "--log_steps=10",
@@ -91,7 +104,7 @@ local tpus = import "../../tpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = base.Convergence {
     command+: [
       "--max-epoch=3",
       "--log_steps=100",

--- a/templates/pytorch/nightly/mnist.libsonnet
+++ b/templates/pytorch/nightly/mnist.libsonnet
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 local base = import "base.libsonnet";
-local mixins = import "../../mixins.libsonnet";
 local timeouts = import "../../timeouts.libsonnet";
 local tpus = import "../../tpus.libsonnet";
 
@@ -26,7 +25,9 @@ local tpus = import "../../tpus.libsonnet";
       "--logdir=$(MODEL_DIR)",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = base.Convergence {
+    # Run at 6AM PST daily instead of 2x per week since convergence is fast.
+    schedule: "0 14 * * *",
     accelerator+: tpus.Preemptible,
     regressionTestConfig+: {
       metric_success_conditions+: {

--- a/templates/pytorch/nightly/python-operations.libsonnet
+++ b/templates/pytorch/nightly/python-operations.libsonnet
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 local base = import "base.libsonnet";
-local mixins = import "../../mixins.libsonnet";
 local timeouts = import "../../timeouts.libsonnet";
 local tpus = import "../../tpus.libsonnet";
 
@@ -34,7 +33,7 @@ local tpus = import "../../tpus.libsonnet";
   },
 
   configs: [
-    operations + v2_8 + mixins.Functional + timeouts.Hours(2),
-    operations + v3_8 + mixins.Functional + timeouts.Hours(2),
+    operations + v2_8 + base.Functional + timeouts.Hours(2),
+    operations + v3_8 + base.Functional + timeouts.Hours(2),
   ],
 }

--- a/templates/pytorch/nightly/resnet50.libsonnet
+++ b/templates/pytorch/nightly/resnet50.libsonnet
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 local base = import "base.libsonnet";
-local mixins = import "../../mixins.libsonnet";
 local timeouts = import "../../timeouts.libsonnet";
 local tpus = import "../../tpus.libsonnet";
 
@@ -46,7 +45,7 @@ local tpus = import "../../tpus.libsonnet";
       },
     },
   },
-  local functional = mixins.Functional {
+  local functional = base.Functional {
     command+: [
       "--num_epochs=2",
       "--datadir=/datasets/imagenet-mini",
@@ -77,7 +76,7 @@ local tpus = import "../../tpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = base.Convergence {
     accelerator+: tpus.Preemptible,
     command+: [
       "--num_epochs=90",


### PR DESCRIPTION
This should reduce the load spike on TPUs. Override schedule to run some convergence tests daily for fast models: MNIST and CIFAR-based resnet

Change-Id: Ifa96d4ed040680f69fd6dc9466ea6e469bc29dae