### PR TITLE
Switch pytorch cifar tests to download dataset.

### DIFF
--- a/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v2-8.yaml
@@ -35,7 +35,6 @@
             - "--logdir=$(MODEL_DIR)"
             - "--metrics_debug"
             - "--target_accuracy=72"
-            - "--datadir=/datasets/cifar-data"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -73,9 +72,6 @@
             - "mountPath": "/dev/shm"
               "name": "dshm"
               "readOnly": false
-            - "mountPath": "/datasets"
-              "name": "cifar-pd"
-              "readOnly": true
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -165,10 +161,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-          - "gcePersistentDisk":
-              "fsType": "ext4"
-              "pdName": "cifar-pd-central1-b"
-              "readOnly": true
-            "name": "cifar-pd"
   "schedule": "0 14 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v3-8.yaml
@@ -35,7 +35,6 @@
             - "--logdir=$(MODEL_DIR)"
             - "--metrics_debug"
             - "--target_accuracy=72"
-            - "--datadir=/datasets/cifar-data"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -73,9 +72,6 @@
             - "mountPath": "/dev/shm"
               "name": "dshm"
               "readOnly": false
-            - "mountPath": "/datasets"
-              "name": "cifar-pd"
-              "readOnly": true
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -165,10 +161,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-          - "gcePersistentDisk":
-              "fsType": "ext4"
-              "pdName": "cifar-pd-central1-b"
-              "readOnly": true
-            "name": "cifar-pd"
   "schedule": "0 14 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v2-8.yaml
@@ -36,7 +36,6 @@
             - "--use_torchvision=True"
             - "--metrics_debug"
             - "--target_accuracy=72"
-            - "--datadir=/datasets/cifar-data"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -74,9 +73,6 @@
             - "mountPath": "/dev/shm"
               "name": "dshm"
               "readOnly": false
-            - "mountPath": "/datasets"
-              "name": "cifar-pd"
-              "readOnly": true
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -166,10 +162,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-          - "gcePersistentDisk":
-              "fsType": "ext4"
-              "pdName": "cifar-pd-central1-b"
-              "readOnly": true
-            "name": "cifar-pd"
   "schedule": "0 14 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v3-8.yaml
@@ -36,7 +36,6 @@
             - "--use_torchvision=True"
             - "--metrics_debug"
             - "--target_accuracy=72"
-            - "--datadir=/datasets/cifar-data"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -74,9 +73,6 @@
             - "mountPath": "/dev/shm"
               "name": "dshm"
               "readOnly": false
-            - "mountPath": "/datasets"
-              "name": "cifar-pd"
-              "readOnly": true
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -166,10 +162,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-          - "gcePersistentDisk":
-              "fsType": "ext4"
-              "pdName": "cifar-pd-central1-b"
-              "readOnly": true
-            "name": "cifar-pd"
   "schedule": "0 14 * * *"
   "successfulJobsHistoryLimit": 1

--- a/templates/pytorch/nightly/cifar-inline.libsonnet
+++ b/templates/pytorch/nightly/cifar-inline.libsonnet
@@ -25,33 +25,7 @@ local tpus = import "../../tpus.libsonnet";
       "--logdir=$(MODEL_DIR)",
       "--metrics_debug",
       "--target_accuracy=72",
-      "--datadir=/datasets/cifar-data",
     ],
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          volumes+: [
-            {
-              name: "cifar-pd",
-              gcePersistentDisk: {
-                pdName: "cifar-pd-central1-b",
-                fsType: "ext4",
-                readOnly: true,
-              },
-            },
-          ],
-          containers: [
-            container {
-              volumeMounts+: [{
-                mountPath: "/datasets",
-                name: "cifar-pd",
-                readOnly: true,
-              }],
-            } for container in super.containers
-          ],
-        },
-      },
-    },
   },
   local convergence = base.Convergence {
     # Run at 6AM PST daily instead of 2x per week since convergence is fast.

--- a/templates/pytorch/nightly/cifar-tv.libsonnet
+++ b/templates/pytorch/nightly/cifar-tv.libsonnet
@@ -26,33 +26,7 @@ local tpus = import "../../tpus.libsonnet";
       "--use_torchvision=True",
       "--metrics_debug",
       "--target_accuracy=72",
-      "--datadir=/datasets/cifar-data",
     ],
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          volumes+: [
-            {
-              name: "cifar-pd",
-              gcePersistentDisk: {
-                pdName: "cifar-pd-central1-b",
-                fsType: "ext4",
-                readOnly: true,
-              },
-            },
-          ],
-          containers: [
-            container {
-              volumeMounts+: [{
-                mountPath: "/datasets",
-                name: "cifar-pd",
-                readOnly: true,
-              }],
-            } for container in super.containers
-          ],
-        },
-      },
-    },
   },
   local convergence = base.Convergence {
     # Run at 6AM PST daily instead of 2x per week since convergence is fast.


### PR DESCRIPTION
This simplifies the config, makes the test consistent with mnist, simplifies our multi-cluster story,  and adds only ~30 sec to the test.

* [successful run 1](https://pantheon.corp.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/pt-nightly-cifar-inline-conv-v2-8-manual-lphr5?project=xl-ml-test&tab=details&duration=P30D&pod_summary_list_tablesize=20&service_list_datatablesize=20)
* [successful run 2](https://pantheon.corp.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/pt-nightly-cifar-tv-conv-v3-8-manual-jwvh2?project=xl-ml-test)
* [successful run 3](https://pantheon.corp.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/pt-nightly-cifar-inline-conv-v3-8-manual-8qpvk?project=xl-ml-test)
* [successful run 4](https://pantheon.corp.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/pt-nightly-cifar-tv-conv-v2-8-manual-vbkpw?project=xl-ml-test&tab=details&duration=P30D&pod_summary_list_tablesize=20&service_list_datatablesize=20)
