### PR TITLE
Update TF nightly examples/sec metric assertion.

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v2-32.yaml
@@ -113,7 +113,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -122,7 +122,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v3-32.yaml
@@ -113,7 +113,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -122,7 +122,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
@@ -113,7 +113,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -122,7 +122,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
@@ -113,7 +113,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -122,7 +122,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v2-32.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v3-32.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v2-32.yaml
@@ -124,7 +124,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -133,7 +133,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v3-32.yaml
@@ -124,7 +124,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -133,7 +133,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
@@ -124,7 +124,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -133,7 +133,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
@@ -124,7 +124,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -133,7 +133,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v2-32.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v3-32.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
@@ -120,7 +120,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -129,7 +129,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
@@ -120,7 +120,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -129,7 +129,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
@@ -120,7 +120,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -129,7 +129,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
@@ -120,7 +120,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -129,7 +129,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-conv-v2-32.yaml
@@ -125,7 +125,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -134,7 +134,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-conv-v3-32.yaml
@@ -125,7 +125,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -134,7 +134,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
@@ -125,7 +125,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -134,7 +134,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
@@ -125,7 +125,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -134,7 +134,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v2-32.yaml
@@ -118,7 +118,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -127,7 +127,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v3-32.yaml
@@ -118,7 +118,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -127,7 +127,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
@@ -118,7 +118,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -127,7 +127,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
@@ -118,7 +118,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -127,7 +127,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v2-8.yaml
@@ -113,7 +113,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -122,7 +122,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v3-8.yaml
@@ -113,7 +113,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -122,7 +122,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
@@ -113,7 +113,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -122,7 +122,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
@@ -113,7 +113,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -122,7 +122,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-conv-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-conv-v100-x1.yaml
@@ -99,7 +99,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -108,7 +108,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x1.yaml
@@ -100,7 +100,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -109,7 +109,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v2-8.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v3-8.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x1.yaml
@@ -94,7 +94,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -103,7 +103,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
@@ -108,7 +108,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -117,7 +117,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x1.yaml
@@ -94,7 +94,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -103,7 +103,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-keras-api-connection-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-connection-v2-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-connection-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-connection-v3-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-training-loop-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-training-loop-v2-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-training-loop-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-training-loop-v3-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v2-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v3-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v2-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
@@ -111,7 +111,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v2-8.yaml
@@ -124,7 +124,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -133,7 +133,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v3-8.yaml
@@ -124,7 +124,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -133,7 +133,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
@@ -110,7 +110,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
@@ -124,7 +124,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -133,7 +133,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
@@ -124,7 +124,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -133,7 +133,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-conv-v2-8.yaml
@@ -106,7 +106,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -115,7 +115,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-conv-v3-8.yaml
@@ -106,7 +106,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -115,7 +115,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v100-x1.yaml
@@ -92,7 +92,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -101,7 +101,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
@@ -106,7 +106,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -115,7 +115,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
@@ -106,7 +106,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -115,7 +115,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v2-8.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v3-8.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
@@ -115,7 +115,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -124,7 +124,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
@@ -120,7 +120,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -129,7 +129,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
@@ -120,7 +120,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -129,7 +129,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
@@ -104,7 +104,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
@@ -120,7 +120,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -129,7 +129,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
@@ -120,7 +120,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -129,7 +129,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-shapemask-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-conv-v2-8.yaml
@@ -125,7 +125,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -134,7 +134,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-shapemask-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-conv-v3-8.yaml
@@ -125,7 +125,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -134,7 +134,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
@@ -125,7 +125,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -134,7 +134,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
@@ -125,7 +125,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -134,7 +134,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v2-8.yaml
@@ -118,7 +118,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -127,7 +127,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v3-8.yaml
@@ -118,7 +118,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -127,7 +127,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v100-x1.yaml
@@ -99,7 +99,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -108,7 +108,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
@@ -118,7 +118,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -127,7 +127,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
@@ -118,7 +118,7 @@
                    "final"
                   ],
                   "metric_to_aggregation_strategies": {
-                   "examples/sec": [
+                   "examples_per_second": [
                     "average"
                    ]
                   },
@@ -127,7 +127,7 @@
                  },
                  "regression_test_config": {
                   "metric_success_conditions": {
-                   "examples/sec_average": {
+                   "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
                      "stddevs_from_mean": 2

--- a/tests/tensorflow/nightly/common.libsonnet
+++ b/tests/tensorflow/nightly/common.libsonnet
@@ -24,13 +24,13 @@ local common = import "../common.libsonnet";
 
     metricCollectionConfig+: {
       metric_to_aggregation_strategies+: {
-        "examples/sec": ["average"],
+        "examples_per_second": ["average"],
       },
       use_run_name_prefix: true,
     },
     regressionTestConfig+: {
       metric_success_conditions+: {
-        "examples/sec_average": {
+        "examples_per_second_average": {
           comparison: "greater_or_equal",
           success_threshold: {
             stddevs_from_mean: 2.0,


### PR DESCRIPTION
Underlying TensorFlow summaries were renamed: https://github.com/tensorflow/models/blob/master/official/utils/misc/keras_utils.py#L137