### PR TITLE
Use retinanet train batch size as default for eval.

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
@@ -48,11 +48,11 @@
               --params_override="architecture":
                 "use_bfloat16": true
               "eval":
-                "batch_size": 8
+                "batch_size": 256
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 256
               "train":
                 "batch_size": 256
                 "checkpoint":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
@@ -48,11 +48,11 @@
               --params_override="architecture":
                 "use_bfloat16": true
               "eval":
-                "batch_size": 8
+                "batch_size": 256
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 256
               "train":
                 "batch_size": 256
                 "checkpoint":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
@@ -48,11 +48,11 @@
               --params_override="architecture":
                 "use_bfloat16": true
               "eval":
-                "batch_size": 8
+                "batch_size": 256
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 256
               "train":
                 "batch_size": 256
                 "checkpoint":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
@@ -48,11 +48,11 @@
               --params_override="architecture":
                 "use_bfloat16": true
               "eval":
-                "batch_size": 8
+                "batch_size": 256
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 256
               "train":
                 "batch_size": 256
                 "checkpoint":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
@@ -48,11 +48,11 @@
               --params_override="architecture":
                 "use_bfloat16": true
               "eval":
-                "batch_size": 8
+                "batch_size": 64
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 64
               "train":
                 "batch_size": 64
                 "checkpoint":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
@@ -48,11 +48,11 @@
               --params_override="architecture":
                 "use_bfloat16": true
               "eval":
-                "batch_size": 8
+                "batch_size": 64
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 64
               "train":
                 "batch_size": 64
                 "checkpoint":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-k80-x8.yaml
@@ -33,11 +33,11 @@
             - "official/vision/detection/main.py"
             - |
               --params_override="eval":
-                "batch_size": 8
+                "batch_size": 32
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 32
               "train":
                 "batch_size": 32
                 "checkpoint":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
@@ -33,11 +33,11 @@
             - "official/vision/detection/main.py"
             - |
               --params_override="eval":
-                "batch_size": 8
+                "batch_size": 4
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 4
               "train":
                 "batch_size": 4
                 "checkpoint":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x4.yaml
@@ -33,11 +33,11 @@
             - "official/vision/detection/main.py"
             - |
               --params_override="eval":
-                "batch_size": 8
+                "batch_size": 16
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 16
               "train":
                 "batch_size": 16
                 "checkpoint":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
@@ -48,11 +48,11 @@
               --params_override="architecture":
                 "use_bfloat16": true
               "eval":
-                "batch_size": 8
+                "batch_size": 64
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 64
               "train":
                 "batch_size": 64
                 "checkpoint":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
@@ -48,11 +48,11 @@
               --params_override="architecture":
                 "use_bfloat16": true
               "eval":
-                "batch_size": 8
+                "batch_size": 64
                 "eval_file_pattern": "$(COCO_DIR)/val*"
                 "val_json_file": "$(COCO_DIR)/instances_val2017.json"
               "predict":
-                "batch_size": 8
+                "batch_size": 64
               "train":
                 "batch_size": 64
                 "checkpoint":

--- a/tests/tensorflow/nightly/retinanet.libsonnet
+++ b/tests/tensorflow/nightly/retinanet.libsonnet
@@ -22,13 +22,15 @@ local gpus = import "templates/gpus.libsonnet";
   local retinanet = common.ModelGardenTest {
     modelName: "retinanet",
     paramsOverride:: {
+      local params = self,
+
       eval: {
         eval_file_pattern: "$(COCO_DIR)/val*",
-        batch_size: 8,
+        batch_size: params.train.batch_size,
         val_json_file: "$(COCO_DIR)/instances_val2017.json",
       },
       predict: {
-        batch_size: 8,
+        batch_size: params.train.batch_size,
       },
       train: {
         checkpoint: {


### PR DESCRIPTION
Fixes a crash on single-V100 version of this test.