### PR TITLE
Update TF example metric config

### DIFF
--- a/examples/metrics/tf-mnist-tpu-v2-8.json
+++ b/examples/metrics/tf-mnist-tpu-v2-8.json
@@ -6,25 +6,14 @@
     "default_aggregation_strategies": ["final"],
     "metric_to_aggregation_strategies": {
       "epoch_loss": ["final", "min"]
-    },
-    "time_to_accuracy": {
-      "accuracy_threshold": 99.0,
-      "accuracy_tag": "epoch_sparse_categorical_accuracy"
     }
   },
   "regression_test_config": {
     "write_to_error_reporting": "True",
     "metric_subset_to_alert": [
-      "total_wall_time",
-      "epoch_sparse_categorical_accuracy"
+      "total_wall_time"
     ],
     "metric_success_conditions": {
-      "epoch_sparse_categorical_accuracy": {
-        "comparison": "greater",
-        "success_threshold": {
-          "fixed_value": 99.0
-        }
-      },
       "total_wall_time": {
         "comparison": "less",
         "success_threshold": {


### PR DESCRIPTION
The test runs for just 1 epoch, so there's no point checking for accuracy regressions. This should prevent more alerts from the failing metrics.

Change-Id: Ic28f3eab7e13d9f04e735b9aa3a380eed8aabd68