### PR TITLE
Warn instead of alert for 404 jobs.

### DIFF
--- a/metrics_handler/job_status_handler.py
+++ b/metrics_handler/job_status_handler.py
@@ -106,7 +106,7 @@ class JobStatusHandler(object):
     except Exception as e:
       if isinstance(e, kubernetes.client.rest.ApiException) and \
           e.status == 404:
-        self.logger.error(
+        self.logger.warning(
             'Job with job_name: {} no longer exists in namespace: '
             '{}.  Error was: {}'.format(job_name, namespace, e))
         return DOES_NOT_EXIST, None


### PR DESCRIPTION
These alert emails are not actionable for the oncall. We should still look into why we have so many jobs in the pubsub queue that return 404 when we check for the job status.