### PR TITLE
Add automated script to clean up OS Login keys.

### DIFF
--- a/k8s/europe-west4/profile-cleanup.yaml
+++ b/k8s/europe-west4/profile-cleanup.yaml
@@ -1,0 +1,36 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: profile-cleanup
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: deleter
+            image: google/cloud-sdk
+            args:
+            - /bin/sh
+            - -c
+            - |
+              for i in $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT);
+                do echo Deleting OS Login key $i...;
+                gcloud compute os-login ssh-keys remove --key $i;
+              done
+          restartPolicy: Never

--- a/postsubmit.yaml
+++ b/postsubmit.yaml
@@ -39,12 +39,12 @@ steps:
   - 'CLOUDSDK_COMPUTE_ZONE=europe-west4-a'
   - 'CLOUDSDK_CONTAINER_CLUSTER=xl-ml-test-europe-west4'
 - name: 'gcr.io/cloud-builders/kubectl'
-  args: ['apply', '-f', 'k8s/us-central1/', '-f', 'k8s/common/',]
+  args: ['apply', '-f', 'k8s/us-central1/gcs-buckets.yaml', '-f', 'k8s/us-central1/volumes.yaml', '-f', 'k8s/common/',]
   env:
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
   - 'CLOUDSDK_CONTAINER_CLUSTER=oneshots'
 - name: 'gcr.io/cloud-builders/kubectl'
-  args: ['apply', '-f', 'k8s/europe-west4/', '-f', 'k8s/common/',]
+  args: ['apply', '-f', 'k8s/europe-west4/gcs-buckets.yaml', '-f', 'k8s/common/',]
   env:
   - 'CLOUDSDK_COMPUTE_ZONE=europe-west4-a'
   - 'CLOUDSDK_CONTAINER_CLUSTER=europe-oneshots'


### PR DESCRIPTION
Fix bug where unnecessary quotas and namespaces were created on oneshot clusters.