### PR TITLE
Add tf-r2.2 tab and example test tab to dashboard.

### DIFF
--- a/dashboard/app.yaml
+++ b/dashboard/app.yaml
@@ -33,7 +33,7 @@ resources:
 env_variables:
   REDISHOST: '10.25.27.107'
   REDISPORT: '6379'
-  TEST_NAME_PREFIXES: 'pt-nightly,pt-1.5,tf-nightly'
+  TEST_NAME_PREFIXES: 'example,pt-nightly,pt-1.5,tf-nightly,tf-r2.2'
   JOB_HISTORY_TABLE_NAME: 'xl-ml-test.metrics_handler_dataset.job_history'
   METRIC_HISTORY_TABLE_NAME: 'xl-ml-test.metrics_handler_dataset.metric_history'
 

--- a/dashboard/main_heatmap.py
+++ b/dashboard/main_heatmap.py
@@ -170,7 +170,7 @@ def make_plot(dataframe):
   tooltip_template = """@overall_status on @run_date"""
   plot = figure(
       plot_width=(2*longest_test_name)+(45*len(all_dates)),
-      plot_height=30*len(all_test_names),
+      plot_height=100 + 30*len(all_test_names),
       x_range = all_dates[-1::-1],  # Reverse for latest dates first.
       x_axis_location='above',
       y_range = all_test_names[-1::-1],  # Reverse for alphabetical.


### PR DESCRIPTION
Add an adjustment to the dashboard code for tabs that have very few tests (e.g. the examples tab) so that they can render in a reasonable way.