### PR TITLE
Rename PT nightly tests to match 1.5 tests with shorter names.

### DIFF
--- a/k8s/gen/pt-nightly-cifar-tv-convergence-v2-8.yaml
+++ b/k8s/gen/pt-nightly-cifar-tv-convergence-v2-8.yaml
@@ -15,7 +15,7 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-fairseq-roberta-pretrain-functional-v3-8"
+  "name": "pt-nightly-cifar-tv-convergence-v2-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
@@ -30,9 +30,13 @@
         "spec":
           "containers":
           - "args":
-            - "/bin/bash"
-            - "-c"
-            - "pip install --editable tpu-examples/deps/fairseq && python3 /tpu-examples/deps/fairseq/train.py /datasets/wikitext-103 --tensorboard-logdir=$(MODEL_DIR) --task=masked_lm --criterion=masked_lm --arch=roberta_base --sample-break-mode=complete --tokens-per-sample=512 --optimizer=adam --adam-betas='(0.9,0.98)' --adam-eps=1e-6 --clip-norm=0.0 --lr-scheduler=polynomial_decay --lr=0.0005 --warmup-updates=10000 --dropout=0.1 --attention-dropout=0.1 --weight-decay=0.01 --update-freq=16 --log-format=simple --train-subset=train --valid-subset=valid --num_cores=8 --metrics_debug --save-dir=checkpoints --log_steps=30 --skip-invalid-size-inputs-valid-test --suppress_loss_report --input_shapes 16x512 18x480 21x384 --max-epoch=1"
+            - "python3"
+            - "pytorch/xla/test/test_train_cifar.py"
+            - "--logdir=$(MODEL_DIR)"
+            - "--use_torchvision=True"
+            - "--metrics_debug"
+            - "--target_accuracy=72"
+            - "--datadir=/datasets/cifar-data"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -51,9 +55,9 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-fairseq-roberta-pretrain-functional-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"Accuracy/test_final\": {\n    \"comparison\": \"greater\",\n    \"success_threshold\": {\n     \"fixed_value\": 72\n    }\n   },\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-cifar-tv-convergence-v2-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/fairseq-roberta-pretrain/functional/v3-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/cifar-tv/convergence/v2-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"
@@ -61,15 +65,15 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/preemptible-v3": 8
+                "cloud-tpus.google.com/v2": 8
               "requests":
-                "cpu": "9.0"
-                "memory": "30Gi"
+                "cpu": "4.5"
+                "memory": "8Gi"
             "volumeMounts":
             - "mountPath": "/dev/shm"
               "name": "dshm"
             - "mountPath": "/datasets"
-              "name": "wikitext-pd"
+              "name": "cifar-pd"
               "readOnly": true
           "restartPolicy": "Never"
           "volumes":
@@ -78,7 +82,7 @@
             "name": "dshm"
           - "gcePersistentDisk":
               "fsType": "ext4"
-              "pdName": "wikitext-103-pd-central1-b"
+              "pdName": "cifar-pd-central1-b"
               "readOnly": true
-            "name": "wikitext-pd"
+            "name": "cifar-pd"
   "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-cifar-tv-convergence-v3-8.yaml
+++ b/k8s/gen/pt-nightly-cifar-tv-convergence-v3-8.yaml
@@ -15,7 +15,7 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-cifar-torchvision-convergence-v2-8"
+  "name": "pt-nightly-cifar-tv-convergence-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
@@ -55,9 +55,9 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"Accuracy/test_final\": {\n    \"comparison\": \"greater\",\n    \"success_threshold\": {\n     \"fixed_value\": 72\n    }\n   },\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-cifar-torchvision-convergence-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"Accuracy/test_final\": {\n    \"comparison\": \"greater\",\n    \"success_threshold\": {\n     \"fixed_value\": 72\n    }\n   },\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-cifar-tv-convergence-v3-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/cifar-torchvision/convergence/v2-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/cifar-tv/convergence/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"
@@ -65,7 +65,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/v3": 8
               "requests":
                 "cpu": "4.5"
                 "memory": "8Gi"

--- a/k8s/gen/pt-nightly-cpp-ops-functional-v2-8.yaml
+++ b/k8s/gen/pt-nightly-cpp-ops-functional-v2-8.yaml
@@ -15,13 +15,13 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-python-operations-functional-v2-8"
+  "name": "pt-nightly-cpp-ops-functional-v2-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 7200
+      "activeDeadlineSeconds": 14400
       "backoffLimit": 2
       "template":
         "metadata":
@@ -31,7 +31,7 @@
           "containers":
           - "args":
             - "bash"
-            - "pytorch/xla/test/run_tests.sh"
+            - "pytorch/xla/test/cpp/run_tests.sh"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -50,9 +50,9 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-python-operations-functional-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-cpp-ops-functional-v2-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/python-operations/functional/v2-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/cpp-ops/functional/v2-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"

--- a/k8s/gen/pt-nightly-cpp-ops-functional-v3-8.yaml
+++ b/k8s/gen/pt-nightly-cpp-ops-functional-v3-8.yaml
@@ -15,13 +15,13 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-python-operations-functional-v3-8"
+  "name": "pt-nightly-cpp-ops-functional-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 7200
+      "activeDeadlineSeconds": 14400
       "backoffLimit": 2
       "template":
         "metadata":
@@ -31,7 +31,7 @@
           "containers":
           - "args":
             - "bash"
-            - "pytorch/xla/test/run_tests.sh"
+            - "pytorch/xla/test/cpp/run_tests.sh"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -50,9 +50,9 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-python-operations-functional-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-cpp-ops-functional-v3-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/python-operations/functional/v3-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/cpp-ops/functional/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"

--- a/k8s/gen/pt-nightly-fs-transformer-convergence-v3-8.yaml
+++ b/k8s/gen/pt-nightly-fs-transformer-convergence-v3-8.yaml
@@ -15,13 +15,13 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-fairseq-transformer-functional-v3-8"
+  "name": "pt-nightly-fs-transformer-convergence-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 3600
+      "activeDeadlineSeconds": 18000
       "backoffLimit": 2
       "template":
         "metadata":
@@ -59,11 +59,13 @@
             - "--weight-decay=0.0"
             - "--valid-subset=valid"
             - "--num_cores=8"
-            - "--max-epoch=1"
-            - "--log_steps=10"
-            - "--train-subset=valid"
+            - "--max-epoch=3"
+            - "--log_steps=100"
+            - "--train-subset=train"
             - "--input_shapes"
-            - "128x64"
+            - "64x64"
+            - "128x32"
+            - "256x16"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -82,17 +84,17 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-fairseq-transformer-functional-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"loss_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"fixed_value\": 4.5\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-fs-transformer-convergence-v3-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/fairseq-transformer/functional/v3-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/fs-transformer/convergence/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
-              "value": "1"
+              "value": "0"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/preemptible-v3": 8
+                "cloud-tpus.google.com/v3": 8
               "requests":
                 "cpu": "9.0"
                 "memory": "30Gi"
@@ -112,4 +114,4 @@
               "pdName": "wmt18-en-de-pd-central1-b"
               "readOnly": true
             "name": "wmt18-pd"
-  "schedule": "0 14 * * *"
+  "schedule": "0 6 * * 1,6"

--- a/k8s/gen/pt-nightly-fs-transformer-functional-v3-8.yaml
+++ b/k8s/gen/pt-nightly-fs-transformer-functional-v3-8.yaml
@@ -15,13 +15,13 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-fairseq-transformer-convergence-v3-8"
+  "name": "pt-nightly-fs-transformer-functional-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 18000
+      "activeDeadlineSeconds": 3600
       "backoffLimit": 2
       "template":
         "metadata":
@@ -59,13 +59,11 @@
             - "--weight-decay=0.0"
             - "--valid-subset=valid"
             - "--num_cores=8"
-            - "--max-epoch=3"
-            - "--log_steps=100"
-            - "--train-subset=train"
+            - "--max-epoch=1"
+            - "--log_steps=10"
+            - "--train-subset=valid"
             - "--input_shapes"
-            - "64x64"
-            - "128x32"
-            - "256x16"
+            - "128x64"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -84,17 +82,17 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"loss_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"fixed_value\": 4.5\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-fairseq-transformer-convergence-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-fs-transformer-functional-v3-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/fairseq-transformer/convergence/v3-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/fs-transformer/functional/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
-              "value": "0"
+              "value": "1"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
               "requests":
                 "cpu": "9.0"
                 "memory": "30Gi"
@@ -114,4 +112,4 @@
               "pdName": "wmt18-en-de-pd-central1-b"
               "readOnly": true
             "name": "wmt18-pd"
-  "schedule": "0 6 * * 1,6"
+  "schedule": "0 14 * * *"

--- a/k8s/gen/pt-nightly-python-ops-functional-v2-8.yaml
+++ b/k8s/gen/pt-nightly-python-ops-functional-v2-8.yaml
@@ -15,13 +15,13 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-cpp-operations-functional-v2-8"
+  "name": "pt-nightly-python-ops-functional-v2-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 14400
+      "activeDeadlineSeconds": 7200
       "backoffLimit": 2
       "template":
         "metadata":
@@ -31,7 +31,7 @@
           "containers":
           - "args":
             - "bash"
-            - "pytorch/xla/test/cpp/run_tests.sh"
+            - "pytorch/xla/test/run_tests.sh"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -50,9 +50,9 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-cpp-operations-functional-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-python-ops-functional-v2-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/cpp-operations/functional/v2-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/python-ops/functional/v2-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"

--- a/k8s/gen/pt-nightly-python-ops-functional-v3-8.yaml
+++ b/k8s/gen/pt-nightly-python-ops-functional-v3-8.yaml
@@ -15,13 +15,13 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-cpp-operations-functional-v3-8"
+  "name": "pt-nightly-python-ops-functional-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 14400
+      "activeDeadlineSeconds": 7200
       "backoffLimit": 2
       "template":
         "metadata":
@@ -31,7 +31,7 @@
           "containers":
           - "args":
             - "bash"
-            - "pytorch/xla/test/cpp/run_tests.sh"
+            - "pytorch/xla/test/run_tests.sh"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -50,9 +50,9 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-cpp-operations-functional-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-python-ops-functional-v3-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/cpp-operations/functional/v3-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/python-ops/functional/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"

--- a/k8s/gen/pt-nightly-roberta-pre-convergence-v3-8.yaml
+++ b/k8s/gen/pt-nightly-roberta-pre-convergence-v3-8.yaml
@@ -15,7 +15,7 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-fairseq-roberta-pretrain-convergence-v3-8"
+  "name": "pt-nightly-roberta-pre-convergence-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
@@ -51,9 +51,9 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-fairseq-roberta-pretrain-convergence-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-roberta-pre-convergence-v3-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/fairseq-roberta-pretrain/convergence/v3-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/roberta-pre/convergence/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"

--- a/k8s/gen/pt-nightly-roberta-pre-functional-v3-8.yaml
+++ b/k8s/gen/pt-nightly-roberta-pre-functional-v3-8.yaml
@@ -15,7 +15,7 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-nightly-cifar-torchvision-convergence-v3-8"
+  "name": "pt-nightly-roberta-pre-functional-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
@@ -30,13 +30,9 @@
         "spec":
           "containers":
           - "args":
-            - "python3"
-            - "pytorch/xla/test/test_train_cifar.py"
-            - "--logdir=$(MODEL_DIR)"
-            - "--use_torchvision=True"
-            - "--metrics_debug"
-            - "--target_accuracy=72"
-            - "--datadir=/datasets/cifar-data"
+            - "/bin/bash"
+            - "-c"
+            - "pip install --editable tpu-examples/deps/fairseq && python3 /tpu-examples/deps/fairseq/train.py /datasets/wikitext-103 --tensorboard-logdir=$(MODEL_DIR) --task=masked_lm --criterion=masked_lm --arch=roberta_base --sample-break-mode=complete --tokens-per-sample=512 --optimizer=adam --adam-betas='(0.9,0.98)' --adam-eps=1e-6 --clip-norm=0.0 --lr-scheduler=polynomial_decay --lr=0.0005 --warmup-updates=10000 --dropout=0.1 --attention-dropout=0.1 --weight-decay=0.01 --update-freq=16 --log-format=simple --train-subset=train --valid-subset=valid --num_cores=8 --metrics_debug --save-dir=checkpoints --log_steps=30 --skip-invalid-size-inputs-valid-test --suppress_loss_report --input_shapes 16x512 18x480 21x384 --max-epoch=1"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -55,9 +51,9 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_subset_to_alert\": [\n   \"ExecuteTime__Percentile_99_sec_final\",\n   \"CompileTime__Percentile_99_sec_final\",\n   \"total_wall_time\",\n   \"Accuracy/test_final\",\n   \"aten_ops_sum_final\"\n  ],\n  \"metric_success_conditions\": {\n   \"Accuracy/test_final\": {\n    \"comparison\": \"greater\",\n    \"success_threshold\": {\n     \"fixed_value\": 72\n    }\n   },\n   \"CompileTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"ExecuteTime__Percentile_99_sec_final\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   },\n   \"aten_ops_sum_final\": {\n    \"comparison\": \"less_or_equal\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 0\n    }\n   },\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"pt-nightly-cifar-torchvision-convergence-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"tags_to_ignore\": [\n   \"LearningRate\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": null,\n \"test_name\": \"pt-nightly-roberta-pre-functional-v3-8\"\n}"
             - "name": "MODEL_DIR"
-              "value": "gs://xl-ml-test-us-central1/k8s/cifar-torchvision/convergence/v3-8/$(JOB_NAME)"
+              "value": "gs://xl-ml-test-us-central1/k8s/roberta-pre/functional/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "image": "gcr.io/xl-ml-test/pytorch-xla:nightly"
@@ -65,15 +61,15 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
               "requests":
-                "cpu": "4.5"
-                "memory": "8Gi"
+                "cpu": "9.0"
+                "memory": "30Gi"
             "volumeMounts":
             - "mountPath": "/dev/shm"
               "name": "dshm"
             - "mountPath": "/datasets"
-              "name": "cifar-pd"
+              "name": "wikitext-pd"
               "readOnly": true
           "restartPolicy": "Never"
           "volumes":
@@ -82,7 +78,7 @@
             "name": "dshm"
           - "gcePersistentDisk":
               "fsType": "ext4"
-              "pdName": "cifar-pd-central1-b"
+              "pdName": "wikitext-103-pd-central1-b"
               "readOnly": true
-            "name": "cifar-pd"
+            "name": "wikitext-pd"
   "schedule": "0 14 * * *"

--- a/templates/pytorch/nightly/cifar-tv.libsonnet
+++ b/templates/pytorch/nightly/cifar-tv.libsonnet
@@ -18,7 +18,7 @@ local tpus = import "../../tpus.libsonnet";
 
 {
   local cifar = base.PyTorchTest {
-    modelName: "cifar-torchvision",
+    modelName: "cifar-tv",
     command: [
       "python3",
       "pytorch/xla/test/test_train_cifar.py",

--- a/templates/pytorch/nightly/cpp-ops.libsonnet
+++ b/templates/pytorch/nightly/cpp-ops.libsonnet
@@ -18,10 +18,10 @@ local tpus = import "../../tpus.libsonnet";
 
 {
   local operations = base.PyTorchTest {
-    modelName: "python-operations",
+    modelName: "cpp-ops",
     command: [
       "bash",
-      "pytorch/xla/test/run_tests.sh",
+      "pytorch/xla/test/cpp/run_tests.sh",
     ],
     regressionTestConfig: null,
   },
@@ -33,7 +33,7 @@ local tpus = import "../../tpus.libsonnet";
   },
 
   configs: [
-    operations + v2_8 + base.Functional + timeouts.Hours(2),
-    operations + v3_8 + base.Functional + timeouts.Hours(2),
+    operations + v2_8 + base.Functional + timeouts.Hours(4),
+    operations + v3_8 + base.Functional + timeouts.Hours(4),
   ],
 }

--- a/templates/pytorch/nightly/fs-transformer.libsonnet
+++ b/templates/pytorch/nightly/fs-transformer.libsonnet
@@ -18,7 +18,7 @@ local tpus = import "../../tpus.libsonnet";
 
 {
   local transformer = base.PyTorchTest {
-    modelName: "fairseq-transformer",
+    modelName: "fs-transformer",
     command: [
       "python3",
       "/tpu-examples/deps/fairseq/train.py",

--- a/templates/pytorch/nightly/python-ops.libsonnet
+++ b/templates/pytorch/nightly/python-ops.libsonnet
@@ -18,10 +18,10 @@ local tpus = import "../../tpus.libsonnet";
 
 {
   local operations = base.PyTorchTest {
-    modelName: "cpp-operations",
+    modelName: "python-ops",
     command: [
       "bash",
-      "pytorch/xla/test/cpp/run_tests.sh",
+      "pytorch/xla/test/run_tests.sh",
     ],
     regressionTestConfig: null,
   },
@@ -33,7 +33,7 @@ local tpus = import "../../tpus.libsonnet";
   },
 
   configs: [
-    operations + v2_8 + base.Functional + timeouts.Hours(4),
-    operations + v3_8 + base.Functional + timeouts.Hours(4),
+    operations + v2_8 + base.Functional + timeouts.Hours(2),
+    operations + v3_8 + base.Functional + timeouts.Hours(2),
   ],
 }

--- a/templates/pytorch/nightly/roberta-pre.libsonnet
+++ b/templates/pytorch/nightly/roberta-pre.libsonnet
@@ -20,7 +20,7 @@ local tpus = import "../../tpus.libsonnet";
   local base_command = "pip install --editable tpu-examples/deps/fairseq && python3 /tpu-examples/deps/fairseq/train.py /datasets/wikitext-103 --tensorboard-logdir=$(MODEL_DIR) --task=masked_lm --criterion=masked_lm --arch=roberta_base --sample-break-mode=complete --tokens-per-sample=512 --optimizer=adam --adam-betas='(0.9,0.98)' --adam-eps=1e-6 --clip-norm=0.0 --lr-scheduler=polynomial_decay --lr=0.0005 --warmup-updates=10000 --dropout=0.1 --attention-dropout=0.1 --weight-decay=0.01 --update-freq=16 --log-format=simple --train-subset=train --valid-subset=valid --num_cores=8 --metrics_debug --save-dir=checkpoints --log_steps=30 --skip-invalid-size-inputs-valid-test --suppress_loss_report --input_shapes 16x512 18x480 21x384",
 
   local roberta = base.PyTorchTest {
-    modelName: "fairseq-roberta-pretrain",
+    modelName: "roberta-pre",
     command: [
       "/bin/bash",
       "-c",

--- a/templates/pytorch/nightly/targets.jsonnet
+++ b/templates/pytorch/nightly/targets.jsonnet
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 local cifarInline = import "cifar-inline.libsonnet";
-local cifarTorchvision = import "cifar-torchvision.libsonnet";
-local cppOperations = import "cpp-operations.libsonnet";
-local fairseqRobertaPretrain = import "fairseq-roberta-pretrain.libsonnet";
-local fairseqTransformer = import "fairseq-transformer.libsonnet";
+local cifarTorchvision = import "cifar-tv.libsonnet";
+local cppOperations = import "cpp-ops.libsonnet";
+local fairseqRobertaPretrain = import "roberta-pre.libsonnet";
+local fairseqTransformer = import "fs-transformer.libsonnet";
 local mnist = import "mnist.libsonnet";
-local pythonOperations = import "python-operations.libsonnet";
+local pythonOperations = import "python-ops.libsonnet";
 local resnet50 = import "resnet50.libsonnet";
 
 # Add new models here


### PR DESCRIPTION
I've deleted the old versions of the workloads and created the new versions for the 10 affected tests. I'll add details of the SQL updates to Buganizer to migrate the job/metrics data to the new test names.

Change-Id: I61ea5609589938f9accf25b63f59974ec5974fd4