### PR TITLE
Update README for creating images to mention OAuth for Scheduler.

### DIFF
--- a/examples/pt-imagenet-mini-gpu.yaml
+++ b/examples/pt-imagenet-mini-gpu.yaml
@@ -45,7 +45,7 @@ spec:
           - name: "train-container"
             # TODO: Change this to your image if desired. See `images/README`
             # for more on setting up images.
-            image: "gcr.io/xl-ml-test/pytorch-examples-gpu:latest"
+            image: "gcr.io/xl-ml-test/pytorch-examples-gpu:nightly"
             imagePullPolicy: Always
             resources:
               limits:

--- a/images/README.md
+++ b/images/README.md
@@ -67,5 +67,14 @@ Navigate to the [Cloud Schedulers page](https://console.cloud.google.com/cloudsc
 * For the "URL", use your trigger, e.g. `https://cloudbuild.googleapis.com/v1/projects/xl-ml-test/triggers/pytorch-examples-gpu-master:run`.
     * The format is `https://cloudbuild.googleapis.com/v1/projects/your-project-name/triggers/your-trigger-name:run`.
 * Use `POST` for the "HTTP method".
-* For "Body", use: `{"branchName": "master", "substitutions": {"_VERSION": "nightly"}}`
+* For "Body", use: `{"branchName": "master", "substitutions": {"_VERSION": "nightly"}}`.
+* Click "Show More" to add a few more things:
+    * "Auth header": `Add OAuth token`.
+    * "Service account": Find the email of the "Compute Engine default service account":
+        1. Go to the [IAM page](https://console.cloud.google.com/iam-admin/iam) for your project.
+        2. Find the row with "Name" = "Compute Engine default service account".
+        3. Copy the email address (i.e. the "Member" column).
+            * The Member field will be of the form: `1234567890123-compute@developer.gserviceaccount.com`.
+        4. Use this address for the "Service account" field of your Cloud Scheduler.
+    * "Scope": `https://www.googleapis.com/auth/cloud-platform`.
 


### PR DESCRIPTION
Also change PyTorch GPU example to use `nightly` instead of `latest` for the image tag

Change-Id: Ia2edf1ddf6dc84a6f551386bed9d612d25eb0ed8