### PR TITLE
Dashboard: use download command from BQ if it exists

### DIFF
--- a/dashboard/main_heatmap.py
+++ b/dashboard/main_heatmap.py
@@ -125,8 +125,6 @@ def process_dataframes(job_status_dataframe, metrics_dataframe):
       'job_status'].apply(lambda x: x)
 
   # Record the status of the metrics for every test.
-  job_status_dataframe['logs_download_command'] = job_status_dataframe[
-      'logs_download_command'].apply(lambda x: x)
   job_status_dataframe['failed_metrics'] = job_status_dataframe[
       'job_status'].apply(lambda x: [])
   for row in job_status_dataframe.iterrows():

--- a/dashboard/main_heatmap.py
+++ b/dashboard/main_heatmap.py
@@ -35,6 +35,7 @@ SELECT
   x.job_status,
   SAFE_CAST(DATE(timestamp, 'US/Pacific') AS STRING) AS run_date,
   x.stackdriver_logs_link AS logs_link,
+  x.logs_download_command AS logs_download_command,
   x.uuid
 FROM (
   SELECT
@@ -124,6 +125,8 @@ def process_dataframes(job_status_dataframe, metrics_dataframe):
       'job_status'].apply(lambda x: x)
 
   # Record the status of the metrics for every test.
+  job_status_dataframe['logs_download_command'] = job_status_dataframe[
+      'logs_download_command'].apply(lambda x: x)
   job_status_dataframe['failed_metrics'] = job_status_dataframe[
       'job_status'].apply(lambda x: [])
   for row in job_status_dataframe.iterrows():
@@ -133,6 +136,11 @@ def process_dataframes(job_status_dataframe, metrics_dataframe):
     if failed_metrics:
       job_status_dataframe['failed_metrics'][row[0]] = failed_metrics
       job_status_dataframe['overall_status'][row[0]] = 'failure'
+    if not row[1]['logs_download_command']:
+      # If the job does not have any download command in Bigquery, attempt to
+      # create one by parsing the logs_link.
+      job_status_dataframe['logs_download_command'][
+          row[0]] = utils.get_download_command(row[1]['logs_link'])
 
   # Create a few convenience columns to use in the dashboard.
   job_status_dataframe['job_status_abbrev'] = job_status_dataframe[
@@ -140,8 +148,6 @@ def process_dataframes(job_status_dataframe, metrics_dataframe):
           lambda x: '' if x.startswith('success') else x[:1].upper())
   job_status_dataframe['metrics_link'] = job_status_dataframe[
       'test_name'].apply(lambda x: 'metrics?test_name={}'.format(x))
-  job_status_dataframe['logs_download_command'] = job_status_dataframe[
-      'logs_link'].apply(utils.get_download_command)
   return job_status_dataframe
 
 def make_plot(dataframe):

--- a/dashboard/main_heatmap_test.py
+++ b/dashboard/main_heatmap_test.py
@@ -49,6 +49,8 @@ class MainHeatmapTest(parameterized.TestCase):
             len(job_statuses))]),
         'job_status': pd.Series(job_statuses),
         'logs_link': pd.Series([SAMPLE_LOGS_LINK for _ in job_statuses]),
+        'logs_download_command': pd.Series(
+            ['my command'] + ['' for _ in job_statuses[1:]]),
     })
 
     # The SQL query in the real code only returns rows where metrics were
@@ -82,6 +84,15 @@ class MainHeatmapTest(parameterized.TestCase):
     df = main_heatmap.process_dataframes(job_status_df, metric_status_df)
     self.assertEqual(df['overall_status'].tolist(),
                      args_dict['expected_overall_statuses'])
+
+    commands = df['logs_download_command'].tolist()
+    # If a command is already populated, it should be left alone.
+    self.assertEqual(commands[0], 'my command')
+
+    # Empty strings should be replaced by valid download commands.
+    if len(args_dict['expected_overall_statuses']) > 1:
+      for command in commands[1:]:
+        self.assertTrue('gcloud' in command)
 
   def test_make_plot(self):
     input_df = pd.DataFrame({

--- a/dashboard/main_heatmap_test.py
+++ b/dashboard/main_heatmap_test.py
@@ -86,10 +86,11 @@ class MainHeatmapTest(parameterized.TestCase):
                      args_dict['expected_overall_statuses'])
 
     commands = df['logs_download_command'].tolist()
-    # If a command is already populated, it should be left alone.
+    # If the command is already populated, it should be left alone.
     self.assertEqual(commands[0], 'my command')
 
-    # Empty strings should be replaced by valid download commands.
+    # If the command is not populated, the empty string should be replaced
+    # by a valid download command.
     if len(args_dict['expected_overall_statuses']) > 1:
       for command in commands[1:]:
         self.assertTrue('gcloud' in command)

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -58,7 +58,7 @@ def run_query(query, cache_key, config={}, expire=3600):
 # TODO: Reconcile this with the similar helper method under
 # metrics_handler/util.py
 LOGS_DOWNLOAD_COMMAND = """gcloud logging read 'resource.type=k8s_container resource.labels.project_id={project} resource.labels.location={zone} resource.labels.cluster_name={cluster} resource.labels.namespace_name={namespace} resource.labels.pod_name:{pod}' --limit 10000000000000 --order asc --format 'value(textPayload)' --project={project} > {pod}_logs.txt && sed -i '/^$/d' {pod}_logs.txt"""
-LOG_LINK_REGEX = re.compile('https://console\.cloud\.google\.com/logs\?project=(\S+)\&advancedFilter=resource\.type\%3Dk8s_container\%0Aresource\.labels\.project_id\%3D(?P<project>\S+)\%0Aresource\.labels\.location=(?P<zone>\S+)\%0Aresource\.labels\.cluster_name=(?P<cluster>\S+)\%0Aresource\.labels\.namespace_name=(?P<namespace>\S+)\%0Aresource\.labels\.pod_name:(?P<pod>\S+)(\&dateRangeUnbound=backwardInTime)?')
+LOG_LINK_REGEX = re.compile('https://console\.cloud\.google\.com/logs\?project=(\S+)\&advancedFilter=resource\.type\%3Dk8s_container\%0Aresource\.labels\.project_id\%3D(?P<project>\S+)\%0Aresource\.labels\.location=(?P<zone>\S+)\%0Aresource\.labels\.cluster_name=(?P<cluster>\S+)\%0Aresource\.labels\.namespace_name=(?P<namespace>\S+)\%0Aresource\.labels\.pod_name:(?P<pod>[a-zA-Z0-9\-\.]+)')
 def get_download_command(logs_link):
   log_pieces = LOG_LINK_REGEX.match(logs_link)
   if not log_pieces:


### PR DESCRIPTION
This PR does 2 things:
1. Adds a fix for the current command to generate the download command (which I intend to remove soon). see https://b.corp.google.com/issues/154725122
2. Changes the dashboard to use the download command stored in Bigquery (added in #83) if it exists rather than generating the download command

TESTED=unit tests + ran `bokeh serve`

