### PR TITLE
Use custom start time for total_wall_time if provided.

### DIFF
--- a/metrics_handler/metrics.py
+++ b/metrics_handler/metrics.py
@@ -98,7 +98,14 @@ def get_computed_metrics(raw_metrics_dict, job_status_dict,
       MetricPoints.
   """
   computed_metrics_dict = {}
-  start_time = job_status_dict['start_time']
+  if 'TensorboardStartTimestamp' in raw_metrics_dict:
+    custom_start_time = raw_metrics_dict[
+        'TensorboardStartTimestamp'][-1].metric_value
+    logging.warning('Using TensorboardStartTimestamp for start time with '
+                    'value: {}'.format(custom_start_time))
+    start_time = custom_start_time
+  else:
+    start_time = job_status_dict['start_time']
   stop_time = job_status_dict['stop_time']
   computed_metrics_dict['total_wall_time'] = MetricPoint(
       stop_time - start_time, stop_time)

--- a/metrics_handler/metrics_test.py
+++ b/metrics_handler/metrics_test.py
@@ -170,7 +170,11 @@ class MetricsTest(parameterized.TestCase):
     within_bounds = metrics.within_bounds(value, *bounds, inclusive)
     self.assertIs(within_bounds, expected)
 
-  def test_get_computed_metrics(self):
+  @parameterized.named_parameters(
+    ('with_custom_start', 1),
+    ('without_custom_start', None),
+  )
+  def test_get_computed_metrics(self, custom_start):
     job_status_dict = {
         'start_time': 0,
         'stop_time': 20,
@@ -185,6 +189,13 @@ class MetricsTest(parameterized.TestCase):
         metrics.MetricPoint(metric_value=.8, wall_time=0),
       ],
     }
+
+    if custom_start is not None:
+      raw_metrics['TensorboardStartTimestamp'] = [
+        metrics.MetricPoint(metric_value=custom_start, wall_time=0),
+      ]
+    else:
+      custom_start = 0
     tta_config = {
         'accuracy_tag': 'accuracy',
         'accuracy_threshold': 0.4,
@@ -194,8 +205,10 @@ class MetricsTest(parameterized.TestCase):
         find_memory_metrics=False)
     self.assertEqual(
         computed_metrics,
-        {'total_wall_time': metrics.MetricPoint(metric_value=20, wall_time=20),
-         'time_to_accuracy': metrics.MetricPoint(metric_value=10, wall_time=10)}
+        {'total_wall_time': metrics.MetricPoint(
+            metric_value=20-custom_start, wall_time=20),
+         'time_to_accuracy': metrics.MetricPoint(
+             metric_value=10-custom_start, wall_time=10)}
     )
 
 


### PR DESCRIPTION
This means the `total_wall_time` will be low if e.g. the job timed out after waiting a long time for a TPU.

The `TensorboardStartTimestamp` field is being set for all pytorch models here: https://github.com/pytorch/xla/blob/master/torch_xla/test/test_utils.py#L76