### PR TITLE
Request ephemeral-storage for PT roberta test.

### DIFF
--- a/k8s/us-central1/gen/pt-nightly-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-roberta-pre-conv-v3-8.yaml
@@ -112,6 +112,7 @@
                 "cloud-tpus.google.com/v3": 8
               "requests":
                 "cpu": "9.0"
+                "ephemeral-storage": "10Gi"
                 "memory": "30Gi"
             "volumeMounts":
             - "mountPath": "/dev/shm"

--- a/k8s/us-central1/gen/pt-nightly-roberta-pre-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-roberta-pre-func-v3-8.yaml
@@ -112,6 +112,7 @@
                 "cloud-tpus.google.com/v3": 8
               "requests":
                 "cpu": "9.0"
+                "ephemeral-storage": "10Gi"
                 "memory": "30Gi"
             "volumeMounts":
             - "mountPath": "/dev/shm"

--- a/tests/pytorch/nightly/roberta-pre.libsonnet
+++ b/tests/pytorch/nightly/roberta-pre.libsonnet
@@ -69,6 +69,7 @@ local utils = import "templates/utils.libsonnet";
                 requests: {
                   cpu: "9.0",
                   memory: "30Gi",
+		  "ephemeral-storage": "10Gi",
                 },
               },
             },


### PR DESCRIPTION
`The node was low on resource: ephemeral-storage. Container monitor was using 776Ki, which exceeds its request of 0. Container train was using 7499Mi, which exceeds its request of 0.`

Not sure if the usage would have continued to go up past 7.5GB so I'm using 10GB for now