### PR TITLE
Safer method of creating debug info.

### DIFF
--- a/metrics_handler/alert_handler_test.py
+++ b/metrics_handler/alert_handler_test.py
@@ -14,7 +14,15 @@ from absl.testing import parameterized
 import alert_handler
 
 
-VALID_LOGS_LINK = 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-1.5-fs-transformer-functional-v3-8-1585756800&extra_junk&dateRangeUnbound=backwardInTime'
+LOGS_LINK = """https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-1.5-fs-transformer-functional-v3-8-1585756800&extra_junk&dateRangeUnbound=backwardInTime"""
+DOWNLOAD_COMMAND = """gcloud logging read 'resource.type=k8s_container resource.labels.project_id=xl-ml-test resource.labels.location=us-central1-b resource.labels.cluster_name=xl-ml-test resource.labels.namespace_name=automated resource.labels.pod_name:pt-1.5-fs-transformer-functional-v3-8-1585756800' --limit 10000000000000 --order asc --format 'value(textPayload)' --project=xl-ml-test > pt-1.5-fs-transformer-functional-v3-8-1585756800_logs.txt && sed -i '/^$/d' pt-1.5-fs-transformer-functional-v3-8-1585756800_logs.txt"""
+WORKLOAD_LINK = """https://console.cloud.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/pt-1.5-fs-transformer-functional-v3-8-1585756800?project=xl-ml-test&pt-1.5-fs-transformer-functional-v3-8-1585756800_events_tablesize=50&tab=events&duration=P30D&pod_summary_list_tablesize=20&service_list_datatablesize=20"""
+DEBUG_INFO = alert_handler.DebugInfo(
+    'pt-1.5-fs-transformer-functional-v3-8-1585756800',
+    LOGS_LINK,
+    DOWNLOAD_COMMAND,
+    WORKLOAD_LINK)
+
 HTML_GENERAL_ERRORS_ONLY = """New errors in test suite for my-project-id:<ul><li>General errors:<ul><li>msg1</li><li>msg2</li></ul></li></ul>"""
 HTML_GENERAL_AND_SPECIFIC_ERRORS = """New errors in test suite for my-project-id:<ul><li>General errors:<ul><li>msg1</li><li>msg2</li></ul></li><li>pt-1.5-fs-transformer-functional-v3-8-1585756800:<ul><li>msg3</li><li>msg4</li><li><a href="https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-1.5-fs-transformer-functional-v3-8-1585756800&extra_junk&dateRangeUnbound=backwardInTime">Stackdriver logs for this run of the test</a></li><li><a href="https://console.cloud.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/pt-1.5-fs-transformer-functional-v3-8-1585756800?project=xl-ml-test&pt-1.5-fs-transformer-functional-v3-8-1585756800_events_tablesize=50&tab=events&duration=P30D&pod_summary_list_tablesize=20&service_list_datatablesize=20">Kubernetes workload for this run of the test</a></li><li>Command to download plaintext logs: <code style="background-color:#e3e3e3;">gcloud logging read 'resource.type=k8s_container resource.labels.project_id=xl-ml-test resource.labels.location=us-central1-b resource.labels.cluster_name=xl-ml-test resource.labels.namespace_name=automated resource.labels.pod_name:pt-1.5-fs-transformer-functional-v3-8-1585756800' --limit 10000000000000 --order asc --format 'value(textPayload)' --project=xl-ml-test > pt-1.5-fs-transformer-functional-v3-8-1585756800_logs.txt && sed -i '/^$/d' pt-1.5-fs-transformer-functional-v3-8-1585756800_logs.txt</code></li></ul></li></ul>"""
 HTML_SPECIFIC_ERRORS_ONLY = """New errors in test suite for my-project-id:<ul><li>pt-1.5-fs-transformer-functional-v3-8-1585756800:<ul><li>msg3</li><li>msg4</li><li><a href="https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-1.5-fs-transformer-functional-v3-8-1585756800&extra_junk&dateRangeUnbound=backwardInTime">Stackdriver logs for this run of the test</a></li><li><a href="https://console.cloud.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/pt-1.5-fs-transformer-functional-v3-8-1585756800?project=xl-ml-test&pt-1.5-fs-transformer-functional-v3-8-1585756800_events_tablesize=50&tab=events&duration=P30D&pod_summary_list_tablesize=20&service_list_datatablesize=20">Kubernetes workload for this run of the test</a></li><li>Command to download plaintext logs: <code style="background-color:#e3e3e3;">gcloud logging read 'resource.type=k8s_container resource.labels.project_id=xl-ml-test resource.labels.location=us-central1-b resource.labels.cluster_name=xl-ml-test resource.labels.namespace_name=automated resource.labels.pod_name:pt-1.5-fs-transformer-functional-v3-8-1585756800' --limit 10000000000000 --order asc --format 'value(textPayload)' --project=xl-ml-test > pt-1.5-fs-transformer-functional-v3-8-1585756800_logs.txt && sed -i '/^$/d' pt-1.5-fs-transformer-functional-v3-8-1585756800_logs.txt</code></li></ul></li></ul>"""
@@ -52,9 +60,9 @@ class AlertHandlerTest(parameterized.TestCase):
     with self.assertLogs() as cm:
       getattr(self.handler, log_method_name)('msg1')
       getattr(self.handler, log_method_name)('msg2')
-      getattr(self.handler, log_method_name)('msg3', logs_link='link1')
-      getattr(self.handler, log_method_name)('msg4', logs_link='link1')
-      getattr(self.handler, log_method_name)('msg5', logs_link='link2')
+      getattr(self.handler, log_method_name)('msg3', debug_info='link1')
+      getattr(self.handler, log_method_name)('msg4', debug_info='link1')
+      getattr(self.handler, log_method_name)('msg5', debug_info='link2')
       self.assertEqual(cm.output, [
           f'{log_level}:absl:msg1',
           f'{log_level}:absl:msg2',
@@ -63,7 +71,7 @@ class AlertHandlerTest(parameterized.TestCase):
           f'{log_level}:absl:msg5',
       ])
     expected_messages = {
-        alert_handler._NO_LOGS: ['msg1', 'msg2'],
+        alert_handler._NO_INFO: ['msg1', 'msg2'],
         'link1': ['msg3', 'msg4'],
         'link2': ['msg5'],
     }
@@ -76,7 +84,7 @@ class AlertHandlerTest(parameterized.TestCase):
 
   def test_generate_email_body_general_errors_only(self):
     self.handler.messages_to_email = {
-        alert_handler._NO_LOGS: ['msg1', 'msg2'],
+        alert_handler._NO_INFO: ['msg1', 'msg2'],
     }
     self.assertEqual(
         self.handler.generate_email_body(),
@@ -84,7 +92,7 @@ class AlertHandlerTest(parameterized.TestCase):
 
   def test_generate_email_body_specific_errors_only(self):
     self.handler.messages_to_email = {
-        VALID_LOGS_LINK: ['msg3', 'msg4'],
+        DEBUG_INFO: ['msg3', 'msg4'],
     }
     self.assertEqual(
         self.handler.generate_email_body(),
@@ -92,8 +100,8 @@ class AlertHandlerTest(parameterized.TestCase):
 
   def test_generate_email_body_general_and_specific_errors(self):
     self.handler.messages_to_email = {
-        alert_handler._NO_LOGS: ['msg1', 'msg2'],
-        VALID_LOGS_LINK: ['msg3', 'msg4'],
+        alert_handler._NO_INFO: ['msg1', 'msg2'],
+        DEBUG_INFO: ['msg3', 'msg4'],
     }
     self.assertEqual(
         self.handler.generate_email_body(),

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -433,15 +433,13 @@ def _process_pubsub_message(msg, status_handler, logger):
   logs_link = msg.get('logs_link')
   metric_collection_config = msg.get('metric_collection_config')
   regression_test_config = msg.get('regression_test_config')
-
   job_name = msg.get('job_name')
   job_namespace = msg.get('job_namespace')
   test_type = msg.get('test_type')
   accelerator = msg.get('accelerator')
   framework_version = msg.get('framework_version')
-
-  zone = msgs_to_process[0].get('zone')
-  cluster = msgs_to_process[0].get('cluster_name')
+  zone = msg.get('zone')
+  cluster = msg.get('cluster_name')
   project = google.auth.default()[1]
   download_command = util.download_command(
       job_name, job_namespace, zone, cluster, project)

--- a/metrics_handler/main_test.py
+++ b/metrics_handler/main_test.py
@@ -51,7 +51,7 @@ class CloudMetricsHandlerTest(absltest.TestCase):
     metrics_handler = main.CloudMetricsHandler(
       test_name="test",
       events_dir=self.temp_dir,
-      stackdriver_logs_link=None,
+      debug_info=None,
       metric_collection_config={
         'default_aggregation_strategies': ['final', 'min',]
       },
@@ -72,7 +72,7 @@ class CloudMetricsHandlerTest(absltest.TestCase):
     metrics_handler = main.CloudMetricsHandler(
       test_name="test",
       events_dir=self.temp_dir,
-      stackdriver_logs_link=None,
+      debug_info=None,
       metric_collection_config={
         'default_aggregation_strategies': ['final'],
         'tags_to_ignore': ['bar'],

--- a/metrics_handler/metrics_test.py
+++ b/metrics_handler/metrics_test.py
@@ -100,22 +100,6 @@ class MetricsTest(parameterized.TestCase):
       }
     )
 
-  def test_total_wall_time(self):
-    raw_metrics = {
-      'foo': [
-        metrics.MetricPoint(metric_value=0, wall_time=0),
-        metrics.MetricPoint(metric_value=1, wall_time=1),
-      ],
-      'bar': [
-        metrics.MetricPoint(metric_value=0, wall_time=0),
-        metrics.MetricPoint(metric_value=2, wall_time=2),
-      ],
-    }
-
-    total_wall_time = metrics.total_wall_time(raw_metrics)
-    self.assertEqual(
-        total_wall_time, metrics.MetricPoint(metric_value=2, wall_time=2))
-
   def test_time_to_accuracy(self):
     raw_metrics = {
       'accuracy': [

--- a/metrics_handler/util_test.py
+++ b/metrics_handler/util_test.py
@@ -24,7 +24,6 @@ import util
 
 VALID_LOGS_LINK = 'https://console.cloud.google.com/logs?project=xl-ml-test&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.location=us-central1-b%0Aresource.labels.cluster_name=xl-ml-test%0Aresource.labels.namespace_name=automated%0Aresource.labels.pod_name:pt-1.5-resnet50-functional-v3-8-1584453600&extra_junk&dateRangeUnbound=backwardInTime'
 VALID_DOWNLOAD_COMMAND = """gcloud logging read 'resource.type=k8s_container resource.labels.project_id=xl-ml-test resource.labels.location=us-central1-b resource.labels.cluster_name=xl-ml-test resource.labels.namespace_name=automated resource.labels.pod_name:pt-1.5-resnet50-functional-v3-8-1584453600' --limit 10000000000000 --order asc --format 'value(textPayload)' --project=xl-ml-test > pt-1.5-resnet50-functional-v3-8-1584453600_logs.txt && sed -i '/^$/d' pt-1.5-resnet50-functional-v3-8-1584453600_logs.txt"""
-VALID_TEST_NAME = 'pt-1.5-resnet50-functional-v3-8-1584453600'
 VALID_WORKLOAD_LINK = 'https://console.cloud.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/pt-1.5-resnet50-functional-v3-8-1584453600?project=xl-ml-test&pt-1.5-resnet50-functional-v3-8-1584453600_events_tablesize=50&tab=events&duration=P30D&pod_summary_list_tablesize=20&service_list_datatablesize=20'
 
 
@@ -39,24 +38,26 @@ class UtilTest(parameterized.TestCase):
         'abc{}'.format(util.UNBOUND_DATE_RANGE),
         util.add_unbound_time_to_logs_link('abc'))
 
-  def test_download_command_from_logs_link_fail_to_parse(self):
-    with self.assertRaises(ValueError):
-      _ = util.download_command_from_logs_link('abc')
-
-  def test_download_command_from_logs_link_success(self):
+  def test_download_command(self):
+    project = 'xl-ml-test'
+    cluster = 'xl-ml-test'
+    namespace = 'automated'
+    pod_name = 'pt-1.5-resnet50-functional-v3-8-1584453600'
+    zone = 'us-central1-b'
     self.assertEqual(
-        VALID_DOWNLOAD_COMMAND,
-        util.download_command_from_logs_link(VALID_LOGS_LINK))
+        util.download_command(pod_name, namespace, zone, cluster, project),
+        VALID_DOWNLOAD_COMMAND)
 
-  def test_test_name_from_logs_link_fail_to_parse(self):
-    with self.assertRaises(ValueError):
-      _ = util.test_name_from_logs_link('abc')
-
-  def test_test_name_from_logs_link_success(self):
+  def test_workload_link(self):
+    project = 'xl-ml-test'
+    cluster = 'xl-ml-test'
+    namespace = 'automated'
+    pod_name = 'pt-1.5-resnet50-functional-v3-8-1584453600'
+    zone = 'us-central1-b'
     self.assertEqual(
-        VALID_TEST_NAME,
-        util.test_name_from_logs_link(VALID_LOGS_LINK))
-  
+        util.workload_link(pod_name, namespace, zone, cluster, project),
+        VALID_WORKLOAD_LINK)
+
   @parameterized.named_parameters(
     ('inf', [1, 2, 3, math.inf, 4, 5], [1, 2, 3, None, 4, 5]),
     ('-inf', [1, 2, 3, -math.inf, 4, 5], [1, 2, 3, None, 4, 5]),
@@ -68,11 +69,6 @@ class UtilTest(parameterized.TestCase):
   def test_replace_invalid_values(self, row, expected_row):
     clean_row = util.replace_invalid_values(row)
     self.assertSequenceEqual(clean_row, expected_row)
-
-  def test_workload_link_from_logs_link(self):
-    self.assertEqual(
-        VALID_WORKLOAD_LINK,
-        util.workload_link_from_logs_link(VALID_LOGS_LINK))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Create workload link and download command using direct information from the pubsub message rather than parsing the logs link.

Refactor all the code to pass around debug_info instead of just the logs link.

TESTED=unit testing and ran the metrics handler locally