### PR TITLE
Fix unbound logs link

### DIFF
--- a/examples/metrics/kustomization.yaml
+++ b/examples/metrics/kustomization.yaml
@@ -20,5 +20,5 @@ configMapGenerator:
 - name: metrics-config
   files:
   - pt-cifar-tpu-v3-8.json
-  - pt-imagenet-mini-gpu.json
+  - example-pt-imagenet-mini-gpu.json
   - tf-mnist-tpu-v2-8.json

--- a/examples/metrics/kustomization.yaml
+++ b/examples/metrics/kustomization.yaml
@@ -20,5 +20,5 @@ configMapGenerator:
 - name: metrics-config
   files:
   - pt-cifar-tpu-v3-8.json
-  - example-pt-imagenet-mini-gpu.json
+  - pt-imagenet-mini-gpu.json
   - tf-mnist-tpu-v2-8.json

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -433,7 +433,7 @@ def _process_pubsub_message(msg, status_handler, logger):
     return False  # Do not ack the message.
   events_dir = msg.get('model_dir')
   test_name = msg.get('test_name')
-  logs_link = msg.get('logs_link')
+  logs_link = util.add_unbound_time_to_logs_link(msg.get('logs_link', ''))
   metric_collection_config = msg.get('metric_collection_config')
   regression_test_config = msg.get('regression_test_config')
   job_name = msg.get('job_name')
@@ -456,7 +456,6 @@ def _process_pubsub_message(msg, status_handler, logger):
     raise ValueError('Pubsub message must contain 7 required fields: '
                      'events_dir, test_name, logs_link, job_name, '
                      'zone, cluster, project. Message was: {}'.format(event))
-  logs_link = util.add_unbound_time_to_logs_link(logs_link)
   if not regression_test_config and not metric_collection_config:
     raise ValueError('metric_collection_config and regression_test_config '
                      'were both null; stopping early. See README for '

--- a/metrics_handler/util.py
+++ b/metrics_handler/util.py
@@ -34,7 +34,7 @@ def add_unbound_time_to_logs_link(logs_link):
     logs_link (string): Input with dateRangeUnbound added to it or the
       input unchanged if it already contained dateRangeUnbound.
   """
-  return logs_link if UNBOUND_DATE_RANGE in logs_link else \
+  return logs_link if (not logs_link or UNBOUND_DATE_RANGE in logs_link) else \
       logs_link + UNBOUND_DATE_RANGE
 
 

--- a/metrics_handler/util_test.py
+++ b/metrics_handler/util_test.py
@@ -28,6 +28,11 @@ VALID_WORKLOAD_LINK = 'https://console.cloud.google.com/kubernetes/job/us-centra
 
 
 class UtilTest(parameterized.TestCase):
+  def test_add_unbound_time_to_logs_link_empty_string(self):
+    self.assertEqual(
+        '',
+        util.add_unbound_time_to_logs_link(''))
+
   def test_add_unbound_time_to_logs_link_already_exists(self):
     self.assertEqual(
         VALID_LOGS_LINK,


### PR DESCRIPTION
This will make the stackdriver logs links snap straight to latest logs rather than defaulting to past hour (which is usually blank)