### PR TITLE
Edit r1.15 transformer command so pods initialize correctly.

### DIFF
--- a/k8s/europe-west4/gen/tf-r1.15-transformer-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15-transformer-conv-v2-32.yaml
@@ -49,7 +49,7 @@
             - "--use_tpu=True"
             - "--schedule=train"
             - "--data_dir=$(T2T_TRANSFORMER_DIR)"
-            - "--cloud_tpu_name=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--output_dir=$(MODEL_DIR)"
             - "--iterations_per_loop=5000"
             - "--tpu_num_shards=32"

--- a/k8s/europe-west4/gen/tf-r1.15-transformer-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15-transformer-conv-v3-32.yaml
@@ -49,7 +49,7 @@
             - "--use_tpu=True"
             - "--schedule=train"
             - "--data_dir=$(T2T_TRANSFORMER_DIR)"
-            - "--cloud_tpu_name=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--output_dir=$(MODEL_DIR)"
             - "--iterations_per_loop=5000"
             - "--tpu_num_shards=32"

--- a/k8s/europe-west4/gen/tf-r1.15-transformer-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15-transformer-func-v2-32.yaml
@@ -49,7 +49,7 @@
             - "--use_tpu=True"
             - "--schedule=train"
             - "--data_dir=$(T2T_TRANSFORMER_DIR)"
-            - "--cloud_tpu_name=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--output_dir=$(MODEL_DIR)"
             - "--iterations_per_loop=5000"
             - "--tpu_num_shards=32"

--- a/k8s/europe-west4/gen/tf-r1.15-transformer-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15-transformer-func-v3-32.yaml
@@ -49,7 +49,7 @@
             - "--use_tpu=True"
             - "--schedule=train"
             - "--data_dir=$(T2T_TRANSFORMER_DIR)"
-            - "--cloud_tpu_name=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--output_dir=$(MODEL_DIR)"
             - "--iterations_per_loop=5000"
             - "--tpu_num_shards=32"

--- a/k8s/us-central1/gen/tf-r1.15-transformer-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15-transformer-conv-v2-8.yaml
@@ -49,7 +49,7 @@
             - "--use_tpu=True"
             - "--schedule=train"
             - "--data_dir=$(T2T_TRANSFORMER_DIR)"
-            - "--cloud_tpu_name=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--output_dir=$(MODEL_DIR)"
             - "--iterations_per_loop=100"
             - "--tpu_num_shards=8"

--- a/k8s/us-central1/gen/tf-r1.15-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15-transformer-conv-v3-8.yaml
@@ -49,7 +49,7 @@
             - "--use_tpu=True"
             - "--schedule=train"
             - "--data_dir=$(T2T_TRANSFORMER_DIR)"
-            - "--cloud_tpu_name=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--output_dir=$(MODEL_DIR)"
             - "--iterations_per_loop=100"
             - "--tpu_num_shards=8"

--- a/k8s/us-central1/gen/tf-r1.15-transformer-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15-transformer-func-v2-8.yaml
@@ -49,7 +49,7 @@
             - "--use_tpu=True"
             - "--schedule=train"
             - "--data_dir=$(T2T_TRANSFORMER_DIR)"
-            - "--cloud_tpu_name=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--output_dir=$(MODEL_DIR)"
             - "--iterations_per_loop=100"
             - "--tpu_num_shards=8"

--- a/k8s/us-central1/gen/tf-r1.15-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15-transformer-func-v3-8.yaml
@@ -49,7 +49,7 @@
             - "--use_tpu=True"
             - "--schedule=train"
             - "--data_dir=$(T2T_TRANSFORMER_DIR)"
-            - "--cloud_tpu_name=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--output_dir=$(MODEL_DIR)"
             - "--iterations_per_loop=100"
             - "--tpu_num_shards=8"

--- a/tests/tensorflow/r1.15/transformer.libsonnet
+++ b/tests/tensorflow/r1.15/transformer.libsonnet
@@ -26,7 +26,7 @@ local tpus = import "templates/tpus.libsonnet";
       "--use_tpu=True",
       "--schedule=train",
       "--data_dir=$(T2T_TRANSFORMER_DIR)",
-      "--cloud_tpu_name=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)",
+      "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)",
       "--output_dir=$(MODEL_DIR)",
     ],
   },


### PR DESCRIPTION
`--cloud_tpu_name` was leading to an [error](b/158014511):

```
INFO:tensorflow:Querying Tensorflow master (grpc://10.120.19.18:8470,grpc://10.120.19.20:8470,grpc://10.120.19.21:8470,grpc://10.120.19.19:8470) for TPU system metadata.
Error recorded from training_loop: Could not interpret "10.120.19.18:8470,grpc://10.120.19.20:8470,grpc://10.120.19.21:8470,grpc://10.120.19.19:8470" as a host-port pair.
```
Replaced w/ `--tpu`

I've been trying for 2 days now to get a pod run to verify the fix, but unfortunately I can't seem to get available tpu pods for it. In the meantime, getting this out there to collect comments.

failed oneshots because no capacity:
[oneshot for v2-32 func](https://pantheon.corp.google.com/kubernetes/job/us-central1-b/oneshots/default/tf-r1.15-transformer-func-v2-32-4p7sb/details?project=xl-ml-test)
[oneshot for v3-32 func](https://pantheon.corp.google.com/kubernetes/job/us-central1-b/oneshots/default/tf-r1.15-transformer-func-v3-32-qv5zk/details?project=xl-ml-test)
success: 
[oneshot for v2-8 func](https://pantheon.corp.google.com/kubernetes/job/us-central1-b/oneshots/default/tf-r1.15-transformer-func-v2-8-tbm9g/details?project=xl-ml-test)