### PR TITLE
Fix pytorch GPU example

### DIFF
--- a/examples/examples-pt-imagenet-mini-gpu.yaml
+++ b/examples/examples-pt-imagenet-mini-gpu.yaml
@@ -34,14 +34,14 @@ spec:
           - name: dshm
             emptyDir:
               medium: Memory
-          - gcePersistentDisk:
-              fsType: ext4
-              pdName: imagenet-mini-pd-central1-b
-              readOnly: true
-            # TODO: This `name` should match the `name` below under volumeMounts.
-            name: imagenet-mini-pd
+          # TODO: This should match `name` under volumeMounts below.
+          - name: imagenet-mini-pd
+            gcePersistentDisk:
+              # TODO: Change this to the name of your Cloud persistent disk.
+              pdName: "imagenet-mini-pd-central1-b"
+              fsType: "ext4"
           containers:
-          - name: "train-container"
+          - name: train-container
             # TODO: Change this to your image if desired. See `images/README`
             # for more on setting up images.
             image: "gcr.io/xl-ml-test/pytorch-examples-gpu:nightly"
@@ -55,7 +55,7 @@ spec:
               mountPath: "/dev/shm"
             # TODO: This should match `name` of the gcePersistentDisk above.
             - name: imagenet-mini-pd
-              mountPath: /datasets
+              mountPath: "/datasets"
               readOnly: true
             args:
             # TODO: Change this to the command to run your test.
@@ -112,7 +112,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: metrics-config
-                  key: "pt-imagenet-mini-gpu.json"
+                  key: pt-imagenet-mini-gpu.json
             envFrom:
             - configMapRef:
                 name: gcs-buckets

--- a/examples/examples-pt-imagenet-mini-gpu.yaml
+++ b/examples/examples-pt-imagenet-mini-gpu.yaml
@@ -16,7 +16,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   # TODO: Change this to a unique name within your project.
-  name: pt-imagenet-mini-gpu
+  name: example-pt-imagenet-mini-gpu
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:
@@ -34,13 +34,12 @@ spec:
           - name: dshm
             emptyDir:
               medium: Memory
-          # TODO: This should match `name` under volumeMounts below.
-          - name: "imagenet-mini-pd"
-            gcePersistentDisk:
-              # TODO: Change this to the name of your Cloud persistent disk.
-              pdName: "imagenet-mini-pd-central1-b"
-              fsType: "ext4"
+          - gcePersistentDisk:
+              fsType: ext4
+              pdName: imagenet-mini-pd-central1-b
               readOnly: true
+            # TODO: This `name` should match the `name` below under volumeMounts.
+            name: imagenet-mini-pd
           containers:
           - name: "train-container"
             # TODO: Change this to your image if desired. See `images/README`
@@ -56,7 +55,7 @@ spec:
               mountPath: "/dev/shm"
             # TODO: This should match `name` of the gcePersistentDisk above.
             - name: imagenet-mini-pd
-              mountPath: "/datasets"
+              mountPath: /datasets
               readOnly: true
             args:
             # TODO: Change this to the command to run your test.
@@ -88,11 +87,37 @@ spec:
               # name away from `xl-ml-test-us-central1` since you won't have
               # write access to that bucket.
               value: "gs://xl-ml-test-us-central1/k8s/imagenet/functional/gpu/$(JOB_NAME)"
-            - name: METRIC_CONFIG
+          initContainers:
+          - env:
+            - name: "POD_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.name"
+            - name: "POD_UID"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.uid"
+            - name: "POD_NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.namespace"
+            - name: "JOB_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['job-name']"
+            - name: "MODEL_DIR"
+              # TODO: Change to match "MODEL_DIR" value from above.
+              value: "gs://xl-ml-test-us-central1/k8s/imagenet/functional/gpu/$(JOB_NAME)"
+            - name: "METRIC_CONFIG"
               valueFrom:
                 configMapKeyRef:
                   name: metrics-config
-                  key: pt-imagenet-mini-gpu.json
+                  key: "pt-imagenet-mini-gpu.json"
+            envFrom:
+            - configMapRef:
+                name: gcs-buckets
+            image: "gcr.io/xl-ml-test/publisher:stable"
+            name: publisher
   # TODO: Update the timing of your test runs:
   # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
   schedule: "0 */24 * * *"

--- a/examples/examples-pt-imagenet-mini-gpu.yaml
+++ b/examples/examples-pt-imagenet-mini-gpu.yaml
@@ -112,7 +112,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: metrics-config
-                  key: pt-imagenet-mini-gpu.json
+                  key: example-pt-imagenet-mini-gpu.json
             envFrom:
             - configMapRef:
                 name: gcs-buckets

--- a/examples/metrics/example-pt-imagenet-mini-gpu.json
+++ b/examples/metrics/example-pt-imagenet-mini-gpu.json
@@ -1,5 +1,5 @@
 {
-  "test_name": "pt-imagenet-mini-gpu",
+  "test_name": "example-pt-imagenet-mini-gpu",
   "metric_collection_config": {
     "write_to_bigquery": "True",
     "default_aggregation_strategies": ["final"]

--- a/examples/pt-imagenet-mini-gpu.yaml
+++ b/examples/pt-imagenet-mini-gpu.yaml
@@ -65,10 +65,6 @@ spec:
             - "--a=resnet18"
             - "/datasets/imagenet-mini"
             - "--epochs=3"
-            - "--multiprocessing-distributed"
-            - "--dist-url=tcp://localhost:23456"
-            - "--rank=0"
-            - "--world-size=1"
             env:
             - name: "POD_NAME"
               valueFrom:

--- a/images/pytorch-examples-gpu/Dockerfile
+++ b/images/pytorch-examples-gpu/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tensorflow/tensorflow:nightly-gpu-py3
+FROM gcr.io/deeplearning-platform-release/pytorch-gpu.1-4
 
 RUN apt-get update && apt-get install -y --no-install-recommends git
 RUN curl -sSL https://sdk.cloud.google.com | bash


### PR DESCRIPTION
1. Change the image Dockerfile to pull from a newer base image to fix out-of-date NVIDIA driver error
2. Remove multiprocessing args since these cause the script to exit successfully even when there are fatal errors
3. Switch the test to use publisher initContainer so that runs get published to pubsub

[Example workflow](https://pantheon.corp.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/example-pt-imagenet-mini-gpu-manual-fhjhh?organizationId=433637338589&project=xl-ml-test&tab=details&duration=P30D&pod_summary_list_tablesize=20&service_list_datatablesize=20)