### PR TITLE
Fix failing TF 2.3 GPU tests.

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
@@ -51,9 +51,9 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
@@ -51,9 +51,9 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":

--- a/k8s/europe-west4/gen/tf-r2.3-classifier-resnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-classifier-resnet-func-v2-32.yaml
@@ -51,9 +51,9 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":

--- a/k8s/europe-west4/gen/tf-r2.3-classifier-resnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-classifier-resnet-func-v3-32.yaml
@@ -51,9 +51,9 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x1.yaml
@@ -36,11 +36,11 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "runtime":
                 "num_gpus": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "batch_size": 128
                 "builder": "records"
@@ -140,3 +140,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x8.yaml
@@ -36,12 +36,12 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "runtime":
                 "all_reduce_alg": "hierarchical_copy"
                 "num_gpus": 8
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "batch_size": 128
                 "builder": "records"
@@ -141,3 +141,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x1.yaml
@@ -36,11 +36,11 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "runtime":
                 "num_gpus": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":
@@ -138,3 +138,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
@@ -51,9 +51,9 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
@@ -51,9 +51,9 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-k80-x8.yaml
@@ -21,7 +21,7 @@
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 7200
+      "activeDeadlineSeconds": 14400
       "backoffLimit": 1
       "template":
         "spec":
@@ -139,3 +139,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x4.yaml
@@ -138,3 +138,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-k80-x8.yaml
@@ -131,3 +131,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
@@ -130,3 +130,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x4.yaml
@@ -130,3 +130,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-k80-x8.yaml
@@ -139,3 +139,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x1.yaml
@@ -124,3 +124,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v100-x4.yaml
@@ -124,3 +124,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x1.yaml
@@ -133,3 +133,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x8.yaml
@@ -134,3 +134,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v100-x1.yaml
@@ -133,3 +133,4 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-r2.3-classifier-resnet-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-resnet-conv-v100-x4.yaml
@@ -15,13 +15,13 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-nightly-efficientnet-func-v100-x1"
+  "name": "tf-r2.3-classifier-resnet-conv-v100-x4"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 28800
+      "activeDeadlineSeconds": 36000
       "backoffLimit": 1
       "template":
         "spec":
@@ -30,7 +30,7 @@
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
             - "--data_dir=$(IMAGENET_DIR)"
-            - "--model_type=efficientnet"
+            - "--model_type=resnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
@@ -38,14 +38,14 @@
               --params_override="evaluation":
                 "epochs_between_evals": 1
               "runtime":
-                "num_gpus": 1
+                "num_gpus": 4
               "train":
-                "epochs": 1
+                "epochs": 90
               "train_dataset":
                 "builder": "records"
               "validation_dataset":
                 "builder": "records"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-gpu.yaml"
+            - "--config_file=official/vision/image_classification/configs/examples/resnet/imagenet/gpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -64,16 +64,16 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/classifier-resnet/conv/v100-x4/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/tensorflow:nightly"
+            "image": "gcr.io/xl-ml-test/tensorflow:r2.3"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "nvidia.com/gpu": 1
+                "nvidia.com/gpu": 4
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -93,7 +93,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/classifier-resnet/conv/v100-x4/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -123,10 +123,16 @@
                      "stddevs_from_mean": 5
                     },
                     "wait_for_n_points_of_history": 10
+                   },
+                   "validation/epoch_accuracy_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 0.76000000000000001
+                    }
                    }
                   }
                  },
-                 "test_name": "tf-nightly-efficientnet-func-v100-x1"
+                 "test_name": "tf-r2.3-classifier-resnet-conv-v100-x4"
                 }
             "envFrom":
             - "configMapRef":
@@ -136,6 +142,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * *"
+  "schedule": "0 6 * * 0,5"
   "successfulJobsHistoryLimit": 1
-  "suspend": true

--- a/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-k80-x8.yaml
@@ -36,12 +36,12 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "runtime":
                 "all_reduce_alg": "hierarchical_copy"
                 "num_gpus": 8
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "batch_size": 128
                 "builder": "records"

--- a/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-v100-x1.yaml
@@ -36,11 +36,11 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "runtime":
                 "num_gpus": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":

--- a/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-v100-x4.yaml
@@ -15,13 +15,13 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-nightly-efficientnet-func-v100-x1"
+  "name": "tf-r2.3-classifier-resnet-func-v100-x4"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 28800
+      "activeDeadlineSeconds": 3600
       "backoffLimit": 1
       "template":
         "spec":
@@ -30,7 +30,7 @@
             - "python3"
             - "official/vision/image_classification/classifier_trainer.py"
             - "--data_dir=$(IMAGENET_DIR)"
-            - "--model_type=efficientnet"
+            - "--model_type=resnet"
             - "--dataset=imagenet"
             - "--mode=train_and_eval"
             - "--model_dir=$(MODEL_DIR)"
@@ -38,14 +38,14 @@
               --params_override="evaluation":
                 "epochs_between_evals": 1
               "runtime":
-                "num_gpus": 1
+                "num_gpus": 4
               "train":
                 "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":
                 "builder": "records"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-gpu.yaml"
+            - "--config_file=official/vision/image_classification/configs/examples/resnet/imagenet/gpu.yaml"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -64,16 +64,16 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/classifier-resnet/func/v100-x4/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/tensorflow:nightly"
+            "image": "gcr.io/xl-ml-test/tensorflow:r2.3"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "nvidia.com/gpu": 1
+                "nvidia.com/gpu": 4
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -93,7 +93,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/classifier-resnet/func/v100-x4/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -126,7 +126,7 @@
                    }
                   }
                  },
-                 "test_name": "tf-nightly-efficientnet-func-v100-x1"
+                 "test_name": "tf-r2.3-classifier-resnet-func-v100-x4"
                 }
             "envFrom":
             - "configMapRef":
@@ -138,4 +138,3 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
-  "suspend": true

--- a/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-v2-8.yaml
@@ -51,9 +51,9 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":

--- a/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-resnet-func-v3-8.yaml
@@ -51,9 +51,9 @@
             - "--model_dir=$(MODEL_DIR)"
             - |
               --params_override="evaluation":
-                "epochs_between_evals": 3
+                "epochs_between_evals": 1
               "train":
-                "epochs": 3
+                "epochs": 1
               "train_dataset":
                 "builder": "records"
               "validation_dataset":

--- a/k8s/us-central1/gen/tf-r2.3-efficientnet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-efficientnet-func-k80-x8.yaml
@@ -21,7 +21,7 @@
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 7200
+      "activeDeadlineSeconds": 14400
       "backoffLimit": 1
       "template":
         "spec":

--- a/k8s/us-central1/gen/tf-r2.3-maskrcnn-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-maskrcnn-conv-v100-x4.yaml
@@ -15,37 +15,43 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-nightly-efficientnet-func-v100-x1"
+  "name": "tf-r2.3-maskrcnn-conv-v100-x4"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 28800
+      "activeDeadlineSeconds": 36000
       "backoffLimit": 1
       "template":
         "spec":
           "containers":
           - "args":
             - "python3"
-            - "official/vision/image_classification/classifier_trainer.py"
-            - "--data_dir=$(IMAGENET_DIR)"
-            - "--model_type=efficientnet"
-            - "--dataset=imagenet"
-            - "--mode=train_and_eval"
-            - "--model_dir=$(MODEL_DIR)"
+            - "official/vision/detection/main.py"
+            - "--model=mask_rcnn"
             - |
-              --params_override="evaluation":
-                "epochs_between_evals": 1
-              "runtime":
-                "num_gpus": 1
+              --params_override="architecture":
+                "use_bfloat16": false
+              "eval":
+                "batch_size": 16
+                "eval_file_pattern": "$(COCO_DIR)/val*"
+                "val_json_file": "$(COCO_DIR)/instances_val2017.json"
+              "postprocess":
+                "pre_nms_num_boxes": 1000
+              "predict":
+                "batch_size": 16
               "train":
-                "epochs": 1
-              "train_dataset":
-                "builder": "records"
-              "validation_dataset":
-                "builder": "records"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-gpu.yaml"
+                "batch_size": 16
+                "checkpoint":
+                  "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
+                  "prefix": "resnet50/"
+                "iterations_per_loop": 5000
+                "total_steps": 5625
+                "train_file_pattern": "$(COCO_DIR)/train*"
+            - "--model_dir=$(MODEL_DIR)"
+            - "--mode=train"
+            - "--num_gpus=4"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -64,16 +70,16 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/maskrcnn/conv/v100-x4/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/tensorflow:nightly"
+            "image": "gcr.io/xl-ml-test/tensorflow:r2.3"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "nvidia.com/gpu": 1
+                "nvidia.com/gpu": 4
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -93,7 +99,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/maskrcnn/conv/v100-x4/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -110,23 +116,9 @@
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
-                  "metric_success_conditions": {
-                   "examples_per_second_average": {
-                    "comparison": "greater_or_equal",
-                    "success_threshold": {
-                     "stddevs_from_mean": 2
-                    }
-                   },
-                   "total_wall_time": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   }
-                  }
+                  "alert_for_failed_jobs": false
                  },
-                 "test_name": "tf-nightly-efficientnet-func-v100-x1"
+                 "test_name": "tf-r2.3-maskrcnn-conv-v100-x4"
                 }
             "envFrom":
             - "configMapRef":
@@ -136,6 +128,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * *"
+  "schedule": "0 6 * * 0,5"
   "successfulJobsHistoryLimit": 1
-  "suspend": true

--- a/k8s/us-central1/gen/tf-r2.3-retinanet-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-retinanet-conv-v100-x4.yaml
@@ -15,39 +15,37 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-r2.3-classifier-resnet-func-k80-x1"
+  "name": "tf-r2.3-retinanet-conv-v100-x4"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 18000
+      "activeDeadlineSeconds": 36000
       "backoffLimit": 1
       "template":
         "spec":
           "containers":
           - "args":
             - "python3"
-            - "official/vision/image_classification/classifier_trainer.py"
-            - "--data_dir=$(IMAGENET_DIR)"
-            - "--model_type=resnet"
-            - "--dataset=imagenet"
-            - "--mode=train_and_eval"
-            - "--model_dir=$(MODEL_DIR)"
+            - "official/vision/detection/main.py"
             - |
-              --params_override="evaluation":
-                "epochs_between_evals": 3
-              "runtime":
-                "num_gpus": 1
+              --params_override="eval":
+                "batch_size": 16
+                "eval_file_pattern": "$(COCO_DIR)/val*"
+                "val_json_file": "$(COCO_DIR)/instances_val2017.json"
+              "predict":
+                "batch_size": 16
               "train":
-                "epochs": 3
-              "train_dataset":
-                "batch_size": 128
-                "builder": "records"
-              "validation_dataset":
-                "batch_size": 128
-                "builder": "records"
-            - "--config_file=official/vision/image_classification/configs/examples/resnet/imagenet/gpu.yaml"
+                "batch_size": 16
+                "checkpoint":
+                  "path": "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07"
+                  "prefix": "resnet50/"
+                "total_steps": 5625
+                "train_file_pattern": "$(COCO_DIR)/train*"
+            - "--model_dir=$(MODEL_DIR)"
+            - "--mode=train"
+            - "--num_gpus=4"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -66,7 +64,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-r2.3/classifier-resnet/func/k80-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/retinanet/conv/v100-x4/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
@@ -75,7 +73,7 @@
             "name": "train"
             "resources":
               "limits":
-                "nvidia.com/gpu": 1
+                "nvidia.com/gpu": 4
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -95,7 +93,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-r2.3/classifier-resnet/func/k80-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/retinanet/conv/v100-x4/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -112,23 +110,9 @@
                   "write_to_bigquery": true
                  },
                  "regression_test_config": {
-                  "metric_success_conditions": {
-                   "examples_per_second_average": {
-                    "comparison": "greater_or_equal",
-                    "success_threshold": {
-                     "stddevs_from_mean": 2
-                    }
-                   },
-                   "total_wall_time": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   }
-                  }
+                  "alert_for_failed_jobs": false
                  },
-                 "test_name": "tf-r2.3-classifier-resnet-func-k80-x1"
+                 "test_name": "tf-r2.3-retinanet-conv-v100-x4"
                 }
             "envFrom":
             - "configMapRef":
@@ -136,7 +120,7 @@
             "image": "gcr.io/xl-ml-test/publisher:stable"
             "name": "publisher"
           "nodeSelector":
-            "cloud.google.com/gke-accelerator": "nvidia-tesla-k80"
+            "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * *"
+  "schedule": "0 6 * * 0,5"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-transformer-translate-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-transformer-translate-conv-v100-x4.yaml
@@ -15,37 +15,31 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-nightly-efficientnet-func-v100-x1"
+  "name": "tf-r2.3-transformer-translate-conv-v100-x4"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 28800
+      "activeDeadlineSeconds": 36000
       "backoffLimit": 1
       "template":
         "spec":
           "containers":
           - "args":
             - "python3"
-            - "official/vision/image_classification/classifier_trainer.py"
-            - "--data_dir=$(IMAGENET_DIR)"
-            - "--model_type=efficientnet"
-            - "--dataset=imagenet"
-            - "--mode=train_and_eval"
+            - "official/nlp/transformer/transformer_main.py"
+            - "--param_set=big"
+            - "--max_length=64"
+            - "--data_dir=$(TRANSFORMER_DIR)"
+            - "--vocab_file=$(TRANSFORMER_DIR)/vocab.ende.32768"
+            - "--bleu_source=$(TRANSFORMER_DIR)/newstest2014.en"
+            - "--bleu_ref=$(TRANSFORMER_DIR)/newstest2014.de"
+            - "--enable_tensorboard"
             - "--model_dir=$(MODEL_DIR)"
-            - |
-              --params_override="evaluation":
-                "epochs_between_evals": 1
-              "runtime":
-                "num_gpus": 1
-              "train":
-                "epochs": 1
-              "train_dataset":
-                "builder": "records"
-              "validation_dataset":
-                "builder": "records"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-gpu.yaml"
+            - "--num_gpus=4"
+            - "--steps_between_evals=5000"
+            - "--train_steps=50000"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -64,16 +58,16 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/transformer-translate/conv/v100-x4/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/tensorflow:nightly"
+            "image": "gcr.io/xl-ml-test/tensorflow:r2.3"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "nvidia.com/gpu": 1
+                "nvidia.com/gpu": 4
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -93,7 +87,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/transformer-translate/conv/v100-x4/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -126,7 +120,7 @@
                    }
                   }
                  },
-                 "test_name": "tf-nightly-efficientnet-func-v100-x1"
+                 "test_name": "tf-r2.3-transformer-translate-conv-v100-x4"
                 }
             "envFrom":
             - "configMapRef":
@@ -136,6 +130,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * *"
+  "schedule": "0 6 * * 0,5"
   "successfulJobsHistoryLimit": 1
-  "suspend": true

--- a/k8s/us-central1/gen/tf-r2.3-transformer-translate-func-k80-x1.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-transformer-translate-func-k80-x1.yaml
@@ -40,7 +40,7 @@
             - "--num_gpus=1"
             - "--steps_between_evals=5000"
             - "--batch_size=2048"
-            - "--train_steps=10000"
+            - "--train_steps=5000"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-r2.3-transformer-translate-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-transformer-translate-func-k80-x8.yaml
@@ -41,7 +41,7 @@
             - "--steps_between_evals=5000"
             - "--batch_size=16384"
             - "--all_reduce_alg=hierarchical_copy"
-            - "--train_steps=10000"
+            - "--train_steps=5000"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-r2.3-transformer-translate-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-transformer-translate-func-v100-x1.yaml
@@ -40,7 +40,7 @@
             - "--num_gpus=1"
             - "--steps_between_evals=5000"
             - "--batch_size=4096"
-            - "--train_steps=10000"
+            - "--train_steps=5000"
             "env":
             - "name": "POD_NAME"
               "valueFrom":

--- a/k8s/us-central1/gen/tf-r2.3-transformer-translate-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-transformer-translate-func-v100-x4.yaml
@@ -15,37 +15,31 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "tf-nightly-efficientnet-func-v100-x1"
+  "name": "tf-r2.3-transformer-translate-func-v100-x4"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 28800
+      "activeDeadlineSeconds": 10800
       "backoffLimit": 1
       "template":
         "spec":
           "containers":
           - "args":
             - "python3"
-            - "official/vision/image_classification/classifier_trainer.py"
-            - "--data_dir=$(IMAGENET_DIR)"
-            - "--model_type=efficientnet"
-            - "--dataset=imagenet"
-            - "--mode=train_and_eval"
+            - "official/nlp/transformer/transformer_main.py"
+            - "--param_set=big"
+            - "--max_length=64"
+            - "--data_dir=$(TRANSFORMER_DIR)"
+            - "--vocab_file=$(TRANSFORMER_DIR)/vocab.ende.32768"
+            - "--bleu_source=$(TRANSFORMER_DIR)/newstest2014.en"
+            - "--bleu_ref=$(TRANSFORMER_DIR)/newstest2014.de"
+            - "--enable_tensorboard"
             - "--model_dir=$(MODEL_DIR)"
-            - |
-              --params_override="evaluation":
-                "epochs_between_evals": 1
-              "runtime":
-                "num_gpus": 1
-              "train":
-                "epochs": 1
-              "train_dataset":
-                "builder": "records"
-              "validation_dataset":
-                "builder": "records"
-            - "--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-gpu.yaml"
+            - "--num_gpus=4"
+            - "--steps_between_evals=5000"
+            - "--train_steps=5000"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -64,16 +58,16 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/transformer-translate/func/v100-x4/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/tensorflow:nightly"
+            "image": "gcr.io/xl-ml-test/tensorflow:r2.3"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "nvidia.com/gpu": 1
+                "nvidia.com/gpu": 4
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -93,7 +87,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/tf-nightly/efficientnet/func/v100-x1/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/tf-r2.3/transformer-translate/func/v100-x4/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -126,7 +120,7 @@
                    }
                   }
                  },
-                 "test_name": "tf-nightly-efficientnet-func-v100-x1"
+                 "test_name": "tf-r2.3-transformer-translate-func-v100-x4"
                 }
             "envFrom":
             - "configMapRef":
@@ -138,4 +132,3 @@
           "restartPolicy": "Never"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
-  "suspend": true

--- a/templates/mixins.libsonnet
+++ b/templates/mixins.libsonnet
@@ -35,4 +35,11 @@ local timeouts = import "timeouts.libsonnet";
       preemptible: true,
     },
   },
+  Suspended:: {
+    cronJob+:: {
+      spec+: {
+        suspend: true,
+      },
+    },
+  },
 }

--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -124,10 +124,10 @@ local gpus = import "templates/gpus.libsonnet";
   },
 
   configs: [
-    efficientnet + k80x8 + functional + timeouts.Hours(2),
+    efficientnet + k80x8 + functional + timeouts.Hours(4) + mixins.Suspended,
     efficientnet + k80x8 + convergence + mixins.Experimental,
-    efficientnet + v100 + functional + timeouts.Hours(8),
-    efficientnet + v100x4 + functional + timeouts.Hours(2),
+    efficientnet + v100 + functional + timeouts.Hours(8) + mixins.Suspended,
+    efficientnet + v100x4 + functional + timeouts.Hours(2) + mixins.Suspended,
     efficientnet + v100x4 + convergence + mixins.Experimental,
     efficientnet + v2_8 + functional,
     efficientnet + v3_8 + functional,

--- a/tests/tensorflow/nightly/classifier-resnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnet.libsonnet
@@ -49,10 +49,10 @@ local gpus = import "templates/gpus.libsonnet";
   local functional = mixins.Functional {
     paramsOverride+: {
       train+: {
-        epochs: 3, 
+        epochs: 1, 
       },
       evaluation+: {
-        epochs_between_evals: 3,
+        epochs_between_evals: 1,
       },
     },
   },
@@ -140,10 +140,10 @@ local gpus = import "templates/gpus.libsonnet";
   },
 
   configs: [
-    resnet + k80 + functional + timeouts.Hours(5),
-    resnet + k80x8 + functional + timeouts.Hours(4),
+    resnet + k80 + functional + timeouts.Hours(5) + mixins.Suspended,
+    resnet + k80x8 + functional + timeouts.Hours(4) + mixins.Suspended,
     resnet + k80x8 + convergence + mixins.Experimental,
-    resnet + v100 + functional + timeouts.Hours(3),
+    resnet + v100 + functional + timeouts.Hours(3) + mixins.Suspended,
     resnet + v100x4 + functional + mixins.Experimental,
     resnet + v100x4 + convergence + mixins.Experimental,
     resnet + v100x8 + functional + mixins.Experimental,

--- a/tests/tensorflow/nightly/maskrcnn.libsonnet
+++ b/tests/tensorflow/nightly/maskrcnn.libsonnet
@@ -181,10 +181,10 @@ local gpus = import "templates/gpus.libsonnet";
   },
 
   configs: [
-    maskrcnn + functional + k80x8,
+    maskrcnn + functional + k80x8 + mixins.Suspended,
     maskrcnn + convergence + k80x8 + mixins.Experimental,
-    maskrcnn + functional + v100,
-    maskrcnn + functional + v100x4,
+    maskrcnn + functional + v100 + mixins.Suspended,
+    maskrcnn + functional + v100x4 + mixins.Suspended,
     maskrcnn + convergence + v100x4 + mixins.Experimental,
     maskrcnn + functional + v2_8,
     maskrcnn + functional + v3_8,

--- a/tests/tensorflow/nightly/retinanet.libsonnet
+++ b/tests/tensorflow/nightly/retinanet.libsonnet
@@ -156,10 +156,10 @@ local gpus = import "templates/gpus.libsonnet";
   },
 
   configs: [
-    retinanet + functional + k80x8,
+    retinanet + functional + k80x8 + mixins.Suspended,
     retinanet + convergence + k80x8 + mixins.Experimental,
-    retinanet + functional + v100,
-    retinanet + functional + v100x4,
+    retinanet + functional + v100 + mixins.Suspended,
+    retinanet + functional + v100x4 + mixins.Suspended,
     retinanet + convergence + v100x4 + mixins.Experimental,
     retinanet + functional + v2_8,
     retinanet + functional + v3_8,

--- a/tests/tensorflow/nightly/transformer-translate.libsonnet
+++ b/tests/tensorflow/nightly/transformer-translate.libsonnet
@@ -124,10 +124,10 @@ local gpus = import "templates/gpus.libsonnet";
   },
 
   configs: [
-    transformer + k80 + functional_short + timeouts.Hours(6),
-    transformer + k80x8 + functional_short + timeouts.Hours(6),
+    transformer + k80 + functional_short + timeouts.Hours(6) + mixins.Suspended,
+    transformer + k80x8 + functional_short + timeouts.Hours(6) + mixins.Suspended,
     transformer + k80x8 + convergence + mixins.Experimental,
-    transformer + v100 + functional_short + timeouts.Hours(3),
+    transformer + v100 + functional_short + timeouts.Hours(3) + mixins.Suspended,
     transformer + v100x4 + functional_short + timeouts.Hours(3) + mixins.Experimental,
     transformer + v100x4 + convergence + mixins.Experimental,
     transformer + k80 + convergence  + mixins.Experimental,

--- a/tests/tensorflow/r2.3/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/r2.3/classifier-efficientnet.libsonnet
@@ -124,7 +124,7 @@ local gpus = import "templates/gpus.libsonnet";
   },
 
   configs: [
-    efficientnet + k80x8 + functional + timeouts.Hours(2),
+    efficientnet + k80x8 + functional + timeouts.Hours(4),
     efficientnet + k80x8 + convergence + mixins.Experimental,
     efficientnet + v100 + functional + timeouts.Hours(8),
     efficientnet + v100x4 + functional + timeouts.Hours(2),

--- a/tests/tensorflow/r2.3/classifier-resnet.libsonnet
+++ b/tests/tensorflow/r2.3/classifier-resnet.libsonnet
@@ -49,10 +49,10 @@ local gpus = import "templates/gpus.libsonnet";
   local functional = mixins.Functional {
     paramsOverride+: {
       train+: {
-        epochs: 3, 
+        epochs: 1, 
       },
       evaluation+: {
-        epochs_between_evals: 3,
+        epochs_between_evals: 1,
       },
     },
   },
@@ -140,12 +140,12 @@ local gpus = import "templates/gpus.libsonnet";
   },
 
   configs: [
-    resnet + k80 + functional + timeouts.Hours(5),
+    resnet + k80 + functional + timeouts.Hours(5) + mixins.Experimental,
     resnet + k80x8 + functional + timeouts.Hours(4),
     resnet + k80x8 + convergence + mixins.Experimental,
     resnet + v100 + functional + timeouts.Hours(3),
-    resnet + v100x4 + functional + mixins.Experimental,
-    resnet + v100x4 + convergence + mixins.Experimental,
+    resnet + v100x4 + functional,
+    resnet + v100x4 + convergence,
     resnet + v100x8 + functional + mixins.Experimental,
     resnet + v2_8 + functional,
     resnet + v3_8 + functional,

--- a/tests/tensorflow/r2.3/maskrcnn.libsonnet
+++ b/tests/tensorflow/r2.3/maskrcnn.libsonnet
@@ -185,7 +185,7 @@ local gpus = import "templates/gpus.libsonnet";
     maskrcnn + convergence + k80x8 + mixins.Experimental,
     maskrcnn + functional + v100,
     maskrcnn + functional + v100x4,
-    maskrcnn + convergence + v100x4 + mixins.Experimental,
+    maskrcnn + convergence + v100x4,
     maskrcnn + functional + v2_8,
     maskrcnn + functional + v3_8,
     maskrcnn + convergence + v2_8,

--- a/tests/tensorflow/r2.3/retinanet.libsonnet
+++ b/tests/tensorflow/r2.3/retinanet.libsonnet
@@ -160,7 +160,7 @@ local gpus = import "templates/gpus.libsonnet";
     retinanet + convergence + k80x8 + mixins.Experimental,
     retinanet + functional + v100,
     retinanet + functional + v100x4,
-    retinanet + convergence + v100x4 + mixins.Experimental,
+    retinanet + convergence + v100x4,
     retinanet + functional + v2_8,
     retinanet + functional + v3_8,
     retinanet + convergence + v2_8,

--- a/tests/tensorflow/r2.3/transformer-translate.libsonnet
+++ b/tests/tensorflow/r2.3/transformer-translate.libsonnet
@@ -41,7 +41,7 @@ local gpus = import "templates/gpus.libsonnet";
   },
   local functional_short = mixins.Functional {
     command+: [
-      "--train_steps=10000",
+      "--train_steps=5000",
     ],
   },
   local convergence = mixins.Convergence {
@@ -128,8 +128,8 @@ local gpus = import "templates/gpus.libsonnet";
     transformer + k80x8 + functional_short + timeouts.Hours(6),
     transformer + k80x8 + convergence + mixins.Experimental,
     transformer + v100 + functional_short + timeouts.Hours(3),
-    transformer + v100x4 + functional_short + timeouts.Hours(3) + mixins.Experimental,
-    transformer + v100x4 + convergence + mixins.Experimental,
+    transformer + v100x4 + functional_short + timeouts.Hours(3),
+    transformer + v100x4 + convergence,
     transformer + k80 + convergence  + mixins.Experimental,
     transformer + v100 + convergence  + mixins.Experimental,
     transformer + v2_8 + functional,


### PR DESCRIPTION
@aman2930 FYI

- Add option to suspend CronJobs. This lets us pause them without deleting the resource.
  - Temporarily suspend nightly TF GPU tests since 2.3 tests aren't scheduled consistently.
- Reduce the number of steps or increase time-out for tests that are timing-out.
- Enable some v100-x4 tests that were erroneously marked as experimental.
- Remove some extremely slow functional tests on single-k80.