### PR TITLE
Clean up command to wait for healthy instance group.

### DIFF
--- a/images/pytorch-pods/setup-instances.sh
+++ b/images/pytorch-pods/setup-instances.sh
@@ -50,17 +50,13 @@ gcloud compute --project="${PROJECT}" \
   --zone="${ZONE}"
 
 echo "Waiting for ${INSTANCE_GROUP_NAME} to start..."
-while [[ ${size:-0} != ${INSTANCE_GROUP_SIZE} ]];
-  do sleep 10 && \
-  size=$(gcloud compute instance-groups \
-    list-instances \
-    ${INSTANCE_GROUP_NAME} \
-    --zone=${ZONE} \
-    --filter="STATUS=RUNNING" \
-    --format="value(NAME)" \
-    | wc -l) && \
-  echo "$size/${INSTANCE_GROUP_SIZE} instances started...";
-done
+gcloud compute --project="${PROJECT}" \
+  instance-groups \
+  managed \
+  wait-until \
+  --stable \
+  "${INSTANCE_GROUP_NAME}" \
+  --zone "${ZONE}"
 
 # GKE will wait until the TPU is READY, but not necessarily until it is HEALTHY
 echo "Waiting for TPU Pod ${TPU_POD_NAME} to become healthy..."


### PR DESCRIPTION
[oneshot logs](https://pantheon.corp.google.com/logs/viewer?interval=PT1H&project=xl-ml-test&minLogLevel=0&expandAll=false&timestamp=2020-04-30T19:42:38.626000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22xl-ml-test%22%0Aresource.labels.location%3D%22europe-west4-a%22%0Aresource.labels.cluster_name%3D%22europe-oneshots%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fcontroller-uid%3D%22fc93e7c6-b464-4289-b9cf-c5e0a958bae3%22&dateRangeStart=2020-04-30T18:42:38.625Z&dateRangeEnd=2020-04-30T19:42:38.625Z&scrollTimestamp=2020-04-30T19:42:10.056944853Z)