### PR TITLE
Remove unused logs_link from some levels of logger

### DIFF
--- a/metrics_handler/alert_handler.py
+++ b/metrics_handler/alert_handler.py
@@ -96,21 +96,21 @@ class AlertHandler(object):
     if self.write_to_email and log_level <= logging.ERROR:
       self._add_to_email(message, logs_link)
 
-  def debug(self, message, logs_link=_NO_LOGS):
+  def debug(self, message):
     """Log a message at DEBUG level.
 
     Args:
       message (string): Message to log.
     """
-    self._log_all(message, logging.DEBUG, logs_link=logs_link)
+    self._log_all(message, logging.DEBUG)
 
-  def info(self, message, logs_link=_NO_LOGS):
+  def info(self, message):
     """Log a message at INFO level.
 
     Args:
       message (string): Message to log.
     """
-    self._log_all(message, logging.INFO, logs_link=logs_link)
+    self._log_all(message, logging.INFO)
 
   def warning(self, message):
     """Log a message at WARNING level.
@@ -118,7 +118,7 @@ class AlertHandler(object):
     Args:
       message (string): Message to log.
     """
-    self._log_all(message, logging.WARNING, logs_link=logs_link)
+    self._log_all(message, logging.WARNING)
 
   def error(self, message, logs_link=_NO_LOGS):
     """Log a message at ERROR level.

--- a/metrics_handler/job_status_handler.py
+++ b/metrics_handler/job_status_handler.py
@@ -121,7 +121,7 @@ class JobStatusHandler(object):
     self.logger.info('job_name: {}. status: {}'.format(job_name, status))
     start_time = status.start_time.timestamp()
     if status.active:
-      self.logger.error('Job is still active. Returning UNKNOWN_STATUS.')
+      self.logger.warning('Job is still active. Returning UNKNOWN_STATUS.')
       return UNKNOWN_STATUS, start_time, None, None
 
     # Interpret status and return the important parts.


### PR DESCRIPTION
The log links only get used for ERROR and FATAL logging. Remove them from lower log levels