### PR TITLE
Use fixed_value for pytorch cifar torchvision tests

### DIFF
--- a/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v2-8.yaml
@@ -135,29 +135,26 @@
                    "CompileTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
+                     "fixed_value": 6
+                    }
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
+                     "fixed_value": 0.5
+                    }
                    },
                    "aten_ops_sum_final": {
                     "comparison": "less_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 0
+                     "fixed_value": 2400
                     }
                    },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
+                     "fixed_value": 1000
+                    }
                    }
                   }
                  },

--- a/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v3-8.yaml
@@ -135,29 +135,26 @@
                    "CompileTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
+                     "fixed_value": 6
+                    }
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
+                     "fixed_value": 0.5
+                    }
                    },
                    "aten_ops_sum_final": {
                     "comparison": "less_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 0
+                     "fixed_value": 2400
                     }
                    },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
+                     "fixed_value": 1000
+                    }
                    }
                   }
                  },

--- a/tests/pytorch/nightly/cifar-tv.libsonnet
+++ b/tests/pytorch/nightly/cifar-tv.libsonnet
@@ -31,13 +31,44 @@ local tpus = import "templates/tpus.libsonnet";
   local convergence = common.Convergence {
     # Run daily instead of 2x per week since convergence is fast.
     schedule: "0 18 * * *",
-    regressionTestConfig+: {
-      metric_success_conditions+: {
+    regressionTestConfig: {
+      metric_subset_to_alert: [
+        "ExecuteTime__Percentile_99_sec_final",
+        "CompileTime__Percentile_99_sec_final",
+        "total_wall_time",
+        "Accuracy/test_final",
+        "aten_ops_sum_final",
+      ],
+      metric_success_conditions: {
+        "ExecuteTime__Percentile_99_sec_final": {
+          success_threshold: {
+            fixed_value: 0.5,
+          },
+          comparison: "less",
+        },
+        "CompileTime__Percentile_99_sec_final": {
+          success_threshold: {
+            fixed_value: 6.0,
+          },
+          comparison: "less",
+        },
+        "aten_ops_sum_final": {
+          success_threshold: {
+            fixed_value: 2400.0,
+          },
+          comparison: "less_or_equal",
+        },
         "Accuracy/test_final": {
           success_threshold: {
             fixed_value: 72.0,
           },
           comparison: "greater",
+        },
+        "total_wall_time": {
+          success_threshold: {
+            fixed_value: 1000.0,
+          },
+          comparison: "less",
         },
       },
     },


### PR DESCRIPTION
This test has been so slow for over a week while pytorch/xla team works on a fix that the test is no longer failing since the mean values have gotten so high