### PR TITLE
Add build args to TensorFlow Dockerfile.

### DIFF
--- a/images/garden/Dockerfile
+++ b/images/garden/Dockerfile
@@ -23,9 +23,7 @@ RUN pip3 install cloud-tpu-client pyyaml
 
 # Checkout tensorflow/models at HEAD
 WORKDIR /
-RUN curl -LO https://github.com/tensorflow/models/archive/${model_garden_branch}.zip
-RUN unzip ${model_garden_branch}.zip
-RUN rm ${model_garden_branch}.zip
+RUN curl -L https://github.com/tensorflow/models/archive/${model_garden_branch}.tar.gz | tar zx
 RUN mv models-${model_garden_branch} garden/
 RUN pip3 install -r /garden/official/requirements.txt
 ENV PYTHONPATH /garden
@@ -33,10 +31,8 @@ ENV PYTHONPATH /garden
 COPY images/setup.sh /
 COPY images/garden/entrypoint.sh /
 
-RUN curl -sSO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-289.0.0-linux-x86_64.tar.gz
-RUN tar -xf google-cloud-sdk-*.tar.gz
-RUN rm google-cloud-sdk-*.tar.gz
-RUN ./google-cloud-sdk/install.sh
+RUN curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-289.0.0-linux-x86_64.tar.gz | tar zx
+ENV PATH "/google-cloud-sdk/bin/:${PATH}"
 
 WORKDIR /garden
 ENTRYPOINT ["/entrypoint.sh"]

--- a/images/garden/Dockerfile
+++ b/images/garden/Dockerfile
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tensorflow/tensorflow:nightly-gpu-py3
+ARG image_version=nightly
+FROM tensorflow/tensorflow:${image_version}-gpu
+
+ARG model_garden_branch=master
 
 RUN apt-get update && apt-get install -y --no-install-recommends git
 
@@ -20,10 +23,10 @@ RUN pip3 install cloud-tpu-client pyyaml
 
 # Checkout tensorflow/models at HEAD
 WORKDIR /
-RUN curl -LO https://github.com/tensorflow/models/archive/master.zip
-RUN unzip master.zip
-RUN rm master.zip
-RUN mv models-master garden/
+RUN curl -LO https://github.com/tensorflow/models/archive/${model_garden_branch}.zip
+RUN unzip ${model_garden_branch}.zip
+RUN rm ${model_garden_branch}.zip
+RUN mv models-${model_garden_branch} garden/
 RUN pip3 install -r /garden/official/requirements.txt
 ENV PYTHONPATH /garden
 
@@ -31,7 +34,7 @@ COPY images/setup.sh /
 COPY images/garden/entrypoint.sh /
 
 RUN curl -sSO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-289.0.0-linux-x86_64.tar.gz
-RUN tar -xvf google-cloud-sdk-*.tar.gz
+RUN tar -xf google-cloud-sdk-*.tar.gz
 RUN rm google-cloud-sdk-*.tar.gz
 RUN ./google-cloud-sdk/install.sh
 

--- a/images/garden/cloudbuild.yaml
+++ b/images/garden/cloudbuild.yaml
@@ -14,12 +14,21 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/model-garden:$_VERSION', '.', '-f', 'images/garden/Dockerfile']
+  args: [
+    'build',
+    '-t',
+    'gcr.io/$PROJECT_ID/model-garden:$_VERSION', '.',
+    '-f', 'images/garden/Dockerfile',
+    '--build-arg', 'image_version=$_BASE_IMAGE_VERSION',
+    '--build-arg', 'model_garden_branch=$_MODEL_GARDEN_BRANCH'
+  ]
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/model-garden:$_VERSION']
 images: ['gcr.io/$PROJECT_ID/model-garden:$_VERSION']
 timeout: 1200s  # 20 minutes
 substitutions:
   _VERSION: 'latest'
+  _BASE_IMAGE_VERSION: 'nightly'
+  _MODEL_GARDEN_BRANCH: 'master'
 options:
-    substitution_option: 'ALLOW_LOOSE'
+  substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
This unblocks building stable TF images, e.g. `gcloud builds submit --config images/garden/cloudbuild.yaml --substitutions="_VERSION=r2.2.0,_BASE_IMAGE_VERSION=2.2.0rc3,_MODEL_GARDEN_BRANCH=r2.2.0"`