### PR TITLE
Handle duplicate rows in Bigquery.

### DIFF
--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -527,8 +527,7 @@ def run_main(event, context):
     subscription = subscriber.create_subscription(
         subscription_id, topic, ack_deadline_seconds=300).name
   try:
-    #all_msgs = subscriber.pull(subscription, 100).received_messages
-    all_msgs = []
+    all_msgs = subscriber.pull(subscription, 100).received_messages
   except google.api_core.exceptions.DeadlineExceeded:
     logger.info(
         'No messages found for subscription: {}'.format(subscription))
@@ -556,8 +555,6 @@ def run_main(event, context):
   # Grab the latest message for each test. We will process only that message
   # and all other messages for that test will be ack'ed without being processed.
   msgs_to_process = []
-  msgs_to_process = [{'model_dir': 'gs://xl-ml-test-us-central1/k8s/python-ops/functional/v2-8/pt-nightly-python-ops-functional-v2-8-1585922400', 'logs_link': 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-nightly-python-ops-functional-v2-8-1585922400', 'job_name': 'pt-nightly-python-ops-functional-v2-8-1585922400', 'job_namespace': 'automated', 'zone': 'us-central1-b', 'cluster_name': 'xl-ml-test', 'metric_collection_config': {'default_aggregation_strategies': ['final'], 'tags_to_ignore': ['LearningRate'], 'write_to_bigquery': True}, 'regression_test_config': None, 'test_name': 'pt-nightly-python-ops-functional-v2-8', 'publish_time': 1585926077, 'ack_id': 'IT4wPkVTRFAGFixdRkhRNxkIaFEOT14jPzUgKEUVBAgUBXx9cEFFdV9bdmhRDRlyfWBya14TCVBAAi9WURoHaE5tdSVxDBl6eWF8YlkTBQNHVHhbUjPWxYOG7ui-PANORfiHx54mIbf7lrhuZiU9XxJLLD5-LyJFQV5AEkwkF0RJUytDCypYEU4EIQ'}]
-  msgs_to_process = [{'model_dir': 'gs://xl-ml-test-us-central1/k8s/python-ops/functional/v2-8/pt-nightly-python-ops-functional-v2-8-1585922400', 'logs_link': 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-nightly-mnist-convergence-v3-8-1582356600', 'job_name': 'pt-nightly-python-ops-functional-v2-8-1585922400', 'job_namespace': 'automated', 'zone': 'us-central1-b', 'cluster_name': 'xl-ml-test', 'metric_collection_config': {'default_aggregation_strategies': ['final'], 'tags_to_ignore': ['LearningRate'], 'write_to_bigquery': True}, 'regression_test_config': None, 'test_name': 'pt-nightly-python-ops-functional-v2-8', 'publish_time': 1585926077, 'ack_id': 'IT4wPkVTRFAGFixdRkhRNxkIaFEOT14jPzUgKEUVBAgUBXx9cEFFdV9bdmhRDRlyfWBya14TCVBAAi9WURoHaE5tdSVxDBl6eWF8YlkTBQNHVHhbUjPWxYOG7ui-PANORfiHx54mIbf7lrhuZiU9XxJLLD5-LyJFQV5AEkwkF0RJUytDCypYEU4EIQ'}]
   for test_name, msgs in test_name_to_msgs.items():
     sorted_msgs = sorted(msgs, key = lambda x: x['publish_time'])
     ids_to_ack.extend([msg['ack_id'] for msg in msgs[:-1]])

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -510,7 +510,7 @@ def _process_pubsub_message(msg, status_handler, logger):
 
 def run_main(event, context):
   project_id = google.auth.default()[1]
-  logger = alert_handler.AlertHandler(project_id, write_to_email=False)
+  logger = alert_handler.AlertHandler(project_id)
 
   # Retrieve pubsub messages for all the tests that have been kicked off by
   # the test runner.

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -234,7 +234,7 @@ class CloudMetricsHandler(object):
         int(job_status['stop_time'] - job_status['start_time']),
         self._wall_time_to_sql_timestamp(job_status['stop_time']),
         self.stackdriver_logs_link,
-        None,  # TODO: Pass int for msg_publish_time.
+        job_status['publish_time'],
     ]
 
     # Create rows to represent the computed metrics for this job.
@@ -313,7 +313,7 @@ class CloudMetricsHandler(object):
                         logs_link=self.stackdriver_logs_link)
     for row in query_result:
       uuid = row['uuid']
-      publish_time = row['publish_time']
+      publish_time = row['msg_publish_time']
     raise ValueError("stopping early")
     return uuid, publish_time
 
@@ -459,6 +459,7 @@ def _process_pubsub_message(msg, status_handler, logger):
   job_status = {
       'final_status': status,
       'start_time': publish_time,
+      'publish_time': publish_time,
       'stop_time': stop_time,
       'num_failures': num_failures,
   }

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -300,7 +300,6 @@ class CloudMetricsHandler(object):
     """
     uuid = None
     publish_time = None
-    import pdb; pdb.set_trace()
     if not self.metric_collection_config.get('write_to_bigquery', True):
       self.logger.info('Skipping check for existing Bigquery rows.')
       return uuid, publish_time
@@ -314,21 +313,15 @@ class CloudMetricsHandler(object):
     for row in query_result:
       uuid = row['uuid']
       publish_time = row['msg_publish_time']
-    raise ValueError("stopping early")
     return uuid, publish_time
 
   def delete_outdated_rows(self, uuid):
-    import pdb; pdb.set_trace()
-    x = 1
-    return
     delete_job_row_result = self.bigquery_client.query(
         'DELETE FROM `{}` WHERE uuid=\"{}\"'.format(
             self.job_history_table_id, uuid)).result()
     delete_metric_rows_result = self.bigquery_client.query(
         'DELETE FROM `{}` WHERE uuid=\"{}\"'.format(
             self.metric_history_table_id, uuid)).result()
-    # do more stuff
-    x=1
 
 
   def compute_bounds_and_report_errors(self, metrics_history, new_metrics):
@@ -564,6 +557,7 @@ def run_main(event, context):
   # and all other messages for that test will be ack'ed without being processed.
   msgs_to_process = []
   msgs_to_process = [{'model_dir': 'gs://xl-ml-test-us-central1/k8s/python-ops/functional/v2-8/pt-nightly-python-ops-functional-v2-8-1585922400', 'logs_link': 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-nightly-python-ops-functional-v2-8-1585922400', 'job_name': 'pt-nightly-python-ops-functional-v2-8-1585922400', 'job_namespace': 'automated', 'zone': 'us-central1-b', 'cluster_name': 'xl-ml-test', 'metric_collection_config': {'default_aggregation_strategies': ['final'], 'tags_to_ignore': ['LearningRate'], 'write_to_bigquery': True}, 'regression_test_config': None, 'test_name': 'pt-nightly-python-ops-functional-v2-8', 'publish_time': 1585926077, 'ack_id': 'IT4wPkVTRFAGFixdRkhRNxkIaFEOT14jPzUgKEUVBAgUBXx9cEFFdV9bdmhRDRlyfWBya14TCVBAAi9WURoHaE5tdSVxDBl6eWF8YlkTBQNHVHhbUjPWxYOG7ui-PANORfiHx54mIbf7lrhuZiU9XxJLLD5-LyJFQV5AEkwkF0RJUytDCypYEU4EIQ'}]
+  msgs_to_process = [{'model_dir': 'gs://xl-ml-test-us-central1/k8s/python-ops/functional/v2-8/pt-nightly-python-ops-functional-v2-8-1585922400', 'logs_link': 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-nightly-mnist-convergence-v3-8-1582356600', 'job_name': 'pt-nightly-python-ops-functional-v2-8-1585922400', 'job_namespace': 'automated', 'zone': 'us-central1-b', 'cluster_name': 'xl-ml-test', 'metric_collection_config': {'default_aggregation_strategies': ['final'], 'tags_to_ignore': ['LearningRate'], 'write_to_bigquery': True}, 'regression_test_config': None, 'test_name': 'pt-nightly-python-ops-functional-v2-8', 'publish_time': 1585926077, 'ack_id': 'IT4wPkVTRFAGFixdRkhRNxkIaFEOT14jPzUgKEUVBAgUBXx9cEFFdV9bdmhRDRlyfWBya14TCVBAAi9WURoHaE5tdSVxDBl6eWF8YlkTBQNHVHhbUjPWxYOG7ui-PANORfiHx54mIbf7lrhuZiU9XxJLLD5-LyJFQV5AEkwkF0RJUytDCypYEU4EIQ'}]
   for test_name, msgs in test_name_to_msgs.items():
     sorted_msgs = sorted(msgs, key = lambda x: x['publish_time'])
     ids_to_ack.extend([msg['ack_id'] for msg in msgs[:-1]])
@@ -609,5 +603,3 @@ def run_main(event, context):
   logger.info('Processed a message for each of the following tests: '
               '{}'.format([x['test_name'] for x in msgs_to_process]))
   logger.send_email()
-
-run_main(None, None)


### PR DESCRIPTION
Delays in Cloud Pubsub sometimes lead to weird sequences of messages arriving at the metrics handler, which can lead to writing duplicate rows to Bigquery.  ([more context](https://b.corp.google.com/issues/151974471#comment14))

This PR adds logic to check for existing rows in Bigquery for the current test before attempting to process a message. If rows already exist but the current message is more recent, then the new logic will clean up the existing rows so that we have the most accurate data in Bigquery.

Tested locally to make sure both paths work, including deleting rows.