### PR TITLE
Append date range arg to Stackdriver logs link.

### DIFF
--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -24,6 +24,7 @@ import uuid
 
 import alert_handler
 import job_status_handler
+import util
 
 import google.api_core.exceptions
 from google.cloud import bigquery
@@ -562,6 +563,7 @@ def _process_pubsub_message(msg, status_handler, logger):
     raise ValueError('Pubsub message must contain 4 required fields: '
                      'events_dir, test_name, logs_link, and job_name. '
                      'Message was: {}'.format(event))
+  logs_link = util.add_unbound_time_to_logs_link(logs_link)
   if not regression_test_config and not metric_collection_config:
     raise ValueError('metric_collection_config and regression_test_config '
                      'were both null; stopping early. See README for '

--- a/metrics_handler/util.py
+++ b/metrics_handler/util.py
@@ -20,6 +20,7 @@ import re
 
 LOGS_DOWNLOAD_COMMAND = """gcloud logging read 'resource.type=k8s_container resource.labels.project_id={project} resource.labels.location={zone} resource.labels.cluster_name={cluster} resource.labels.namespace_name={namespace} resource.labels.pod_name:{pod}' --limit 10000000000000 --order asc --format 'value(textPayload)' > {pod}_logs.txt && sed -i '/^$/d' {pod}_logs.txt"""
 LOG_LINK_REGEX = re.compile('https://console\.cloud\.google\.com/logs\?project=(\S+)\&advancedFilter=resource\.type\%3Dk8s_container\%0Aresource\.labels\.project_id\%3D(?P<project>\S+)\%0Aresource\.labels\.location=(?P<zone>\S+)\%0Aresource\.labels\.cluster_name=(?P<cluster>\S+)\%0Aresource\.labels\.namespace_name=(?P<namespace>\S+)\%0Aresource\.labels\.pod_name:(?P<pod>[a-zA-Z0-9\-\.]+)')
+UNBOUND_DATE_RANGE = '&dateRangeUnbound=backwardInTime'
 
 def _parse_logs_link(logs_link):
   log_pieces = LOG_LINK_REGEX.match(logs_link)
@@ -27,6 +28,20 @@ def _parse_logs_link(logs_link):
     raise ValueError('Could not parse Stackdriver logs link. '
                      'Logs link was: {}'.format(logs_link))
   return log_pieces.groupdict()
+
+
+def add_unbound_time_to_logs_link(logs_link):
+  """Add dateRangeUnbound arg to `logs_link` if it doesn't already exist.
+
+  Args:
+    logs_link (string): Link to the logs of a Kubernetes pod.
+
+  Returns:
+    logs_link (string): Input with dateRangeUnbound added to it or the
+      input unchanged if it already contained dateRangeUnbound.
+  """
+  return logs_link if UNBOUND_DATE_RANGE in logs_link else \
+      logs_link + UNBOUND_DATE_RANGE
 
 
 def download_command_from_logs_link(logs_link):

--- a/metrics_handler/util.py
+++ b/metrics_handler/util.py
@@ -19,7 +19,7 @@ import re
 
 
 LOGS_DOWNLOAD_COMMAND = """gcloud logging read 'resource.type=k8s_container resource.labels.project_id={project} resource.labels.location={zone} resource.labels.cluster_name={cluster} resource.labels.namespace_name={namespace} resource.labels.pod_name:{pod}' --limit 10000000000000 --order asc --format 'value(textPayload)' > {pod}_logs.txt && sed -i '/^$/d' {pod}_logs.txt"""
-LOG_LINK_REGEX = re.compile('https://console\.cloud\.google\.com/logs\?project=(\S+)\&advancedFilter=resource\.type\%3Dk8s_container\%0Aresource\.labels\.project_id\%3D(?P<project>\S+)\%0Aresource\.labels\.location=(?P<zone>\S+)\%0Aresource\.labels\.cluster_name=(?P<cluster>\S+)\%0Aresource\.labels\.namespace_name=(?P<namespace>\S+)\%0Aresource\.labels\.pod_name:(?P<pod>[a-zA-Z0-9\-]+)')
+LOG_LINK_REGEX = re.compile('https://console\.cloud\.google\.com/logs\?project=(\S+)\&advancedFilter=resource\.type\%3Dk8s_container\%0Aresource\.labels\.project_id\%3D(?P<project>\S+)\%0Aresource\.labels\.location=(?P<zone>\S+)\%0Aresource\.labels\.cluster_name=(?P<cluster>\S+)\%0Aresource\.labels\.namespace_name=(?P<namespace>\S+)\%0Aresource\.labels\.pod_name:(?P<pod>[a-zA-Z0-9\-\.]+)')
 
 def _parse_logs_link(logs_link):
   log_pieces = LOG_LINK_REGEX.match(logs_link)

--- a/metrics_handler/util_test.py
+++ b/metrics_handler/util_test.py
@@ -20,9 +20,9 @@ import unittest
 import util
 
 
-VALID_LOGS_LINK = 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-nightly-resnet50-functional-v3-8-1584453600&extra_junk'
-VALID_DOWNLOAD_COMMAND = """gcloud logging read 'resource.type=k8s_container resource.labels.project_id=xl-ml-test resource.labels.location=us-central1-b resource.labels.cluster_name=xl-ml-test resource.labels.namespace_name=automated resource.labels.pod_name:pt-nightly-resnet50-functional-v3-8-1584453600' --limit 10000000000000 --order asc --format 'value(textPayload)' > pt-nightly-resnet50-functional-v3-8-1584453600_logs.txt && sed -i '/^$/d' pt-nightly-resnet50-functional-v3-8-1584453600_logs.txt"""
-VALID_TEST_NAME = 'pt-nightly-resnet50-functional-v3-8-1584453600'
+VALID_LOGS_LINK = 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-1.5-resnet50-functional-v3-8-1584453600&extra_junk'
+VALID_DOWNLOAD_COMMAND = """gcloud logging read 'resource.type=k8s_container resource.labels.project_id=xl-ml-test resource.labels.location=us-central1-b resource.labels.cluster_name=xl-ml-test resource.labels.namespace_name=automated resource.labels.pod_name:pt-1.5-resnet50-functional-v3-8-1584453600' --limit 10000000000000 --order asc --format 'value(textPayload)' > pt-1.5-resnet50-functional-v3-8-1584453600_logs.txt && sed -i '/^$/d' pt-1.5-resnet50-functional-v3-8-1584453600_logs.txt"""
+VALID_TEST_NAME = 'pt-1.5-resnet50-functional-v3-8-1584453600'
 
 
 class UtilTest(unittest.TestCase):

--- a/metrics_handler/util_test.py
+++ b/metrics_handler/util_test.py
@@ -20,12 +20,21 @@ import unittest
 import util
 
 
-VALID_LOGS_LINK = 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-1.5-resnet50-functional-v3-8-1584453600&extra_junk'
+VALID_LOGS_LINK = 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-1.5-resnet50-functional-v3-8-1584453600&extra_junk&dateRangeUnbound=backwardInTime'
 VALID_DOWNLOAD_COMMAND = """gcloud logging read 'resource.type=k8s_container resource.labels.project_id=xl-ml-test resource.labels.location=us-central1-b resource.labels.cluster_name=xl-ml-test resource.labels.namespace_name=automated resource.labels.pod_name:pt-1.5-resnet50-functional-v3-8-1584453600' --limit 10000000000000 --order asc --format 'value(textPayload)' > pt-1.5-resnet50-functional-v3-8-1584453600_logs.txt && sed -i '/^$/d' pt-1.5-resnet50-functional-v3-8-1584453600_logs.txt"""
 VALID_TEST_NAME = 'pt-1.5-resnet50-functional-v3-8-1584453600'
 
 
 class UtilTest(unittest.TestCase):
+  def test_add_unbound_time_to_logs_link_already_exists(self):
+    self.assertEqual(
+        VALID_LOGS_LINK,
+        util.add_unbound_time_to_logs_link(VALID_LOGS_LINK))
+
+  def test_add_unbound_time_to_logs_link_success(self):
+    self.assertEqual(
+        'abc{}'.format(util.UNBOUND_DATE_RANGE),
+        util.add_unbound_time_to_logs_link('abc'))
 
   def test_download_command_from_logs_link_fail_to_parse(self):
     with self.assertRaises(ValueError):


### PR DESCRIPTION
This is nice so the user doesn't need to click 'See older logs' each time they follow the link to see logs.

By putting it here, it will affect the logs links sent out in emails as well as the logs links stored in Bigquery (and therefore shown in the future dashboard)

Change-Id: I8e1bde484c4bef1b8b3fe80dd5144f5e0ad43a44