### PR TITLE
Handle case where k8s conditions are None for non-success jobs.

### DIFF
--- a/metrics_handler/job_status_handler.py
+++ b/metrics_handler/job_status_handler.py
@@ -154,9 +154,9 @@ class JobStatusHandler(object):
               'job: {}. Using time.time(). Status: {}'.format(job_name, status))
           stop_time = time.time()
     else:
-      if len(status.conditions) != 1:
+      if not status.conditions or len(status.conditions) != 1:
         self.logger.error(
-            'Expected exactly 1 `condition` element in status. '
+            'Expected exactly 1 `condition` element in non-success status. '
             'Status was: {}'.format(status))
         completion_code = FAILURE
         stop_time = status.start_time.timestamp()


### PR DESCRIPTION
This case is extremely rare but it's still better to have a coherent error message rather than the current error of `TypeError: object of type 'NoneType' has no len()`