### PR TITLE
Add remaining 1- and 4-v100 tests for TF nightly models.

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
@@ -44,14 +44,14 @@
           - "args":
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--model_type=efficientnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
             - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 5\n\"train\":\n  \"epochs\": 500\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
@@ -44,14 +44,14 @@
           - "args":
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--model_type=efficientnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
             - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 5\n\"train\":\n  \"epochs\": 500\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
@@ -44,14 +44,14 @@
           - "args":
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--model_type=efficientnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
             - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 3\n\"train\":\n  \"epochs\": 3\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
@@ -44,14 +44,14 @@
           - "args":
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--model_type=efficientnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
             - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 3\n\"train\":\n  \"epochs\": 3\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v2-32.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - "--model=mask_rcnn"
             - |
               --params_override="architecture":
@@ -64,10 +62,12 @@
                   "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
                   "prefix": "resnet50/"
                 "iterations_per_loop": 5000
-                "total_steps": 22500
+                "total_steps": 5625
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--strategy_type=tpu"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v3-32.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - "--model=mask_rcnn"
             - |
               --params_override="architecture":
@@ -64,10 +62,12 @@
                   "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
                   "prefix": "resnet50/"
                 "iterations_per_loop": 5000
-                "total_steps": 22500
+                "total_steps": 5625
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--strategy_type=tpu"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - "--model=mask_rcnn"
             - |
               --params_override="architecture":
@@ -68,6 +66,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--strategy_type=tpu"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - "--model=mask_rcnn"
             - |
               --params_override="architecture":
@@ -68,6 +66,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--strategy_type=tpu"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - |
               --params_override="architecture":
                 "use_bfloat16": true
@@ -60,10 +58,12 @@
                 "checkpoint":
                   "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
                   "prefix": "resnet50/"
-                "total_steps": 22500
+                "total_steps": 5625
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--strategy_type=tpu"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - |
               --params_override="architecture":
                 "use_bfloat16": true
@@ -60,10 +58,12 @@
                 "checkpoint":
                   "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
                   "prefix": "resnet50/"
-                "total_steps": 22500
+                "total_steps": 5625
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--strategy_type=tpu"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - |
               --params_override="architecture":
                 "use_bfloat16": true
@@ -64,6 +62,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--strategy_type=tpu"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - |
               --params_override="architecture":
                 "use_bfloat16": true
@@ -64,6 +62,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--strategy_type=tpu"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v2-32.yaml
@@ -61,7 +61,7 @@
             - "--decode_batch_size=32"
             - "--decode_max_length=97"
             - "--batch_size=24576"
-            - "--train_steps=200000"
+            - "--train_steps=50000"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v3-32.yaml
@@ -61,7 +61,7 @@
             - "--decode_batch_size=32"
             - "--decode_max_length=97"
             - "--batch_size=24576"
-            - "--train_steps=200000"
+            - "--train_steps=50000"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-conv-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-conv-v100-x1.yaml
@@ -15,55 +15,34 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-nightly-retinanet-func-v2-8"
+  "name": "tf-nightly-bert-squad-conv-v100-x1"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 3600
+      "activeDeadlineSeconds": 21600
       "backoffLimit": 1
       "template":
         "metadata":
-          "annotations":
-            "tf-version.cloud-tpus.google.com": "nightly"
+          "annotations": {}
         "spec":
           "containers":
-          - "env":
-            - "name": "POD_NAME"
-              "valueFrom":
-                "fieldRef":
-                  "fieldPath": "metadata.name"
-            - "name": "POD_NAMESPACE"
-              "valueFrom":
-                "fieldRef":
-                  "fieldPath": "metadata.namespace"
-            "image": "gcr.io/xl-ml-test/health-monitor:stable"
-            "imagePullPolicy": "Always"
-            "name": "monitor"
           - "args":
             - "python3"
-            - "official/vision/detection/main.py"
-            - |
-              --params_override="architecture":
-                "use_bfloat16": true
-              "eval":
-                "batch_size": 8
-                "eval_file_pattern": "$(COCO_DIR)/val*"
-                "val_json_file": "$(COCO_DIR)/instances_val2017.json"
-              "predict":
-                "batch_size": 8
-              "train":
-                "batch_size": 64
-                "checkpoint":
-                  "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
-                  "prefix": "resnet50/"
-                "total_steps": 1000
-                "train_file_pattern": "$(COCO_DIR)/train*"
+            - "official/nlp/bert/run_squad.py"
+            - "--input_meta_data_path=gs://xl-ml-test-us-central1/data/squad/squad_v1.1_meta_data.json"
+            - "--train_data_path=gs://xl-ml-test-us-central1/data/squad/squad_v1.1_train.tfrecord"
+            - "--predict_file=gs://xl-ml-test-us-central1/data/squad/dev-v1.1.json"
+            - "--learning_rate=8e-5"
+            - "--do_lower_case=true"
             - "--model_dir=$(MODEL_DIR)"
-            - "--mode=train"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
+            - "--vocab_file=$(KERAS_BERT_DIR)/uncased_L-12_H-768_A-12/vocab.txt"
+            - "--bert_config_file=$(KERAS_BERT_DIR)/uncased_L-12_H-768_A-12/bert_config.json"
+            - "--init_checkpoint=$(KERAS_BERT_DIR)/uncased_L-12_H-768_A-12/bert_model.ckpt"
+            - "--train_batch_size=4"
+            - "--predict_batch_size=4"
+            - "--num_train_epochs=2"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -82,7 +61,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v2-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-nightly/bert-squad/conv/v100-x1/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
@@ -91,7 +70,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "nvidia.com/gpu": 1
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -111,7 +90,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v2-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-nightly/bert-squad/conv/v100-x1/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -144,13 +123,15 @@
                    }
                   }
                  },
-                 "test_name": "tf-nightly-retinanet-func-v2-8"
+                 "test_name": "tf-nightly-bert-squad-conv-v100-x1"
                 }
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
             "image": "gcr.io/xl-ml-test/publisher:stable"
             "name": "publisher"
+          "nodeSelector":
+            "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * *"
+  "schedule": "0 6 * * 0,5"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
@@ -44,14 +44,14 @@
           - "args":
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--model_type=efficientnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
             - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 5\n\"train\":\n  \"epochs\": 500\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
@@ -44,14 +44,14 @@
           - "args":
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--model_type=efficientnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
             - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 5\n\"train\":\n  \"epochs\": 500\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
@@ -44,14 +44,14 @@
           - "args":
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--model_type=efficientnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
             - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 3\n\"train\":\n  \"epochs\": 3\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
@@ -44,14 +44,14 @@
           - "args":
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--model_type=efficientnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
             - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 3\n\"train\":\n  \"epochs\": 3\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x1.yaml
@@ -15,55 +15,29 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-nightly-retinanet-func-v2-8"
+  "name": "tf-nightly-efficientnet-func-v100-x1"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 3600
+      "activeDeadlineSeconds": 10800
       "backoffLimit": 1
       "template":
         "metadata":
-          "annotations":
-            "tf-version.cloud-tpus.google.com": "nightly"
+          "annotations": {}
         "spec":
           "containers":
-          - "env":
-            - "name": "POD_NAME"
-              "valueFrom":
-                "fieldRef":
-                  "fieldPath": "metadata.name"
-            - "name": "POD_NAMESPACE"
-              "valueFrom":
-                "fieldRef":
-                  "fieldPath": "metadata.namespace"
-            "image": "gcr.io/xl-ml-test/health-monitor:stable"
-            "imagePullPolicy": "Always"
-            "name": "monitor"
           - "args":
             - "python3"
-            - "official/vision/detection/main.py"
-            - |
-              --params_override="architecture":
-                "use_bfloat16": true
-              "eval":
-                "batch_size": 8
-                "eval_file_pattern": "$(COCO_DIR)/val*"
-                "val_json_file": "$(COCO_DIR)/instances_val2017.json"
-              "predict":
-                "batch_size": 8
-              "train":
-                "batch_size": 64
-                "checkpoint":
-                  "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
-                  "prefix": "resnet50/"
-                "total_steps": 1000
-                "train_file_pattern": "$(COCO_DIR)/train*"
+            - "official/vision/image_classification/classifier_trainer.py"
+            - "--data_dir=$(IMAGENET_DIR)"
+            - "--model_type=efficientnet"
+            - "--dataset=imagenet"
+            - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
-            - "--mode=train"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
+            - "--params_override=\"evaluation\":\n  \"epochs_between_evals\": 3\n\"runtime\":\n  \"num_gpus\": 1\n\"train\":\n  \"epochs\": 3\n\"train_dataset\":\n  \"builder\": \"records\"\n\"validation_dataset\":\n  \"builder\": \"records\""
+            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-gpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -82,7 +56,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v2-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
@@ -91,7 +65,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "nvidia.com/gpu": 1
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -111,7 +85,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v2-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -144,13 +118,15 @@
                    }
                   }
                  },
-                 "test_name": "tf-nightly-retinanet-func-v2-8"
+                 "test_name": "tf-nightly-efficientnet-func-v100-x1"
                 }
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
             "image": "gcr.io/xl-ml-test/publisher:stable"
             "name": "publisher"
+          "nodeSelector":
+            "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v2-8.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - "--model=mask_rcnn"
             - |
               --params_override="architecture":
@@ -68,6 +66,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--strategy_type=tpu"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v3-8.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - "--model=mask_rcnn"
             - |
               --params_override="architecture":
@@ -68,6 +66,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--strategy_type=tpu"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
@@ -15,7 +15,7 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-nightly-retinanet-func-v2-8"
+  "name": "tf-nightly-maskrcnn-func-v100-x1"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
@@ -25,45 +25,35 @@
       "backoffLimit": 1
       "template":
         "metadata":
-          "annotations":
-            "tf-version.cloud-tpus.google.com": "nightly"
+          "annotations": {}
         "spec":
           "containers":
-          - "env":
-            - "name": "POD_NAME"
-              "valueFrom":
-                "fieldRef":
-                  "fieldPath": "metadata.name"
-            - "name": "POD_NAMESPACE"
-              "valueFrom":
-                "fieldRef":
-                  "fieldPath": "metadata.namespace"
-            "image": "gcr.io/xl-ml-test/health-monitor:stable"
-            "imagePullPolicy": "Always"
-            "name": "monitor"
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
+            - "--model=mask_rcnn"
             - |
               --params_override="architecture":
-                "use_bfloat16": true
+                "use_bfloat16": false
               "eval":
-                "batch_size": 8
+                "batch_size": 4
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
+              "postprocess":
+                "pre_nms_num_boxes": 1000
               "predict":
-                "batch_size": 8
+                "batch_size": 4
               "train":
-                "batch_size": 64
+                "batch_size": 4
                 "checkpoint":
                   "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
                   "prefix": "resnet50/"
+                "iterations_per_loop": 5000
                 "total_steps": 1000
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
+            - "--num_gpus=1"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -82,7 +72,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v2-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-nightly/maskrcnn/func/v100-x1/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
@@ -91,7 +81,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "nvidia.com/gpu": 1
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -111,7 +101,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v2-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-nightly/maskrcnn/func/v100-x1/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -128,29 +118,17 @@
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
-                  "metric_success_conditions": {
-                   "examples/sec_average": {
-                    "comparison": "greater_or_equal",
-                    "success_threshold": {
-                     "stddevs_from_mean": 2
-                    }
-                   },
-                   "total_wall_time": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   }
-                  }
+                  "alert_for_failed_jobs": false
                  },
-                 "test_name": "tf-nightly-retinanet-func-v2-8"
+                 "test_name": "tf-nightly-maskrcnn-func-v100-x1"
                 }
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
             "image": "gcr.io/xl-ml-test/publisher:stable"
             "name": "publisher"
+          "nodeSelector":
+            "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - "--model=mask_rcnn"
             - |
               --params_override="architecture":
@@ -68,6 +66,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--strategy_type=tpu"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - "--model=mask_rcnn"
             - |
               --params_override="architecture":
@@ -68,6 +66,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--strategy_type=tpu"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - |
               --params_override="architecture":
                 "use_bfloat16": true
@@ -64,6 +62,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--strategy_type=tpu"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - |
               --params_override="architecture":
                 "use_bfloat16": true
@@ -64,6 +62,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--strategy_type=tpu"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
@@ -15,7 +15,7 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-nightly-retinanet-func-v2-8"
+  "name": "tf-nightly-retinanet-func-v100-x1"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
@@ -25,36 +25,21 @@
       "backoffLimit": 1
       "template":
         "metadata":
-          "annotations":
-            "tf-version.cloud-tpus.google.com": "nightly"
+          "annotations": {}
         "spec":
           "containers":
-          - "env":
-            - "name": "POD_NAME"
-              "valueFrom":
-                "fieldRef":
-                  "fieldPath": "metadata.name"
-            - "name": "POD_NAMESPACE"
-              "valueFrom":
-                "fieldRef":
-                  "fieldPath": "metadata.namespace"
-            "image": "gcr.io/xl-ml-test/health-monitor:stable"
-            "imagePullPolicy": "Always"
-            "name": "monitor"
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
             - |
-              --params_override="architecture":
-                "use_bfloat16": true
-              "eval":
+              --params_override="eval":
                 "batch_size": 8
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
                 "batch_size": 8
               "train":
-                "batch_size": 64
+                "batch_size": 4
                 "checkpoint":
                   "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
                   "prefix": "resnet50/"
@@ -62,8 +47,7 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
+            - "--num_gpus=1"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -82,7 +66,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v2-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v100-x1/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
@@ -91,7 +75,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "nvidia.com/gpu": 1
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -111,7 +95,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v2-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-nightly/retinanet/func/v100-x1/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -128,29 +112,17 @@
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
-                  "metric_success_conditions": {
-                   "examples/sec_average": {
-                    "comparison": "greater_or_equal",
-                    "success_threshold": {
-                     "stddevs_from_mean": 2
-                    }
-                   },
-                   "total_wall_time": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   }
-                  }
+                  "alert_for_failed_jobs": false
                  },
-                 "test_name": "tf-nightly-retinanet-func-v2-8"
+                 "test_name": "tf-nightly-retinanet-func-v100-x1"
                 }
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
             "image": "gcr.io/xl-ml-test/publisher:stable"
             "name": "publisher"
+          "nodeSelector":
+            "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
@@ -44,8 +44,6 @@
           - "args":
             - "python3"
             - "official/vision/detection/main.py"
-            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
-            - "--strategy_type=tpu"
             - |
               --params_override="architecture":
                 "use_bfloat16": true
@@ -64,6 +62,8 @@
                 "train_file_pattern": "$(COCO_DIR)/train*"
             - "--model_dir=$(MODEL_DIR)"
             - "--mode=train"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--strategy_type=tpu"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/templates/gpus.libsonnet
+++ b/templates/gpus.libsonnet
@@ -16,17 +16,18 @@
   GPUSpec:: {
     local gpu = self,
 
-    name: "%(version)s-x%(number)d" % gpu,
+    name: "%(version)s-x%(count)d" % gpu,
     type: "gpu",
     version: error "Must specify GPUSpec `version`",
-    number: 1,
+    count: 1,
+    replicas: gpu.count,
 
     PodSpec:: {
       containerMap+: {
         train+: {
           resources+: {
             limits+: {
-              "nvidia.com/gpu": gpu.number
+              "nvidia.com/gpu": gpu.count
             },
           },
         },

--- a/templates/tpus.libsonnet
+++ b/templates/tpus.libsonnet
@@ -20,6 +20,7 @@
     type: "tpu",
     version: error "Must override `version`",
     size: error "Must override `size`",
+    replicas: tpu.size / 8, # Each TPU replica has 8 cores
     preemptible: false,
 
     PodSpec:: {

--- a/tests/tensorflow/nightly/bert-squad.libsonnet
+++ b/tests/tensorflow/nightly/bert-squad.libsonnet
@@ -44,7 +44,6 @@ local gpus = import "templates/gpus.libsonnet";
     ],
   },
 
-
   local gpu_common = {
     command+: [
       "--vocab_file=$(KERAS_BERT_DIR)/uncased_L-12_H-768_A-12/vocab.txt",
@@ -64,6 +63,13 @@ local gpus = import "templates/gpus.libsonnet";
     command+: [
       "--train_batch_size=4",
       "--predict_batch_size=4",
+    ],
+  },
+  local v100x4 = gpu_common {
+    accelerator: gpus.teslaV100 + { count: 4 },
+    command+: [
+      "--train_batch_size=8",
+      "--predict_batch_size=8",
     ],
   },
 
@@ -91,10 +97,12 @@ local gpus = import "templates/gpus.libsonnet";
   },
 
   configs: [
-    bert + k80 + functional + mixins.Experimental + timeouts.Hours(6),
     bert + v100 + functional + timeouts.Hours(3),
-    bert + k80 + convergence + mixins.Experimental + timeouts.Hours(12),
-    bert + v100 + convergence + mixins.Experimental + timeouts.Hours(6),
+    bert + v100 + convergence + timeouts.Hours(6),
+    bert + v100x4 + functional + timeouts.Hours(2) + mixins.Experimental,
+    bert + v100x4 + convergence + timeouts.Hours(4) + mixins.Experimental,
+    bert + k80 + functional + timeouts.Hours(6) + mixins.Experimental,
+    bert + k80 + convergence + timeouts.Hours(12) + mixins.Experimental,
     bert + v2_8 + functional,
     bert + v3_8 + functional,
   ],

--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -16,6 +16,7 @@ local common = import "common.libsonnet";
 local mixins = import "templates/mixins.libsonnet";
 local timeouts = import "templates/timeouts.libsonnet";
 local tpus = import "templates/tpus.libsonnet";
+local gpus = import "templates/gpus.libsonnet";
 
 {
   local efficientnet = common.ModelGardenTest {
@@ -37,8 +38,6 @@ local tpus = import "templates/tpus.libsonnet";
     command: [
       "python3",
       "official/vision/image_classification/classifier_trainer.py",
-      "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml",
-      "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)",
       "--data_dir=$(IMAGENET_DIR)",
       "--model_type=efficientnet",
       "--dataset=imagenet",
@@ -77,20 +76,49 @@ local tpus = import "templates/tpus.libsonnet";
       },
     },
   },
-  local v2_8 = {
+  local gpu_common = {
+    local config = self,
+
+    modelName: "efficientnet",
+    paramsOverride+:: {
+      runtime: {
+        num_gpus: config.accelerator.count,
+      },
+    },
+    command+: [
+      "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-gpu.yaml",
+    ],
+  },
+  local v100 = gpu_common {
+    accelerator: gpus.teslaV100,
+  },
+  local v100x4 = gpu_common {
+    accelerator: gpus.teslaV100 + { count: 4 },
+  },
+
+  local tpu_common = {
+    command+: [
+      "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)",
+      "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml",
+    ],
+  },
+  local v2_8 = tpu_common {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = tpu_common {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = {
+  local v2_32 = tpu_common {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = {
+  local v3_32 = tpu_common {
     accelerator: tpus.v3_32,
   },
 
   configs: [
+    efficientnet + v100 + functional + timeouts.Hours(3),
+    efficientnet + v100x4 + functional + timeouts.Hours(2) + mixins.Experimental,
+    efficientnet + v100x4 + convergence + timeouts.Hours(2) + mixins.Experimental,
     efficientnet + v2_8 + functional,
     efficientnet + v3_8 + functional,
     efficientnet + v2_8 + convergence + timeouts.Hours(31),

--- a/tests/tensorflow/nightly/classifier-resnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnet.libsonnet
@@ -81,8 +81,8 @@ local gpus = import "templates/gpus.libsonnet";
     local config = self,
 
     paramsOverride+:: {
-      runtime: {
-        num_gpus: config.accelerator.number,
+      runtime+: {
+        num_gpus: config.accelerator.count,
       },
     },
     command+: [
@@ -92,6 +92,13 @@ local gpus = import "templates/gpus.libsonnet";
   local v100 = gpu_common {
     accelerator: gpus.teslaV100,
   },
+  local v100x4 = gpu_common {
+    accelerator: gpus.teslaV100 + { count: 4 },
+  },
+  local v100x8 = gpu_common {
+    accelerator: gpus.teslaV100 + { count: 8 },
+  },
+
   local k80 = gpu_common {
     paramsOverride+:: {
       train_dataset+: {
@@ -124,10 +131,12 @@ local gpus = import "templates/gpus.libsonnet";
   },
 
   configs: [
-    resnet + k80 + functional + timeouts.Hours(5) + mixins.Experimental,
     resnet + v100 + functional + timeouts.Hours(3),
+    resnet + v100x4 + functional + mixins.Experimental,
+    resnet + v100x4 + convergence + mixins.Experimental,
+    resnet + v100x8 + functional + mixins.Experimental,
+    resnet + k80 + functional + timeouts.Hours(5) + mixins.Experimental,
     resnet + k80 + convergence + timeouts.Hours(48) + mixins.Experimental,
-    resnet + v100 + convergence + timeouts.Hours(48) + mixins.Experimental,
     resnet + v2_8 + functional,
     resnet + v3_8 + functional,
     resnet + v2_8 + convergence,

--- a/tests/tensorflow/nightly/transformer-translate.libsonnet
+++ b/tests/tensorflow/nightly/transformer-translate.libsonnet
@@ -45,8 +45,10 @@ local gpus = import "templates/gpus.libsonnet";
     ],
   },
   local convergence = mixins.Convergence {
+    local config = self,
+
     command+: [
-      "--train_steps=200000",
+      "--train_steps=%d" % (200000 / config.accelerator.replicas),
     ],
   },
 
@@ -54,7 +56,7 @@ local gpus = import "templates/gpus.libsonnet";
     local config = self,
 
     command+: [
-      "--num_gpus=%d" % config.accelerator.number,
+      "--num_gpus=%d" % config.accelerator.count,
       "--steps_between_evals=5000",
     ],
   },
@@ -68,6 +70,12 @@ local gpus = import "templates/gpus.libsonnet";
     accelerator: gpus.teslaV100,
     command+: [
       "--batch_size=4096",
+    ],
+  },
+  local v100x4 = gpu_common {
+    accelerator: gpus.teslaV100 + { count: 4 },
+    command+: [
+      "--batch_size=16384",
     ],
   },
 
@@ -111,6 +119,8 @@ local gpus = import "templates/gpus.libsonnet";
   configs: [
     transformer + k80 + functional_short + timeouts.Hours(6) + mixins.Experimental,
     transformer + v100 + functional_short + timeouts.Hours(3),
+    transformer + v100x4 + functional_short + timeouts.Hours(3) + mixins.Experimental,
+    transformer + v100x4 + convergence + mixins.Experimental,
     transformer + k80 + convergence  + mixins.Experimental,
     transformer + v100 + convergence  + mixins.Experimental,
     transformer + v2_8 + functional,


### PR DESCRIPTION
- Rename `gpu.number` to `gpu.count`
- Add `replica` field to `gpu` and `tpu`.
- Scale `train_steps` according the number of replicas for detection models and transformer translate.

Tested each of the functional tests. Only Mask-RCNN and RetinaNet are failing due to a known issue, so I disabled alerts on those tests. Leaving experimental (only manual runs) while I change the cluster configuration to include a larger GPU pool (will send in follow-up PR).