### PR TITLE
Use null instead of {} for python unit test regression config

### DIFF
--- a/k8s/gen/pt-nightly-python-operations-functional-v2-8.yaml
+++ b/k8s/gen/pt-nightly-python-operations-functional-v2-8.yaml
@@ -50,7 +50,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n\n },\n \"test_name\": \"pt-nightly-python-operations-functional-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-python-operations-functional-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/python-operations/functional/v2-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"

--- a/k8s/gen/pt-nightly-python-operations-functional-v3-8.yaml
+++ b/k8s/gen/pt-nightly-python-operations-functional-v3-8.yaml
@@ -50,7 +50,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n\n },\n \"test_name\": \"pt-nightly-python-operations-functional-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-python-operations-functional-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/python-operations/functional/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"

--- a/templates/pytorch/nightly/python-operations.libsonnet
+++ b/templates/pytorch/nightly/python-operations.libsonnet
@@ -23,7 +23,7 @@ local tpus = import "../../tpus.libsonnet";
       "bash",
       "pytorch/xla/test/run_tests.sh",
     ],
-    regressionTestConfig: {}
+    regressionTestConfig: null,
   },
   local v2_8 = {
     accelerator: tpus.v2_8,


### PR DESCRIPTION
To be consistent with the cpp unit tests added in #15 

Change-Id: I426fdc0d10ea8629884d2f4ff19bddabdc2ceb94