### PR TITLE
Refactor accelerator mixins and preemptible TPU logic.

### DIFF
--- a/k8s/us-central1/gen/tf-nightly-bert-squad-conv-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-conv-k80-x8.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 14400
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-conv-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-conv-v100-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 21600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-conv-v100-x4.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 14400
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-k80-x8.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 7200
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 10800
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x4.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 7200
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 18000
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x8.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 14400
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 10800
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-k80-x8.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 7200
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 10800
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x4.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 7200
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-k80-x8.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 3600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 3600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x4.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 3600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v100-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 3600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-k80-x8.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 3600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 3600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x4.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 3600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 21600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x8.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 21600
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v100-x1.yaml
@@ -24,8 +24,6 @@
       "activeDeadlineSeconds": 10800
       "backoffLimit": 1
       "template":
-        "metadata":
-          "annotations": {}
         "spec":
           "containers":
           - "args":

--- a/templates/base.libsonnet
+++ b/templates/base.libsonnet
@@ -243,6 +243,7 @@ local volumes = import 'volumes.libsonnet';
   cpu:: self.BaseAccelerator {
     name: "cpu",
     type: "cpu",
+    replicas: 1,
 
     # Ignore TPU settings.
     PodTemplate(_):: {

--- a/templates/gpus.libsonnet
+++ b/templates/gpus.libsonnet
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+local base = import 'base.libsonnet';
+
 {
-  GPUSpec:: {
+  GPUSpec:: base.BaseAccelerator {
     local gpu = self,
 
     name: "%(version)s-x%(count)d" % gpu,
@@ -22,18 +24,21 @@
     count: 1,
     replicas: gpu.count,
 
-    PodSpec:: {
-      containerMap+: {
-        train+: {
-          resources+: {
-            limits+: {
-              "nvidia.com/gpu": gpu.count
+    # Ignore TPU settings.
+    PodTemplate(_):: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              limits+: {
+                "nvidia.com/gpu": gpu.count
+              },
             },
           },
         },
-      },
-      nodeSelector+: {
-        "cloud.google.com/gke-accelerator": "nvidia-tesla-%(version)s" % gpu,
+        nodeSelector+: {
+          "cloud.google.com/gke-accelerator": "nvidia-tesla-%(version)s" % gpu,
+        },
       },
     },
   },

--- a/templates/mixins.libsonnet
+++ b/templates/mixins.libsonnet
@@ -20,20 +20,19 @@ local timeouts = import "timeouts.libsonnet";
     timeout: timeouts.one_hour,
     # Run at midnight PST daily
     schedule: "0 8 * * *",
-    accelerator+: {
-      preemptible: false,
-    },
   },
   Convergence:: {
     mode: "conv",
     timeout: timeouts.ten_hours,
     # Run at 22:00 PST on Sunday and Wednesday
     schedule: "0 6 * * 0,5",
-    accelerator+: {
-      preemptible: false,
-    },
   },
   Experimental:: {
     schedule: null,
+  },
+  PreemptibleTpu:: {
+    tpuSettings+: {
+      preemptible: true,
+    },
   },
 }

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -15,6 +15,7 @@
 local common = import "common.libsonnet";
 local timeouts = import "templates/timeouts.libsonnet";
 local tpus = import "templates/tpus.libsonnet";
+local mixins = import "templates/mixins.libsonnet";
 
 {
   local resnet50_MP = common.PyTorchTest {
@@ -55,7 +56,6 @@ local tpus = import "templates/tpus.libsonnet";
     ],
   },
   local convergence = common.Convergence {
-    accelerator+: tpus.Preemptible,
     command+: [
       "--num_epochs=90",
       "--datadir=/datasets/imagenet",
@@ -75,7 +75,7 @@ local tpus = import "templates/tpus.libsonnet";
     accelerator: tpus.v3_8,
   },
   configs: [
-    resnet50_MP + v3_8 + convergence + timeouts.Hours(26),
+    resnet50_MP + v3_8 + convergence + timeouts.Hours(26) + mixins.PreemptibleTpu,
     resnet50_MP + v3_8 + functional + timeouts.Hours(2),
   ],
 }

--- a/tests/pytorch/nightly/resnet50.libsonnet
+++ b/tests/pytorch/nightly/resnet50.libsonnet
@@ -15,6 +15,7 @@
 local common = import "common.libsonnet";
 local timeouts = import "templates/timeouts.libsonnet";
 local tpus = import "templates/tpus.libsonnet";
+local mixins = import "templates/mixins.libsonnet";
 
 {
   local resnet50 = common.PyTorchTest {
@@ -55,7 +56,6 @@ local tpus = import "templates/tpus.libsonnet";
     ],
   },
   local convergence = common.Convergence {
-    accelerator+: tpus.Preemptible,
     command+: [
       "--num_epochs=90",
       "--datadir=/datasets/imagenet",
@@ -75,7 +75,7 @@ local tpus = import "templates/tpus.libsonnet";
     accelerator: tpus.v3_8,
   },
   configs: [
-    resnet50 + v3_8 + convergence + timeouts.Hours(26),
+    resnet50 + v3_8 + convergence + timeouts.Hours(26) + mixins.PreemptibleTpu,
     resnet50 + v3_8 + functional + timeouts.Hours(2),
   ],
 }

--- a/tests/pytorch/r1.5/resnet50-mp.libsonnet
+++ b/tests/pytorch/r1.5/resnet50-mp.libsonnet
@@ -15,6 +15,7 @@
 local common = import "common.libsonnet";
 local timeouts = import "templates/timeouts.libsonnet";
 local tpus = import "templates/tpus.libsonnet";
+local mixins = import "templates/mixins.libsonnet";
 
 {
   local resnet50_MP = common.PyTorchTest {
@@ -55,7 +56,6 @@ local tpus = import "templates/tpus.libsonnet";
     ],
   },
   local convergence = common.Convergence {
-    accelerator+: tpus.Preemptible,
     command+: [
       "--num_epochs=90",
       "--datadir=/datasets/imagenet",
@@ -75,7 +75,7 @@ local tpus = import "templates/tpus.libsonnet";
     accelerator: tpus.v3_8,
   },
   configs: [
-    resnet50_MP + v3_8 + convergence + timeouts.Hours(26),
+    resnet50_MP + v3_8 + convergence + timeouts.Hours(26) + mixins.PreemptibleTpu,
     resnet50_MP + v3_8 + functional + timeouts.Hours(2),
   ],
 }

--- a/tests/tensorflow/nightly/keras-api.libsonnet
+++ b/tests/tensorflow/nightly/keras-api.libsonnet
@@ -41,7 +41,7 @@ local utils = import "templates/utils.libsonnet";
     timeout: timeouts.one_hour,
     # Run at 2AM PST daily
     schedule: "0 10 * * *",
-    accelerator+: {
+    tpuSettings+: {
       preemptible: true,
     },
   },


### PR DESCRIPTION
- Change `accelerator.PodSpec` to `accelerator.PodTemplate(tpuSettings)` that encapsulates all TPU logic. Remove hacky `if type == 'tpu'` conditionals from base template.
- Create explicit `BaseAccelerator` base object.
- Fixes bug/inconsitency where `model + tpu + mode` gave a different result than `model + mode + tpu`
- Remove empty objects from GPU job metadata.
- Replace `tpus.Preemptible` with `mixins.PreemptibleTpu`.
- Fix bug where we were setting a no-op `preemptible` field on GPU accelerators.