### PR TITLE
Alert email tz

### DIFF
--- a/metrics_handler/alert_handler.py
+++ b/metrics_handler/alert_handler.py
@@ -14,6 +14,7 @@
 
 import collections
 from datetime import datetime
+import pytz
 
 import util
 
@@ -70,6 +71,12 @@ class AlertHandler(object):
                   'metrics_handler/README for setup steps. Error '
                   'was: {}'.format(e), logging.ERROR)
         self.write_to_email = False
+
+  @staticmethod
+  def generate_email_subject():
+    return Subject('Errors in ML Accelerators Tests at {}'.format(
+        datetime.now(pytz.timezone('US/Pacific')).strftime(
+            "%Y/%m/%d %H:%M:%S")))
 
   def _get_secret_value(self, secret_name, secret_client):
     secret_resource = \
@@ -195,8 +202,7 @@ class AlertHandler(object):
         from_email=From(self.sender_email,
                         'Cloud Accelerators Alert Manager'),
         to_emails=[To(self.recipient_email)],
-        subject=Subject('Errors in ML Accelerators Tests at {}'.format(
-            datetime.now().strftime("%Y/%m/%d %H:%M:%S"))),
+        subject=AlertHandler.generate_email_subject(),
         plain_text_content=PlainTextContent('empty'),
         html_content=HtmlContent(html_message_body))
     response = self.sendgrid.send(message)

--- a/metrics_handler/alert_handler_test.py
+++ b/metrics_handler/alert_handler_test.py
@@ -6,6 +6,8 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+from datetime import datetime
+import pytz
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -98,10 +100,14 @@ class AlertHandlerTest(parameterized.TestCase):
         HTML_GENERAL_AND_SPECIFIC_ERRORS)
 
   def test_generate_email_subject(self):
-    sj = alert_handler.AlertHandler.generate_email_subject()
-    x = 1
-    y = 2
-    import pdb; pdb.set_trace()
+    sj = alert_handler.AlertHandler.generate_email_subject().subject
+    date_str = sj[sj.find('202'):] # Grab substring from start of year onward.
+    tz = pytz.timezone('US/Pacific')
+    sj_date = tz.localize(datetime.strptime(date_str, '%Y/%m/%d %H:%M:%S'))
+    after_call = datetime.now(pytz.timezone('US/Pacific'))
+    # This checks that the datetime string used in the email is 1. using
+    # current time and 2. is using US/Pacific tz and not e.g. UTC.
+    self.assertTrue((after_call - sj_date).total_seconds())
 
 if __name__ == '__main__':
   absltest.main()

--- a/metrics_handler/alert_handler_test.py
+++ b/metrics_handler/alert_handler_test.py
@@ -107,7 +107,7 @@ class AlertHandlerTest(parameterized.TestCase):
     after_call = datetime.now(pytz.timezone('US/Pacific'))
     # This checks that the datetime string used in the email is 1. using
     # current time and 2. is using US/Pacific tz and not e.g. UTC.
-    self.assertTrue((after_call - sj_date).total_seconds())
+    self.assertTrue((after_call - sj_date).total_seconds() < 2.0)
 
 if __name__ == '__main__':
   absltest.main()

--- a/metrics_handler/alert_handler_test.py
+++ b/metrics_handler/alert_handler_test.py
@@ -97,6 +97,11 @@ class AlertHandlerTest(parameterized.TestCase):
         self.handler.generate_email_body(),
         HTML_GENERAL_AND_SPECIFIC_ERRORS)
 
+  def test_generate_email_subject(self):
+    sj = alert_handler.AlertHandler.generate_email_subject()
+    x = 1
+    y = 2
+    import pdb; pdb.set_trace()
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Use Pacific timezone when generating the datetime string displayed in alert emails instead of UTC.

Refactor the subject creation to allow unit testing and add a unit test for the method.