### PR TITLE
Refactor metrics handler main.py and add tests

### DIFF
--- a/metrics_handler/alert_handler.py
+++ b/metrics_handler/alert_handler.py
@@ -50,9 +50,10 @@ class AlertHandler(object):
     self.project_id = project_id
     self.write_to_logging = write_to_logging
     self.write_to_error_reporting = write_to_error_reporting
+    self.write_to_email = write_to_email
     if write_to_error_reporting:
       self.error_reporter = error_reporting.Client()
-    if write_to_email:
+    if self.write_to_email:
       try:
         secret_client = secretmanager.SecretManagerServiceClient()
         api_key = self._get_secret_value(

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -251,6 +251,7 @@ class CloudMetricsHandler(object):
             logs_link=self.stackdriver_logs_link)
 
   def get_metrics_history_from_bigquery(self):
+    """Returns the historic values of each metric for a given model."""
     query_result = self.bigquery_client.query(
         'SELECT * FROM `{}` WHERE test_name like \"{}\"'.format(
             self.metric_history_table_id, self.test_name)).result()
@@ -272,6 +273,7 @@ class CloudMetricsHandler(object):
 
     Args:
       job_status (dict): Contains information about the Kubernetes Job.
+      metrics_history(dict): Historic values of each metric.
       new_metrics(dict): Key is metric name and value is MetricPoint containing
         the latest aggregated value for that metric.
 

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -115,7 +115,7 @@ class CloudMetricsHandler(object):
       raw_metrics = metrics.read_metrics_from_events_dir(
           self.events_dir, tags_to_ignore)
     except:
-      self.logger.warn(str(e))
+      self.logger.warning(str(e))
 
     default_aggregation_strategies = self.metric_collection_config.get(
         'default_aggregation_strategies')

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -111,8 +111,11 @@ class CloudMetricsHandler(object):
     """
     tags_to_ignore = set(
         self.metric_collection_config.get('tags_to_ignore', []))
-    raw_metrics = metrics.read_metrics_from_events_dir(
-        self.events_dir, tags_to_ignore)
+    try:
+      raw_metrics = metrics.read_metrics_from_events_dir(
+          self.events_dir, tags_to_ignore)
+    except:
+      self.logger.warn(str(e))
 
     default_aggregation_strategies = self.metric_collection_config.get(
         'default_aggregation_strategies')
@@ -135,8 +138,11 @@ class CloudMetricsHandler(object):
                          'See README for how to set up the config.')
       tag = tta_config['accuracy_tag']
       threshold = tta_config['accuracy_threshold']
-      final_metrics['time_to_accuracy'] = metrics.time_to_accuracy(
-          raw_metrics, tag, threshold)
+      try: 
+        final_metrics['time_to_accuracy'] = metrics.time_to_accuracy(
+            raw_metrics, tag, threshold)
+      except ValueError as e:
+        self.logger.error(str(e))
 
     return final_metrics
 

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -25,6 +25,7 @@ import uuid
 import alert_handler
 import job_status_handler
 import metrics
+import util
 
 import google.api_core.exceptions
 from google.cloud import bigquery
@@ -246,7 +247,8 @@ class CloudMetricsHandler(object):
           'Inserting {} rows into BigQuery table `{}`'.format(
               len(rows), table_id))
       table = self.bigquery_client.get_table(table_id)
-      errors = self.bigquery_client.insert_rows(table, rows)
+      clean_rows = [util.replace_invalid_values(row) for row in rows]
+      errors = self.bigquery_client.insert_rows(table, clean_rows)
       if errors == []:
         self.logger.info('Successfully added rows to Bigquery.')
       else:

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -112,11 +112,8 @@ class CloudMetricsHandler(object):
     """
     tags_to_ignore = set(
         self.metric_collection_config.get('tags_to_ignore', []))
-    try:
-      raw_metrics = metrics.read_metrics_from_events_dir(
-          self.events_dir, tags_to_ignore)
-    except:
-      self.logger.warning(str(e), logs_link=self.stackdriver_logs_link)
+    raw_metrics = metrics.read_metrics_from_events_dir(
+        self.events_dir, tags_to_ignore)
 
     default_aggregation_strategies = self.metric_collection_config.get(
         'default_aggregation_strategies')
@@ -143,7 +140,7 @@ class CloudMetricsHandler(object):
         final_metrics['time_to_accuracy'] = metrics.time_to_accuracy(
             raw_metrics, tag, threshold)
       except ValueError as e:
-        self.logger.error(str(e), logs_link=self.stackdriver_logs_link)
+        self.logger.error(str(e))
 
     return final_metrics
 
@@ -320,8 +317,7 @@ class CloudMetricsHandler(object):
             'metric: `{}` has an empty success condition in metric_opt_in_dict '
             'but there is no default condition provided in the regression '
             'test config. No bounds or alerts will be computed'.format(
-                metric_name),
-            logs_link=self.stackdriver_logs_link)
+                metric_name))
         continue
       elif len(value_history) <= success_condition.get(
         'wait_for_n_points_of_history', -1):

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -116,7 +116,7 @@ class CloudMetricsHandler(object):
       raw_metrics = metrics.read_metrics_from_events_dir(
           self.events_dir, tags_to_ignore)
     except:
-      self.logger.warning(str(e))
+      self.logger.warning(str(e), logs_link=self.stackdriver_logs_link)
 
     default_aggregation_strategies = self.metric_collection_config.get(
         'default_aggregation_strategies')
@@ -143,7 +143,7 @@ class CloudMetricsHandler(object):
         final_metrics['time_to_accuracy'] = metrics.time_to_accuracy(
             raw_metrics, tag, threshold)
       except ValueError as e:
-        self.logger.error(str(e))
+        self.logger.error(str(e), logs_link=self.stackdriver_logs_link)
 
     return final_metrics
 
@@ -320,7 +320,8 @@ class CloudMetricsHandler(object):
             'metric: `{}` has an empty success condition in metric_opt_in_dict '
             'but there is no default condition provided in the regression '
             'test config. No bounds or alerts will be computed'.format(
-                metric_name))
+                metric_name),
+            logs_link=self.stackdriver_logs_link)
         continue
       elif len(value_history) <= success_condition.get(
         'wait_for_n_points_of_history', -1):
@@ -347,7 +348,8 @@ class CloudMetricsHandler(object):
           'Metric `{}` was out of bounds for test `{}`. Bounds were '
           '({}, {}) and value was {:.2f}'.format(
               metric_name, self.test_name, lower_bound, upper_bound,
-              metric_value))
+              metric_value),
+          logs_link=self.stackdriver_logs_link)
 
     return metric_name_to_visual_bounds
 

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -119,11 +119,14 @@ class CloudMetricsHandler(object):
         'default_aggregation_strategies')
     metric_to_aggregation_strategies = self.metric_collection_config.get(
         'metric_to_aggregation_strategies')
-    final_metrics = metrics.aggregate_metrics(
-        raw_metrics,
-        default_aggregation_strategies,
-        metric_to_aggregation_strategies
-    )
+    try:
+      final_metrics = metrics.aggregate_metrics(
+          raw_metrics,
+          default_aggregation_strategies,
+          metric_to_aggregation_strategies
+      )
+    except ValueError as e:
+      raise ValueError("Error during metric aggregation: {}".format(e))
 
     final_metrics['total_wall_time'] = metrics.total_wall_time(raw_metrics)
 

--- a/metrics_handler/main_test.py
+++ b/metrics_handler/main_test.py
@@ -1,12 +1,19 @@
 from absl import logging
 from absl.testing import absltest
-
 import tensorflow as tf
+
+import alert_handler
 import main
 import metrics
 
-class CloudMetricsHandlerTest(tf.test.TestCase):
+class CloudMetricsHandlerTest(absltest.TestCase):
   def setUp(self):
+    self.logger = alert_handler.AlertHandler(
+      project_id=None,
+      write_to_logging=True,
+      write_to_error_reporting=False,
+      write_to_email=False)
+
     self.temp_dir = self.create_tempdir().full_path
     self.summary_writer = tf.summary.create_file_writer(self.temp_dir)
 
@@ -17,9 +24,6 @@ class CloudMetricsHandlerTest(tf.test.TestCase):
       tf.summary.scalar("foo", 2, 100)
       tf.summary.scalar("bar", tf.convert_to_tensor(2), 100)
 
-    self.summary_writer.flush()
-
-  def tearDown(self):
     self.summary_writer.close()
 
   def test_get_metrics_from_event_dir(self):
@@ -34,7 +38,7 @@ class CloudMetricsHandlerTest(tf.test.TestCase):
       test_type=None,
       accelerator=None,
       framework_version=None,
-      logger=logging, # pass in absl logging module
+      logger=self.logger, # pass in absl logging module
     )
 
     final_metrics = metrics_handler.get_metrics_from_events_dir()
@@ -65,7 +69,7 @@ class CloudMetricsHandlerTest(tf.test.TestCase):
       test_type=None,
       accelerator=None,
       framework_version=None,
-      logger=logging, # pass in absl logging module
+      logger=self.logger, # pass in absl logging module
     )
 
     final_metrics = metrics_handler.get_metrics_from_events_dir()

--- a/metrics_handler/main_test.py
+++ b/metrics_handler/main_test.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from absl import logging
 from absl.testing import absltest
 import tensorflow as tf

--- a/metrics_handler/main_test.py
+++ b/metrics_handler/main_test.py
@@ -1,0 +1,80 @@
+from absl import logging
+from absl.testing import absltest
+
+import tensorflow as tf
+import main
+import metrics
+
+class CloudMetricsHandlerTest(tf.test.TestCase):
+  def setUp(self):
+    self.temp_dir = self.create_tempdir().full_path
+    self.summary_writer = tf.summary.create_file_writer(self.temp_dir)
+
+    with self.summary_writer.as_default():
+      tf.summary.scalar("foo", 1, 0)
+      tf.summary.scalar("bar", tf.convert_to_tensor(1), 0)
+
+      tf.summary.scalar("foo", 2, 100)
+      tf.summary.scalar("bar", tf.convert_to_tensor(2), 100)
+
+    self.summary_writer.flush()
+
+  def tearDown(self):
+    self.summary_writer.close()
+
+  def test_get_metrics_from_event_dir(self):
+    metrics_handler = main.CloudMetricsHandler(
+      test_name="test",
+      events_dir=self.temp_dir,
+      stackdriver_logs_link=None,
+      metric_collection_config={
+        'default_aggregation_strategies': ['final', 'min',]
+      },
+      regression_test_config={},
+      test_type=None,
+      accelerator=None,
+      framework_version=None,
+      logger=logging, # pass in absl logging module
+    )
+
+    final_metrics = metrics_handler.get_metrics_from_events_dir()
+    self.assertContainsSubset(['foo_final', 'foo_min', 'bar_final', 'bar_min'],
+                              final_metrics.keys())
+
+  def test_compute_bounds_and_report_errors_fixed_value(self):
+    metrics_handler = main.CloudMetricsHandler(
+      test_name="test",
+      events_dir=self.temp_dir,
+      stackdriver_logs_link=None,
+      metric_collection_config={
+        'default_aggregation_strategies': ['final'],
+        'tags_to_ignore': ['bar'],
+      },
+      regression_test_config={
+        'metric_subset_to_alert': ['foo_final'],
+        'metric_success_conditions': {
+          'foo_final': {
+            'success_threshold': {
+              'fixed_value': 3.
+            },
+            'comparison': 'greater',
+            'wait_for_n_points_of_history': 0,
+          }
+        }
+      },
+      test_type=None,
+      accelerator=None,
+      framework_version=None,
+      logger=logging, # pass in absl logging module
+    )
+
+    final_metrics = metrics_handler.get_metrics_from_events_dir()
+    with self.assertLogs(level='ERROR'):
+      metrics_handler.compute_bounds_and_report_errors(
+          {'final_status': 'success'},
+          {'foo_final': [], 'total_wall_time': []},
+          final_metrics
+      )
+
+if __name__ == '__main__':
+  absltest.main()

--- a/metrics_handler/main_test.py
+++ b/metrics_handler/main_test.py
@@ -52,7 +52,7 @@ class CloudMetricsHandlerTest(absltest.TestCase):
       test_type=None,
       accelerator=None,
       framework_version=None,
-      logger=self.logger, # pass in absl logging module
+      logger=self.logger,
     )
 
     final_metrics = metrics_handler.get_metrics_from_events_dir()
@@ -83,7 +83,7 @@ class CloudMetricsHandlerTest(absltest.TestCase):
       test_type=None,
       accelerator=None,
       framework_version=None,
-      logger=self.logger, # pass in absl logging module
+      logger=self.logger,
     )
 
     final_metrics = metrics_handler.get_metrics_from_events_dir()

--- a/metrics_handler/metrics.py
+++ b/metrics_handler/metrics.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import collections
 import itertools
 import math

--- a/metrics_handler/metrics.py
+++ b/metrics_handler/metrics.py
@@ -88,9 +88,14 @@ def aggregate_metrics(raw_metrics, default_strategies, metric_strategies=None):
 
   Returns:
     dict mapping metric name to MetricPoint.
+  
+  Raises:
+    ValueError: If `default_strategies` is empty or an invalid strategy is
+      provided.
   """
   if not raw_metrics:
-    raise ValueError('`raw_metrics` cannot be empty.')
+    logging.warning('`raw_metrics` is empty, skipping metric aggregation.')
+    return {}
   if not default_strategies:
     raise ValueError('`default_strategies` cannot be empty.')
   metric_strategies = metric_strategies or {}
@@ -230,7 +235,7 @@ def metric_bounds(value_history, threshold, comparison):
       lower_bound = -math.inf
       upper_bound = mean + (stddev * threshold.value)
     elif 'greater' in comparison:
-      lower_bound = max(mean - (stddev * threshold.value), 0)
+      lower_bound = mean - (stddev * threshold.value)
       upper_bound = math.inf
   else:
     raise ValueError(

--- a/metrics_handler/metrics.py
+++ b/metrics_handler/metrics.py
@@ -54,7 +54,7 @@ def read_metrics_from_events_dir(events_dir, tags_to_ignore=None):
           raw_metrics[tag].append(
               MetricPoint(metric_value=val[0], wall_time=t.wall_time))
         except ValueError as e:
-          logging.warning(
+          raise ValueError(
               'Unable to parse tag: `{}` from tensor_content: {}. '
               'Error: {}. Consider adding this tag to tags_to_ignore '
               'in config.'.format(tag, t.tensor_proto.tensor_content, e))
@@ -157,12 +157,11 @@ def time_to_accuracy(raw_metrics, tag, threshold):
     return MetricPoint(end_wall_time - start_wall_time, end_wall_time)
   except StopIteration:
     max_accuracy = max(v.metric_value for v in values)
-    logging.error(
+    raise ValueError(
         'Accuracy metric `{}` was never high enough to satisfy the '
         '`time_to_accuracy` settings from the config. Max accuracy: {}. '
         'Target accuracy: {}. Config for `time_to_accuracy`: {}'.format(
-            tag, max_accuracy, threshold)
-    )
+            tag, max_accuracy, threshold))
 
 
 def metric_bounds(value_history, threshold, comparison):

--- a/metrics_handler/metrics.py
+++ b/metrics_handler/metrics.py
@@ -1,0 +1,213 @@
+import collections
+import itertools
+import math
+
+from absl import logging
+import numpy as np
+import tensorflow as tf
+from tensorboard.backend.event_processing import event_multiplexer
+
+
+ALLOWED_COMPARISONS = ['greater', 'less', 'equal', 'less_or_equal']
+
+
+MetricPoint = collections.namedtuple('MetricPoint', ['metric_value', 'wall_time'])
+Threshold = collections.namedtuple('Threshold', ['type', 'value'])
+
+
+def read_metrics_from_events_dir(events_dir, tags_to_ignore=None):
+  """Collect the TensorBoard summary values for each metric.
+  
+  Args:
+    events_dir: path to location of TensorBoard summaries.
+    tags_to_ignore: set of TensorBoard tag names to skip.
+
+  Returns:
+    Dict mapping TensorBoard tags to list of MetricPoint.
+  """
+  tags_to_ignore = tags_to_ignore or set()
+
+  em = event_multiplexer.EventMultiplexer()
+  em.AddRunsFromDirectory(events_dir)
+  em.Reload()
+
+  raw_metrics = collections.defaultdict(list)
+  for run, tags in em.Runs().items():
+    # 'Old-style' runs have a simple format and store values directly.
+    for tag in tags['scalars']:
+      if tag in tags_to_ignore:
+        continue
+      raw_metrics[tag].extend(
+          [MetricPoint(metric_value=x.value, wall_time=x.wall_time)
+          for x in em.Scalars(run, tag)])
+    # 'New-style' runs stores values inside of Tensor protos.
+    for tag in tags['tensors']:
+      if tag in tags_to_ignore:
+        continue
+      for t in em.Tensors(run, tag):
+        tensor_dtype = tf.dtypes.as_dtype(t.tensor_proto.dtype)
+        try:
+          val = np.frombuffer(
+              t.tensor_proto.tensor_content,
+              tensor_dtype.as_numpy_dtype).tolist()
+          assert len(val) == 1  # There should be 1 value per tensor.
+          raw_metrics[tag].append(
+              MetricPoint(metric_value=val[0], wall_time=t.wall_time))
+        except ValueError as e:
+          logging.warning(
+              'Unable to parse tag: `{}` from tensor_content: {}. '
+              'Error: {}. Consider adding this tag to tags_to_ignore '
+              'in config.'.format(tag, t.tensor_proto.tensor_content, e))
+
+  return raw_metrics
+
+
+def aggregate_metrics(raw_metrics, default_strategies, metric_strategies=None):
+  """Aggregate raw TensorBoard metrics according to collection config.
+
+  Available aggregation strategies: `final`, `min`, `max`.
+
+  Args:
+    raw_metrics: dict mapping TensorBoard tags to list of MetricPoint.
+    default_strategies: list of aggregation strategies to use as the default.
+    metric_strategies: dict mapping tags to aggregation strategies.
+  """
+  if not raw_metrics:
+    raise ValueError('`raw_metrics` cannot be empty.')
+  if not default_strategies:
+    raise ValueError('`default_strategies` cannot be empty.')
+  metric_strategies = metric_strategies or {}
+
+  def _aggregate(metrics, strategy):
+    if strategy == 'final':
+      # Take the MetricPoint with the latest wall_time.
+      latest_metric = metrics[0]
+      for metric in metrics[1:]:
+        if metric.wall_time > latest_metric.wall_time:
+          latest_metric = metric
+      return latest_metric
+    elif strategy == 'max':
+      # Take the MetricPoint with the maximum metric value.
+      max_metric = metrics[0]
+      for metric in metrics[1:]:
+        if metric.metric_value > max_metric.metric_value:
+          max_metric = metric
+      return max_metric
+    elif strategy == 'min':
+      # Take the MetricPoint with the minimum metric value.
+      min_metric = metrics[0]
+      for metric in metrics[1:]:
+        if metric.metric_value < min_metric.metric_value:
+          min_metric = metric
+      return min_metric
+    else:
+      raise ValueError('Unknown aggregation strategy: {}'.format(strategy))
+
+  final_metrics = {}
+  for tag, metrics in raw_metrics.items():
+    strategies = metric_strategies.get(tag, default_strategies)
+    for strategy in strategies:
+      metric_name = '{}_{}'.format(tag, strategy)
+      final_metrics[metric_name] = _aggregate(metrics, strategy)
+
+  return final_metrics
+
+
+def total_wall_time(raw_metrics):
+  """Calculate the total wall time from TensorBoard summaries."""
+  values = list(itertools.chain.from_iterable(raw_metrics.values()))
+  min_wall_time = min(v.wall_time for v in values)
+  max_wall_time = max(v.wall_time for v in values)
+
+  return MetricPoint(max_wall_time - min_wall_time, max_wall_time)
+
+
+def time_to_accuracy(raw_metrics, tag, threshold):
+  values = raw_metrics.get(tag)
+  if not values:
+    raise ValueError('No values found for time to accuracy tag: {}. '
+        'Possible tags were: {}'.format(tag, raw_metrics.keys()))
+
+  # MetricPoints should be sorted by timestamp with earlier events first.
+  start_wall_time = values[0].wall_time
+  try:
+    end_wall_time = next(
+        v.wall_time for v in values
+        if v.metric_value >= threshold)
+    return MetricPoint(end_wall_time - start_wall_time, end_wall_time)
+  except StopIteration:
+    max_accuracy = max(v.metric_value for v in values)
+    logging.error(
+        'Accuracy metric `{}` was never high enough to satisfy the '
+        '`time_to_accuracy` settings from the config. Max accuracy: {}. '
+        'Target accuracy: {}. Config for `time_to_accuracy`: {}'.format(
+            tag, max_accuracy, threshold)
+    )
+
+def metric_bounds(value_history, threshold, comparison):
+  """Compute upper/lower bounds and whether metric is within those bounds.
+
+  Args:
+    metric_name (string): Name of the metric to check.
+    value_history (list of floats): History of values for this metric. These
+      should be ordered so the most recent value is the last in the list.
+
+  Returns:
+    tuple(is_within_bounds (bool), lower_bound (float), upper_bound (float)).
+      lower_bound and/or upper_bound can be None.
+
+  Raises:
+    ValueError if the regression test config is invalid.
+  """
+  if not comparison or comparison not in ALLOWED_COMPARISONS:
+    raise ValueError(
+        'A metric success condition must set the `comparison` field to '
+        'one of {}. comparison was: {}'.format(
+            ALLOWED_COMPARISONS, comparison))
+
+  if threshold.type == 'fixed_value':
+    if 'greater' in comparison:
+      lower_bound = threshold.value
+      upper_bound = math.inf
+    elif 'less' in comparison:
+      lower_bound = -math.inf
+      upper_bound = threshold.value
+    elif comparison == 'equal':
+      lower_bound = threshold.value
+      upper_bound = threshold.value
+    else:
+      raise ValueError(
+          'A metric success condition using a `fixed_value`-type threshold '
+          'must use `greater`, `greater_or_equal`, `less`, `less_or_equal`, '
+          'or `equal` for the comparison. The comparison was: {}'.format(
+              comparison))
+  elif threshold.type == 'stddevs_from_mean':
+    if comparison not in ('greater', 'less', 'less_or_equal'):
+      raise ValueError(
+          'A metric success condition using a `stddevs_from_mean`-type '
+          'threshold must use `greater`, `less`, or `less_or_equal` for the '
+          'comparison. The comparison was: {}'.format(comparison))
+    values = [v.metric_value for v in value_history]
+    mean = np.mean(values)
+    stddev = np.std(values)
+
+    if 'less' in comparison:
+      lower_bound = -math.inf
+      upper_bound = mean + (stddev * threshold.value)
+    elif 'greater' in comparison:
+      lower_bound = max(mean - (stddev * threshold.value), 0)
+      upper_bound = math.inf
+  else:
+    raise ValueError(
+      'The threshold type of a metric success condition should be either '
+      '`fixed_value` or `stddevs_from_mean`. Condition was: {}'.format(
+          success_condition))
+
+  return lower_bound, upper_bound
+
+def within_bounds(value, lower_bound, upper_bound, inclusive=False):
+  if inclusive and (
+      math.isclose(value, lower_bound) or math.isclose(value, upper_bound)):
+    return True
+  
+  return value > lower_bound and value < upper_bound

--- a/metrics_handler/metrics.py
+++ b/metrics_handler/metrics.py
@@ -54,7 +54,7 @@ def read_metrics_from_events_dir(events_dir, tags_to_ignore=None):
           raw_metrics[tag].append(
               MetricPoint(metric_value=val[0], wall_time=t.wall_time))
         except ValueError as e:
-          raise ValueError(
+          logging.warning(
               'Unable to parse tag: `{}` from tensor_content: {}. '
               'Error: {}. Consider adding this tag to tags_to_ignore '
               'in config.'.format(tag, t.tensor_proto.tensor_content, e))

--- a/metrics_handler/metrics_test.py
+++ b/metrics_handler/metrics_test.py
@@ -1,0 +1,172 @@
+import math
+
+from absl import logging
+from absl.testing import absltest
+from absl.testing import parameterized
+import tensorflow as tf
+
+import metrics
+
+
+class MetricsTest(parameterized.TestCase):
+  def setUp(self):
+    self.temp_dir = self.create_tempdir().full_path
+    self.summary_writer = tf.summary.create_file_writer(self.temp_dir)
+
+    with self.summary_writer.as_default():
+      tf.summary.scalar("foo", 1, 0)
+      tf.summary.scalar("accuracy", .125, 0)
+
+      tf.summary.scalar("foo", 2, 100)
+      tf.summary.scalar("accuracy", .5, 100)
+
+      tf.summary.scalar("accuracy", .25, 200)
+
+    self.summary_writer.flush()
+
+  def tearDown(self):
+    self.summary_writer.close()
+
+  def test_read_metrics_from_event_dir(self):
+    raw_metrics = metrics.read_metrics_from_events_dir(self.temp_dir)
+
+    self.assertLen(raw_metrics['foo'], 2)
+    self.assertLen(raw_metrics['accuracy'], 3)
+
+  def test_read_metrics_from_event_dir_with_ignore(self):
+    raw_metrics = metrics.read_metrics_from_events_dir(self.temp_dir, {'foo'})
+
+    self.assertNotIn('foo', raw_metrics)
+    self.assertLen(raw_metrics['accuracy'], 3)
+
+  def test_aggregate_metrics_default_all(self):
+    raw_metrics = metrics.read_metrics_from_events_dir(self.temp_dir)
+    final_metrics = metrics.aggregate_metrics(
+      raw_metrics, default_strategies=['final', 'min', 'max'])
+
+    # Remove wall time, since it's non-deterministic
+    metric_to_value = {
+      metric_name: point.metric_value 
+      for metric_name, point in final_metrics.items()
+    }
+
+    self.assertDictEqual(
+      metric_to_value,
+      {
+        'foo_final': 2,
+        'foo_min': 1,
+        'foo_max': 2,
+        'accuracy_final': .25,
+        'accuracy_min': .125,
+        'accuracy_max': .5,
+      }
+    )
+
+  def test_aggregate_metrics_custom(self):
+    raw_metrics = metrics.read_metrics_from_events_dir(self.temp_dir)
+    final_metrics = metrics.aggregate_metrics(
+      raw_metrics,
+      default_strategies=['final', 'min', 'max'],
+      metric_strategies={'accuracy': ['max']}
+    )
+
+    # Remove wall time, since it's non-deterministic
+    metric_to_value = {
+      metric_name: point.metric_value 
+      for metric_name, point in final_metrics.items()
+    }
+
+    self.assertDictEqual(
+      metric_to_value,
+      {
+        'foo_final': 2,
+        'foo_min': 1,
+        'foo_max': 2,
+        'accuracy_max': .5,
+      }
+    )
+
+  def test_total_wall_time(self):
+    raw_metrics = {
+      'foo': [
+        metrics.MetricPoint(metric_value=0, wall_time=0),
+        metrics.MetricPoint(metric_value=1, wall_time=1),
+      ],
+      'bar': [
+        metrics.MetricPoint(metric_value=0, wall_time=0),
+        metrics.MetricPoint(metric_value=2, wall_time=2),
+      ],
+    }
+
+    total_wall_time = metrics.total_wall_time(raw_metrics)
+    self.assertEqual(
+        total_wall_time, metrics.MetricPoint(metric_value=2, wall_time=2))
+
+  def test_time_to_accuracy(self):
+    raw_metrics = {
+      'accuracy': [
+        metrics.MetricPoint(metric_value=.2, wall_time=0),
+        metrics.MetricPoint(metric_value=.4, wall_time=10),
+        metrics.MetricPoint(metric_value=.6, wall_time=20),
+      ],
+      'other_metric': [
+        metrics.MetricPoint(metric_value=1, wall_time=15)
+      ]
+    }
+
+    time_to_accuracy = metrics.time_to_accuracy(
+        raw_metrics, tag='accuracy', threshold=.4)
+    self.assertEqual(time_to_accuracy,
+        metrics.MetricPoint(metric_value=10, wall_time=10))
+
+  @parameterized.named_parameters(
+    ('equal', 'equal', 5., (5., 5.)),
+    ('less', 'less', 5., (-math.inf, 5.)),
+    ('less_or_equal', 'less_or_equal', 5., (-math.inf, 5.)),
+    ('greater', 'greater', 5., (5., math.inf)),
+  )
+  def test_metric_bounds_fixed_value(self, comparison, threshold_value, expected_bounds):
+    # `fixed_value` comparison ignores value history
+    value_history = []
+    threshold = metrics.Threshold('fixed_value', threshold_value)
+    bounds = metrics.metric_bounds(value_history, threshold, comparison)
+
+    self.assertSequenceAlmostEqual(bounds, expected_bounds)
+
+  @parameterized.named_parameters(
+    ('less_1_dev', 'less', 1, (-math.inf, 4.414)),
+    ('less_or_equal', 'less', 1, (-math.inf, 4.414)),
+    ('less_2_dev', 'less', 2, (-math.inf, 5.828)),
+    ('greater', 'greater', 1, (1.586, math.inf)),
+  )
+  def test_metric_bounds_stddevs_from_mean(self, comparison, threshold_value, expected_bounds):
+    # mean = 3, stddev = ~1.414
+    value_history = [
+      metrics.MetricPoint(metric_value=1, wall_time=10),
+      metrics.MetricPoint(metric_value=2, wall_time=20),
+      metrics.MetricPoint(metric_value=3, wall_time=30),
+      metrics.MetricPoint(metric_value=4, wall_time=40),
+      metrics.MetricPoint(metric_value=5, wall_time=50),
+    ]
+
+    threshold = metrics.Threshold('stddevs_from_mean', threshold_value)
+    bounds = metrics.metric_bounds(value_history, threshold, comparison)
+
+    self.assertSequenceAlmostEqual(bounds, expected_bounds, places=3)
+
+  @parameterized.named_parameters(
+    ('less', 5., (-math.inf, 10.), False, True),
+    ('equal', 5., (5., 5.), True, True),
+    ('less_inclusive', 5., (-math.inf, 5.), True, True),
+    ('within', 3., (0., 5.), False, True),
+    ('less_exclusive', 5., (-math.inf, 5.), False, False),
+    ('greater', 5., (-math.inf, 5.), False, False),
+    ('outside', 10, (0., 5.), False, False),
+  )
+  def test_within_bounds(self, value, bounds, inclusive, expected):
+    within_bounds = metrics.within_bounds(value, *bounds, inclusive)
+    self.assertIs(within_bounds, expected)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/metrics_handler/metrics_test.py
+++ b/metrics_handler/metrics_test.py
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import math
 
 from absl import logging

--- a/metrics_handler/util.py
+++ b/metrics_handler/util.py
@@ -15,6 +15,7 @@
 # Lint as: python3
 """Util methods used by the Cloud Accelerators Testing metrics handler."""
 
+import math
 import re
 
 
@@ -60,3 +61,16 @@ def test_name_from_logs_link(logs_link):
     raise ValueError('Unable to parse test name from logs link: {}'.format(
         logs_link))
   return test_name
+
+
+def replace_invalid_values(row):
+  """Replace float values that are not available in BigQuery.
+
+  Args:
+    row: List of values to insert into BigQuery.
+
+  Returns:
+    List, `row` with invalid values replaced with `None`.
+  """
+  invalid_values = [math.inf, -math.inf, math.nan]
+  return [x if x not in invalid_values else None for x in row]

--- a/metrics_handler/util_test.py
+++ b/metrics_handler/util_test.py
@@ -14,8 +14,10 @@
 
 # Lint as: python3
 """Tests for util."""
+import math
 
-import unittest
+from absl.testing import absltest
+from absl.testing import parameterized
 
 import util
 
@@ -25,7 +27,7 @@ VALID_DOWNLOAD_COMMAND = """gcloud logging read 'resource.type=k8s_container res
 VALID_TEST_NAME = 'pt-nightly-resnet50-functional-v3-8-1584453600'
 
 
-class UtilTest(unittest.TestCase):
+class UtilTest(parameterized.TestCase):
 
   def test_download_command_from_logs_link_fail_to_parse(self):
     with self.assertRaises(ValueError):
@@ -44,7 +46,19 @@ class UtilTest(unittest.TestCase):
     self.assertEqual(
         VALID_TEST_NAME,
         util.test_name_from_logs_link(VALID_LOGS_LINK))
+  
+  @parameterized.named_parameters(
+    ('inf', [1, 2, 3, math.inf, 4, 5], [1, 2, 3, None, 4, 5]),
+    ('-inf', [1, 2, 3, -math.inf, 4, 5], [1, 2, 3, None, 4, 5]),
+    ('nan', [1, 2, 3, math.nan, 4, 5], [1, 2, 3, None, 4, 5]),
+    ('all', [math.inf, -math.inf, math.nan], [None, None, None]),
+    ('one_element', [math.inf], [None]),
+    ('empty', [], []),
+  )
+  def test_replace_invalid_values(self, row, expected_row):
+    clean_row = util.replace_invalid_values(row)
+    self.assertSequenceEqual(clean_row, expected_row)
 
 
 if __name__ == '__main__':
-  unittest.main()
+  absltest.main()


### PR DESCRIPTION
Move a lot of business logic into `metrics.py` and add tests. Add simple tests for `main.py`. Use `absltest` in `util_test.py`.

Ran coverage and got the following results:

```
Name                    Stmts   Miss  Cover   Missing
-----------------------------------------------------
alert_handler.py           81     43    47%   55, 57-72, 75-79, 85-87, 90, 96, 98, 106, 122, 150, 154-191
job_status_handler.py      72     57    21%   45-89, 105-152
main.py                   234    155    34%   88-96, 100, 104, 133-143, 148-181, 199-254, 260-268, 296, 316-321, 324-328, 342, 354-420, 424-515
main_test.py               28      0   100%
metrics.py                114     17    85%   38-40, 56-57, 79, 81, 104, 107, 148, 158-160, 184, 200, 207, 222
metrics_test.py            60      0   100%
util.py                    26      1    96%   76
util_test.py               28      0   100%
-----------------------------------------------------
TOTAL                     643    273    58%
```

Coverage is still not great, but most of these numbers are up from ~0%. Tested manually by creating a new cloud function and playing back some PubSub messages.