### PR TITLE
Fix command in README

### DIFF
--- a/metrics_handler/README.md
+++ b/metrics_handler/README.md
@@ -30,15 +30,9 @@ After the basic setup above, you'll be able to see errors in Stackdriver Error R
     * `alert-sender-email-address`: The 'from' email used by Sendgrid for alerts.
     * `sendgrid-api-key`: Sendgrid API key that you copied in step 2.
 1. Give permission to your metrics handler Cloud Function to read these 3 Secrets. Run these from command line:
-    * `gcloud beta secrets add-iam-policy-binding alert-destination-email-address \
-    --role roles/secretmanager.secretAccessor \
-    --member serviceAccount:YOUR-PROJECT-NAME@appspot.gserviceaccount.com`
-    * `gcloud beta secrets add-iam-policy-binding alert-sender-email-address \
-    --role roles/secretmanager.secretAccessor \
-    --member serviceAccount:YOUR-PROJECT-NAME@appspot.gserviceaccount.com`
-    * `gcloud beta secrets add-iam-policy-binding sendgrid-api-key \
-    --role roles/secretmanager.secretAccessor \
-    --member serviceAccount:YOUR-PROJECT-NAME@appspot.gserviceaccount.com`
+    * `gcloud beta secrets add-iam-policy-binding alert-destination-email-address --role roles/secretmanager.secretAccessor --member serviceAccount:YOUR-PROJECT-NAME@appspot.gserviceaccount.com`
+    * `gcloud beta secrets add-iam-policy-binding alert-sender-email-address --role roles/secretmanager.secretAccessor --member serviceAccount:YOUR-PROJECT-NAME@appspot.gserviceaccount.com`
+    * `gcloud beta secrets add-iam-policy-binding sendgrid-api-key --role roles/secretmanager.secretAccessor --member serviceAccount:YOUR-PROJECT-NAME@appspot.gserviceaccount.com`
 
 Once you've finished these steps, the metrics handler will send an alert email to the `alert-destination-email-address` whenever it finds errors in your tests.
 


### PR DESCRIPTION
Tried this command just now and the backslashes resulted in this error if you directly copy/paste the command:

```zcain@zcain:~/ml-testing-accelerators$ gcloud beta secrets add-iam-policy-binding sendgrid-api-key \ --role roles/secretmanager.secretAccessor \ --member serviceAccount:xl-ml-test@appspot.gserviceaccount.com
ERROR: (gcloud.beta.secrets.add-iam-policy-binding) unrecognized arguments:
   --role
  roles/secretmanager.secretAccessor
   --member
  serviceAccount:xl-ml-test@appspot.gserviceaccount.com
  To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS
```

Tried the 3 new commands and they work