### PR TITLE
Fix location in logs link.

### DIFF
--- a/images/setup.sh
+++ b/images/setup.sh
@@ -30,5 +30,5 @@ echo "Region: ${REGION}"
 export CLUSTER=`curl -sS http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-name -H "Metadata-Flavor: Google"`
 echo "Cluster: ${CLUSTER}"
 
-export STACKDRIVER_LOGS="https://console.cloud.google.com/logs?project=$PROJECT&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3D${PROJECT}%0Aresource.labels.location=${ZONE}%0Aresource.labels.cluster_name=${CLUSTER}%0Aresource.labels.namespace_name=${POD_NAMESPACE}%0Aresource.labels.pod_name:${JOB_NAME}"
+export STACKDRIVER_LOGS="https://console.cloud.google.com/logs?project=$PROJECT&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3D${PROJECT}%0Aresource.labels.location:${REGION}%0Aresource.labels.cluster_name=${CLUSTER}%0Aresource.labels.namespace_name=${POD_NAMESPACE}%0Aresource.labels.pod_name:${JOB_NAME}"
 echo "Stackdriver Log link: ${STACKDRIVER_LOGS}"


### PR DESCRIPTION
Look for region prefix instead of matching zone. This lets us generate the correct logs link for regional GKE clusters.