### PR TITLE
Fix metric collection for TF tests.

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v2-32.yaml
@@ -112,10 +112,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v3-32.yaml
@@ -112,10 +112,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
@@ -112,10 +112,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
@@ -112,10 +112,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
@@ -118,7 +130,7 @@
                     },
                     "wait_for_n_points_of_history": 10
                    },
-                   "val_epoch_accuracy_final": {
+                   "validation/epoch_accuracy_final": {
                     "comparison": "greater",
                     "success_threshold": {
                      "fixed_value": 0.76000000000000001

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
@@ -118,7 +130,7 @@
                     },
                     "wait_for_n_points_of_history": 10
                    },
-                   "val_epoch_accuracy_final": {
+                   "validation/epoch_accuracy_final": {
                     "comparison": "greater",
                     "success_threshold": {
                      "fixed_value": 0.76000000000000001

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v2-32.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
@@ -118,7 +130,7 @@
                     },
                     "wait_for_n_points_of_history": 10
                    },
-                   "val_epoch_accuracy_final": {
+                   "validation/epoch_accuracy_final": {
                     "comparison": "greater",
                     "success_threshold": {
                      "fixed_value": 0.76000000000000001

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v3-32.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
@@ -118,7 +130,7 @@
                     },
                     "wait_for_n_points_of_history": 10
                    },
-                   "val_epoch_accuracy_final": {
+                   "validation/epoch_accuracy_final": {
                     "comparison": "greater",
                     "success_threshold": {
                      "fixed_value": 0.76000000000000001

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v2-32.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v3-32.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
@@ -119,10 +119,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
@@ -119,10 +119,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
@@ -119,10 +119,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
@@ -119,10 +119,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v2-32.yaml
@@ -117,10 +117,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v3-32.yaml
@@ -117,10 +117,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
@@ -117,10 +117,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
@@ -117,10 +117,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v2-8.yaml
@@ -112,10 +112,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v3-8.yaml
@@ -112,10 +112,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
@@ -112,10 +112,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
@@ -112,10 +112,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
@@ -118,7 +130,7 @@
                     },
                     "wait_for_n_points_of_history": 10
                    },
-                   "val_epoch_accuracy_final": {
+                   "validation/epoch_accuracy_final": {
                     "comparison": "greater",
                     "success_threshold": {
                      "fixed_value": 0.76000000000000001

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
@@ -118,7 +130,7 @@
                     },
                     "wait_for_n_points_of_history": 10
                    },
-                   "val_epoch_accuracy_final": {
+                   "validation/epoch_accuracy_final": {
                     "comparison": "greater",
                     "success_threshold": {
                      "fixed_value": 0.76000000000000001

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v2-8.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
@@ -118,7 +130,7 @@
                     },
                     "wait_for_n_points_of_history": 10
                    },
-                   "val_epoch_accuracy_final": {
+                   "validation/epoch_accuracy_final": {
                     "comparison": "greater",
                     "success_threshold": {
                      "fixed_value": 0.76000000000000001

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v3-8.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
@@ -118,7 +130,7 @@
                     },
                     "wait_for_n_points_of_history": 10
                    },
-                   "val_epoch_accuracy_final": {
+                   "validation/epoch_accuracy_final": {
                     "comparison": "greater",
                     "success_threshold": {
                      "fixed_value": 0.76000000000000001

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
@@ -107,10 +107,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-connection-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-connection-v2-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-connection-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-connection-v3-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-training-loop-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-training-loop-v2-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-training-loop-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-training-loop-v3-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v2-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v3-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v2-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
@@ -110,6 +110,12 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {

--- a/k8s/us-central1/gen/tf-nightly-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-conv-v2-8.yaml
@@ -105,10 +105,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-conv-v3-8.yaml
@@ -105,10 +105,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-tesla-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-tesla-v100-x1.yaml
@@ -91,10 +91,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
@@ -105,10 +105,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
@@ -105,10 +105,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v2-8.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v3-8.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
@@ -114,10 +114,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
@@ -119,10 +119,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
@@ -119,10 +119,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
@@ -119,10 +119,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
@@ -119,10 +119,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v2-8.yaml
@@ -117,10 +117,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v3-8.yaml
@@ -117,10 +117,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
@@ -117,10 +117,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
@@ -117,10 +117,22 @@
                   "default_aggregation_strategies": [
                    "final"
                   ],
+                  "metric_to_aggregation_strategies": {
+                   "examples/sec": [
+                    "average"
+                   ]
+                  },
+                  "use_run_name_prefix": true,
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
+                   "examples/sec_average": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "stddevs_from_mean": 2
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {

--- a/metrics_handler/README.md
+++ b/metrics_handler/README.md
@@ -60,6 +60,7 @@ Full config options:
   # "final": Save the final value for that metric.
   # "max": Save the max value for that metric.
   # "min": Save the min value for that metric.
+  # "average": Save the average value for that metric.
   "default_aggregation_strategies": ["final"],
 
   # (Optional) Apply special aggregation strategies to some metrics. Key

--- a/metrics_handler/README.md
+++ b/metrics_handler/README.md
@@ -85,7 +85,12 @@ Full config options:
   },
 
   # (Optional) Defaults to True. Set to false to disable all BigQuery writes.
-  "write_to_bigquery": "True"
+  "write_to_bigquery": "True",
+
+  # (Optional) Defaults to false. Set to true to prefix tag names with
+  # the run name, or the subdirectory containing TensorBoard summaries (e.g.
+  # `train/` or `eval/`).
+  "use_run_name_prefix: false
 }
 ```
 

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -116,8 +116,10 @@ class CloudMetricsHandler(object):
     """
     tags_to_ignore = set(
         self.metric_collection_config.get('tags_to_ignore', []))
+    use_run_name_prefix = self.metric_collection_config.get(
+      'use_run_name_prefix', False)
     raw_metrics = metrics.read_metrics_from_events_dir(
-        self.events_dir, tags_to_ignore)
+        self.events_dir, tags_to_ignore, use_run_name_prefix)
 
     if not raw_metrics:
       self.logger.warning("No metrics found in {}".format(self.events_dir))

--- a/metrics_handler/metrics_test.py
+++ b/metrics_handler/metrics_test.py
@@ -18,6 +18,7 @@ from absl import logging
 from absl.testing import absltest
 from absl.testing import parameterized
 import tensorflow as tf
+import numpy as np
 
 import metrics
 
@@ -56,7 +57,7 @@ class MetricsTest(parameterized.TestCase):
   def test_aggregate_metrics_default_all(self):
     raw_metrics = metrics.read_metrics_from_events_dir(self.temp_dir)
     final_metrics = metrics.aggregate_metrics(
-      raw_metrics, default_strategies=['final', 'min', 'max'])
+      raw_metrics, default_strategies=['final', 'min', 'max', 'average'])
 
     # Remove wall time, since it's non-deterministic
     metric_to_value = {
@@ -70,9 +71,11 @@ class MetricsTest(parameterized.TestCase):
         'foo_final': 2,
         'foo_min': 1,
         'foo_max': 2,
+        'foo_average': 1.5,
         'accuracy_final': .25,
         'accuracy_min': .125,
         'accuracy_max': .5,
+        'accuracy_average': np.mean([.125, .25, .5]),
       }
     )
 

--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -68,7 +68,7 @@ local tpus = import "templates/tpus.libsonnet";
     },
     regressionTestConfig+: {
       metric_success_conditions+: {
-        val_epoch_accuracy_final: {
+        "validation/epoch_accuracy_final": {
           success_threshold: {
             fixed_value: 0.76,
           },

--- a/tests/tensorflow/nightly/classifier-resnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnet.libsonnet
@@ -68,7 +68,7 @@ local tpus = import "templates/tpus.libsonnet";
     },
     regressionTestConfig+: {
       metric_success_conditions+: {
-        val_epoch_accuracy_final: {
+        "validation/epoch_accuracy_final": {
           success_threshold: {
             fixed_value: 0.76,
           },

--- a/tests/tensorflow/nightly/common.libsonnet
+++ b/tests/tensorflow/nightly/common.libsonnet
@@ -21,5 +21,22 @@ local common = import "../common.libsonnet";
       softwareVersion: "nightly",
     },
     imageTag: "nightly",
+
+    metricCollectionConfig+: {
+      metric_to_aggregation_strategies+: {
+        "examples/sec": ["average"],
+      },
+      use_run_name_prefix: true,
+    },
+    regressionTestConfig+: {
+      metric_success_conditions+: {
+        "examples/sec_average": {
+          comparison: "greater",
+          success_threshold: {
+            stddevs_from_mean: 2.0,
+          },
+        },
+      },
+    },
   },
 }


### PR DESCRIPTION
- Distinguish metrics in different runs.
- Update regression config for classifier-* tests.
- Add support for averaging metrics.
- Assert on the average metric value for examples/sec in TF nightly tests.

Tested manually in test project.