### PR TITLE
Look up job memory usage in Google Cloud Monitoring and add to model …

### DIFF
--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -157,6 +157,9 @@ class CloudMetricsHandler(object):
       except ValueError as e:
         raise ValueError('Error computing time to accuracy: {}'.format(e))
 
+    metrics.compute_memory_metrics(final_metrics, self.project,
+                                   self.debug_info.job_name)
+
     return final_metrics
 
   def _make_bigquery_tables(self):

--- a/metrics_handler/manual_tests.py
+++ b/metrics_handler/manual_tests.py
@@ -1,0 +1,44 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+
+import metrics
+
+# A collection of tests that read from live GCP resources. Replace args as
+# necessary and then remove the leading underscore of the test name to run.
+class ManualTests(absltest.TestCase):
+  # To use this test, replace 'xl-ml-test' with your proejct name.
+  def _test_compute_memory_metrics_job_does_not_exist(self):
+    m = {}
+    metrics.compute_memory_metrics(
+        m, 'xl-ml-test', 'tf-nightly-mnist-func-tesla-v100-x1-doesnotexist')
+    self.assertFalse(m)
+
+
+  # To use this test, replace the args to compute_memory_metrics with your
+  # project ID and the name of a recent job. Change the assert if your job
+  # does not use GPUs.
+  def _test_compute_memory_metrics(self):
+    m = {}
+    metrics.compute_memory_metrics(
+        m, 'xl-ml-test', 'tf-nightly-mnist-func-tesla-v100-x1-1588665600')
+    self.assertTrue('vm_memory_usage_bytes' in m and \
+                    m['vm_memory_usage_bytes'] > 0)
+    self.assertTrue('gpu_memory_usage_bytes' in m and \
+                    m['gpu_memory_usage_bytes'] > 0)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/metrics_handler/metrics_test.py
+++ b/metrics_handler/metrics_test.py
@@ -165,6 +165,18 @@ class MetricsTest(parameterized.TestCase):
     within_bounds = metrics.within_bounds(value, *bounds, inclusive)
     self.assertIs(within_bounds, expected)
 
+  # To use this test, replace the args to compute_memory_metrics with your
+  # project ID and the name of a recent job. Change the assert if your job
+  # does not use GPUs.
+  def _test_compute_memory_metrics(self):
+    m = {}
+    metrics.compute_memory_metrics(
+        m, 'xl-ml-test', 'tf-nightly-mnist-func-tesla-v100-x1-1588665600')
+    self.assertTrue('vm_memory_usage_bytes' in m and \
+                    m['vm_memory_usage_bytes'] > 0)
+    self.assertTrue('gpu_memory_usage_bytes' in m and \
+                    m['gpu_memory_usage_bytes'] > 0)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/metrics_handler/metrics_test.py
+++ b/metrics_handler/metrics_test.py
@@ -165,18 +165,6 @@ class MetricsTest(parameterized.TestCase):
     within_bounds = metrics.within_bounds(value, *bounds, inclusive)
     self.assertIs(within_bounds, expected)
 
-  # To use this test, replace the args to compute_memory_metrics with your
-  # project ID and the name of a recent job. Change the assert if your job
-  # does not use GPUs.
-  def _test_compute_memory_metrics(self):
-    m = {}
-    metrics.compute_memory_metrics(
-        m, 'xl-ml-test', 'tf-nightly-mnist-func-tesla-v100-x1-1588665600')
-    self.assertTrue('vm_memory_usage_bytes' in m and \
-                    m['vm_memory_usage_bytes'] > 0)
-    self.assertTrue('gpu_memory_usage_bytes' in m and \
-                    m['gpu_memory_usage_bytes'] > 0)
-
 
 if __name__ == '__main__':
   absltest.main()

--- a/metrics_handler/requirements.txt
+++ b/metrics_handler/requirements.txt
@@ -3,6 +3,7 @@ google-api-python-client==1.7.11
 google-cloud-container==0.3.0
 google-cloud-bigquery==1.23.1
 google-cloud-error-reporting==0.33.0
+google-cloud-monitoring==0.34.0
 google-cloud-pubsub==1.2.0
 google-cloud-secret-manager==0.1.1
 google-cloud-storage==1.23.0


### PR DESCRIPTION
…metrics.

I think the VM memory usage (i.e. `memory/used_bytes`) is useful both for us and for other users.

`accelerator/memory_used` may or may not be useful. I want to collect it for a few days from our models and see what it looks like.