### PR TITLE
Fix file name in kustomization.

### DIFF
--- a/examples/metrics/kustomization.yaml
+++ b/examples/metrics/kustomization.yaml
@@ -20,5 +20,5 @@ configMapGenerator:
 - name: metrics-config
   files:
   - pt-cifar-tpu-v3-8.json
-  - pt-imagenet-mini-gpu.json
+  - example-pt-imagenet-mini-gpu.json
   - tf-mnist-tpu-v2-8.json


### PR DESCRIPTION
I've pushed the new kustomization with:
`kubectl apply -k ... --namespace=automated`

Ran the broken workload and it succeeded [here](https://pantheon.corp.google.com/kubernetes/job/us-central1-b/xl-ml-test/automated/example-pt-imagenet-mini-gpu-manual-h7xmg?organizationId=433637338589&project=xl-ml-test&tab=details&duration=P30D&pod_summary_list_tablesize=20&service_list_datatablesize=20)