### PR TITLE
Update README to link to tests instead of templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ This is not an officially supported Google product.
 1. Deploy the [metrics handler](metrics_handler/README.md) to [Google Cloud Functions](https://cloud.google.com/functions).
 1. Set up your tests. Here you have 1 of 2 choices:
     * See [`examples`](examples/README.md) directory if you will have a relatively small number of tests and don't need inheritance in your tests.
-    * See [`templates`](templates/README.md) directory for a more powerful templating engine to generate test config files programmatically.
+    * See [`tests`](tests/README.md) directory for a more powerful templating engine to generate test config files programmatically.
 
 Are you interested in using ML Testing Accelerators? E-mail [ml-testing-accelerators-users@googlegroups.com](mailto:ml-testing-accelerators-users@googlegroups.com) and tell us about your use-case. We're happy to help you get started.


### PR DESCRIPTION
Not sure if we want to still link to templates but the README does not exist there anymore.