### PR TITLE
Pytorch-only dashboard

### DIFF
--- a/dashboard/pytorch-dashboard.yaml
+++ b/dashboard/pytorch-dashboard.yaml
@@ -1,0 +1,44 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+service: pytorch-dashboard
+runtime: python
+env: flex
+entrypoint: bokeh serve --disable-index-redirect --num-procs=1 --port=$PORT --allow-websocket-origin=pytorch-dashboard-dot-xl-ml-test.appspot.com dashboard.py metrics.py
+
+runtime_config:
+  python_version: 3
+
+automatic_scaling:
+  min_num_instances: 2
+  max_num_instances: 20
+  cool_down_period_sec: 240
+
+resources:
+  cpu: 2
+  memory_gb: 3
+  disk_size_gb: 10
+
+# Update to match your project.
+env_variables:
+  REDISHOST: '10.25.27.107'
+  REDISPORT: '6379'
+  TEST_NAME_PREFIXES: 'pt-nightly,pt-1.5'
+  JOB_HISTORY_TABLE_NAME: 'xl-ml-test.metrics_handler_dataset.job_history'
+  METRIC_HISTORY_TABLE_NAME: 'xl-ml-test.metrics_handler_dataset.metric_history'
+
+
+# Update with Redis instance network name
+network:
+  name: default


### PR DESCRIPTION
1. Add App Engine config to run a version of the dashboard that shows only PyTorch tests.
2. Update the metrics history dashboard to show only the metrics of tests that are set by env variable

TESTED=Ran locally, then deployed new app and verified the permissions behavior