### PR TITLE
Double the timeout for EfficientNet donut convergence tests

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
@@ -51,7 +51,7 @@
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
-            - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 5\n\"train\":\n  \"epochs\": 500\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 10\n\"train\":\n  \"epochs\": 350\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
@@ -51,7 +51,7 @@
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
-            - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 5\n\"train\":\n  \"epochs\": 500\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 10\n\"train\":\n  \"epochs\": 350\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
@@ -21,7 +21,7 @@
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 223200
+      "activeDeadlineSeconds": 108000
       "backoffLimit": 1
       "template":
         "metadata":
@@ -51,7 +51,7 @@
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
-            - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 5\n\"train\":\n  \"epochs\": 500\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 10\n\"train\":\n  \"epochs\": 350\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
@@ -21,7 +21,7 @@
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 111600
+      "activeDeadlineSeconds": 223200
       "backoffLimit": 1
       "template":
         "metadata":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
@@ -21,7 +21,7 @@
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 108000
+      "activeDeadlineSeconds": 126000
       "backoffLimit": 1
       "template":
         "metadata":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
@@ -21,7 +21,7 @@
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 223200
+      "activeDeadlineSeconds": 108000
       "backoffLimit": 1
       "template":
         "metadata":
@@ -51,7 +51,7 @@
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
-            - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 5\n\"train\":\n  \"epochs\": 500\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 10\n\"train\":\n  \"epochs\": 350\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
@@ -21,7 +21,7 @@
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 111600
+      "activeDeadlineSeconds": 223200
       "backoffLimit": 1
       "template":
         "metadata":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
@@ -21,7 +21,7 @@
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 108000
+      "activeDeadlineSeconds": 126000
       "backoffLimit": 1
       "template":
         "metadata":

--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -60,10 +60,10 @@ local tpus = import "templates/tpus.libsonnet";
   local convergence = mixins.Convergence {
     paramsOverride+: {
       train+: {
-        epochs: 500, 
+        epochs: 350, 
       },
       evaluation+: {
-        epochs_between_evals: 5,
+        epochs_between_evals: 10,
       },
     },
     regressionTestConfig+: {
@@ -93,8 +93,8 @@ local tpus = import "templates/tpus.libsonnet";
   configs: [
     efficientnet + v2_8 + functional,
     efficientnet + v3_8 + functional,
-    efficientnet + v2_8 + convergence + timeouts.Hours(62),
-    efficientnet + v3_8 + convergence + timeouts.Hours(62),
+    efficientnet + v2_8 + convergence + timeouts.Hours(30),
+    efficientnet + v3_8 + convergence + timeouts.Hours(30),
     efficientnet + v2_32 + functional,
     efficientnet + v3_32 + functional,
     efficientnet + v2_32 + convergence + timeouts.Hours(30),

--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -93,8 +93,8 @@ local tpus = import "templates/tpus.libsonnet";
   configs: [
     efficientnet + v2_8 + functional,
     efficientnet + v3_8 + functional,
-    efficientnet + v2_8 + convergence + timeouts.Hours(30),
-    efficientnet + v3_8 + convergence + timeouts.Hours(30),
+    efficientnet + v2_8 + convergence + timeouts.Hours(35),
+    efficientnet + v3_8 + convergence + timeouts.Hours(35),
     efficientnet + v2_32 + functional,
     efficientnet + v3_32 + functional,
     efficientnet + v2_32 + convergence + timeouts.Hours(30),

--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -93,8 +93,8 @@ local tpus = import "templates/tpus.libsonnet";
   configs: [
     efficientnet + v2_8 + functional,
     efficientnet + v3_8 + functional,
-    efficientnet + v2_8 + convergence + timeouts.Hours(31),
-    efficientnet + v3_8 + convergence + timeouts.Hours(31),
+    efficientnet + v2_8 + convergence + timeouts.Hours(62),
+    efficientnet + v3_8 + convergence + timeouts.Hours(62),
     efficientnet + v2_32 + functional,
     efficientnet + v3_32 + functional,
     efficientnet + v2_32 + convergence + timeouts.Hours(30),


### PR DESCRIPTION
It seems to time out at around 300 epochs in 30 hours. Doubling the timeout should allow it to finish.