### PR TITLE
Initialize 1 job_status_handler per zone/cluster. Retry for empty job…

### DIFF
--- a/metrics_handler/job_status_handler.py
+++ b/metrics_handler/job_status_handler.py
@@ -101,7 +101,7 @@ class JobStatusHandler(object):
     if not self.k8s_client:
       self._init_k8s_client()
     try:
-      status = self.k8s_client.read_namespaced_job_status(
+      status = self.k8s_client.read_namespaced_job(
           job_name, namespace).status
     except Exception as e:
       if isinstance(e, kubernetes.client.rest.ApiException) and \
@@ -155,11 +155,11 @@ class JobStatusHandler(object):
           stop_time = time.time()
     else:
       if not status.conditions or len(status.conditions) != 1:
-        self.logger.error(
+        self.logger.warning(
             'Expected exactly 1 `condition` element in non-success status. '
-            'Status was: {}'.format(status))
-        completion_code = FAILURE
-        stop_time = status.start_time.timestamp()
+            'Will retry later. Status was: {}.'.format(status))
+        completion_code = DOES_NOT_EXIST
+        stop_time = time.time()
       else:
         completion_code = TIMEOUT if \
             status.conditions[0].reason == 'DeadlineExceeded' else FAILURE

--- a/metrics_handler/job_status_handler_test.py
+++ b/metrics_handler/job_status_handler_test.py
@@ -65,6 +65,8 @@ class JobStatusHandlerTest(parameterized.TestCase):
         'condition_transition_time': datetime.datetime(2020, 3, 30, 17, 46, 15),
         'condition_reason': 'BackoffLimitExceeded',
         'expected_status': job_status_handler.FAILURE}),
+    ('empty_status', {
+        'expected_status': job_status_handler.DOES_NOT_EXIST}),
   )
   def test_interpret_status(self, args_dict):
     status = FakeKubernetesStatus(
@@ -77,9 +79,10 @@ class JobStatusHandlerTest(parameterized.TestCase):
     status_code, stop_time, num_failures = self.handler.interpret_status(
         status, "my_job_name")
     self.assertEqual(status_code, args_dict['expected_status'])
-    expected_datetime = args_dict.get('completion_time') or args_dict[
-        'condition_transition_time']
-    self.assertEqual(stop_time, expected_datetime.timestamp())
+    expected_datetime = args_dict.get('completion_time') or args_dict.get(
+        'condition_transition_time')
+    if expected_datetime is not None:
+      self.assertEqual(stop_time, expected_datetime.timestamp())
     self.assertEqual(num_failures, args_dict.get('num_failures', 0))
 
   def test_interpret_status_success_without_completion_or_transition(self):


### PR DESCRIPTION
… status.

TESTED=Unit and ran the metrics handler locally. It handled 1 message and did not crash.