### PR TITLE
Add config option to disable email alerts for crashes/timeouts on a per-test basis.

### DIFF
--- a/k8s/gen/tf-nightly-keras-api-connection-v2-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-connection-v2-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-connection-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-connection-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/connection/v2-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-connection-v3-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-connection-v3-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-connection-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-connection-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/connection/v3-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-custom-layers-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-custom-layers-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/custom-layers/v2-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-custom-layers-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-custom-layers-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/custom-layers/v3-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-custom-training-loop-v2-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-custom-training-loop-v2-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-custom-training-loop-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-custom-training-loop-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/custom-training-loop/v2-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-custom-training-loop-v3-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-custom-training-loop-v3-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-custom-training-loop-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-custom-training-loop-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/custom-training-loop/v3-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-feature-column-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-feature-column-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/feature-column/v2-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-feature-column-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-feature-column-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/feature-column/v3-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-rnn-v2-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-rnn-v2-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-rnn-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-rnn-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/rnn/v2-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-rnn-v3-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-rnn-v3-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-rnn-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-rnn-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/rnn/v3-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-save-and-load-v2-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-save-and-load-v2-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-save-and-load-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-save-and-load-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/save-and-load/v2-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-save-and-load-v3-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-save-and-load-v3-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-save-and-load-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-save-and-load-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/save-and-load/v3-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-train-and-evaluate-v2-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-train-and-evaluate-v2-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-train-and-evaluate-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-train-and-evaluate-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/train-and-evaluate/v2-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-train-and-evaluate-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-train-and-evaluate-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/train-and-evaluate/v3-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-train-validation-dataset-v2-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-train-validation-dataset-v2-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-train-validation-dataset-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-train-validation-dataset-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/train-validation-dataset/v2-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-train-validation-dataset-v3-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-train-validation-dataset-v3-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-train-validation-dataset-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-train-validation-dataset-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/train-validation-dataset/v3-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-transfer-learning-v2-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-transfer-learning-v2-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/transfer-learning/v2-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/k8s/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
+++ b/k8s/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
@@ -52,7 +52,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "METRIC_CONFIG"
-              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"metric_success_conditions\": {\n   \"total_wall_time\": {\n    \"comparison\": \"less\",\n    \"success_threshold\": {\n     \"stddevs_from_mean\": 5\n    },\n    \"wait_for_n_points_of_history\": 10\n   }\n  },\n  \"write_to_error_reporting\": true\n },\n \"test_name\": \"tf-nightly-keras-api-transfer-learning-v3-8\"\n}"
+              "value": "{\n \"metric_collection_config\": {\n  \"default_aggregation_strategies\": [\n   \"final\"\n  ],\n  \"write_to_bigquery\": true\n },\n \"regression_test_config\": {\n  \"alert_for_failed_jobs\": false\n },\n \"test_name\": \"tf-nightly-keras-api-transfer-learning-v3-8\"\n}"
             - "name": "MODEL_DIR"
               "value": "gs://xl-ml-test-us-central1/k8s/keras-api/transfer-learning/v3-8/$(JOB_NAME)"
             "image": "gcr.io/xl-ml-test/model-garden:nightly"

--- a/metrics_handler/README.md
+++ b/metrics_handler/README.md
@@ -151,11 +151,11 @@ Full config options:
     "Accuracy/test_final"
   ],
 
-  # (Optional) Defaults to True. If set to false, this test will not write
+  # (Optional) Defaults to True. If set to False, this test will not write
   # any errors to Stackdriver Error Reporting for out-of-bounds metrics.
   "write_to_error_reporting": "True",
 
-  # (Optional) Defaults to True. If set to false, this test will not send
+  # (Optional) Defaults to True. If set to False, this test will not send
   # any alerts emails if the test crashes or times out.
   "alert_for_failed_jobs": "True"
 }

--- a/metrics_handler/README.md
+++ b/metrics_handler/README.md
@@ -151,8 +151,12 @@ Full config options:
     "Accuracy/test_final"
   ],
 
-  # (Optional) Defaults to True. Set to False to disable Stackdriver alerting
-  # for training metrics of this test.
-  "write_to_error_reporting": "True"
+  # (Optional) Defaults to True. If set to false, this test will not write
+  # any errors to Stackdriver Error Reporting for out-of-bounds metrics.
+  "write_to_error_reporting": "True",
+
+  # (Optional) Defaults to True. If set to false, this test will not send
+  # any alerts emails if the test crashes or times out.
+  "alert_for_failed_jobs": "True"
 }
 ```

--- a/templates/garden/nightly/keras-api.libsonnet
+++ b/templates/garden/nightly/keras-api.libsonnet
@@ -33,6 +33,9 @@ local tpus = import "../../tpus.libsonnet";
       "-c",
       base_command + " behave -e ipynb_checkpoints --tags=-fails -i %s" % self.testFeature,
     ],
+    regressionTestConfig: {
+      alert_for_failed_jobs: false,
+    },
   },
 
   local API = {


### PR DESCRIPTION
Update README to document the new option. Use the new option to disable emails for keras-api tests.