### PR TITLE
Use separate var for pytorch/xla tag vs xl-ml-test tag.

### DIFF
--- a/images/pytorch/Dockerfile
+++ b/images/pytorch/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG _VERSION=nightly
-FROM gcr.io/tpu-pytorch/xla:$_VERSION
+ARG _PT_XLA_VERSION="nightly_3.6"
+FROM gcr.io/tpu-pytorch/xla:$_PT_XLA_VERSION
 
 RUN curl -sSL https://sdk.cloud.google.com | bash
 

--- a/images/pytorch/cloudbuild.yaml
+++ b/images/pytorch/cloudbuild.yaml
@@ -14,11 +14,12 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/pytorch-xla:$_VERSION', '.', '-f', 'images/pytorch/Dockerfile', '--build-arg', '_VERSION=$_VERSION']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/pytorch-xla:$_VERSION', '.', '-f', 'images/pytorch/Dockerfile', '--build-arg', '_PT_XLA_VERSION=$_PT_XLA_VERSION']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/pytorch-xla:$_VERSION']
 images: ['gcr.io/$PROJECT_ID/pytorch-xla:$_VERSION']
 substitutions:
   _VERSION: 'latest'
+  _PT_XLA_VERSION: 'nightly_3.6'
 options:
     substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
We're now (maybe temporarily) using `nightly_3.6` on the `pytorch/xla` side: https://github.com/pytorch/xla/pull/2068

De-couple the tag we use for `xl-ml-test` pytorch image from the tag we use for pulling the `pytorch/xla` image

TESTED=Ran `gcloud builds submit --config images/pytorch/cloudbuild.yaml`
Results: https://console.cloud.google.com/cloud-build/builds/6298f231-33c9-4ec4-b837-1b9b73dcef75?project=1030754782689 