### PR TITLE
Use preemptible TPU for TF nightly functional tests.

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
@@ -84,7 +84,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 32
+                "cloud-tpus.google.com/preemptible-v2": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
@@ -84,7 +84,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 32
+                "cloud-tpus.google.com/preemptible-v3": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
@@ -87,7 +87,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 32
+                "cloud-tpus.google.com/preemptible-v2": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
@@ -87,7 +87,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 32
+                "cloud-tpus.google.com/preemptible-v3": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
@@ -87,7 +87,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 32
+                "cloud-tpus.google.com/preemptible-v2": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
@@ -87,7 +87,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 32
+                "cloud-tpus.google.com/preemptible-v3": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
@@ -95,7 +95,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 32
+                "cloud-tpus.google.com/preemptible-v2": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
@@ -95,7 +95,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 32
+                "cloud-tpus.google.com/preemptible-v3": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
@@ -86,7 +86,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 32
+                "cloud-tpus.google.com/preemptible-v2": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
@@ -86,7 +86,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 32
+                "cloud-tpus.google.com/preemptible-v3": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
@@ -91,7 +91,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 32
+                "cloud-tpus.google.com/preemptible-v2": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
@@ -91,7 +91,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 32
+                "cloud-tpus.google.com/preemptible-v3": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
@@ -96,7 +96,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 32
+                "cloud-tpus.google.com/preemptible-v2": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
@@ -96,7 +96,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 32
+                "cloud-tpus.google.com/preemptible-v3": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
@@ -89,7 +89,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 32
+                "cloud-tpus.google.com/preemptible-v2": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
@@ -89,7 +89,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 32
+                "cloud-tpus.google.com/preemptible-v3": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-r2.3-bert-mnli-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-bert-mnli-conv-v2-32.yaml
@@ -147,5 +147,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-bert-mnli-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-bert-mnli-conv-v3-32.yaml
@@ -147,5 +147,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-classifier-efficientnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-classifier-efficientnet-conv-v2-32.yaml
@@ -156,5 +156,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-classifier-efficientnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-classifier-efficientnet-conv-v3-32.yaml
@@ -156,5 +156,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-classifier-resnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-classifier-resnet-conv-v2-32.yaml
@@ -156,5 +156,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-classifier-resnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-classifier-resnet-conv-v3-32.yaml
@@ -156,5 +156,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-maskrcnn-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-maskrcnn-conv-v2-32.yaml
@@ -158,5 +158,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-maskrcnn-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-maskrcnn-conv-v3-32.yaml
@@ -158,5 +158,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-resnet-ctl-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-resnet-ctl-conv-v2-32.yaml
@@ -149,5 +149,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-resnet-ctl-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-resnet-ctl-conv-v3-32.yaml
@@ -149,5 +149,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-retinanet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-retinanet-conv-v2-32.yaml
@@ -154,5 +154,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-retinanet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-retinanet-conv-v3-32.yaml
@@ -154,5 +154,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-shapemask-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-shapemask-conv-v2-32.yaml
@@ -159,5 +159,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-shapemask-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-shapemask-conv-v3-32.yaml
@@ -159,5 +159,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-transformer-translate-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-transformer-translate-conv-v2-32.yaml
@@ -152,5 +152,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r2.3-transformer-translate-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3-transformer-translate-conv-v3-32.yaml
@@ -152,5 +152,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
@@ -84,7 +84,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
@@ -84,7 +84,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
@@ -86,7 +86,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
@@ -86,7 +86,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
@@ -87,7 +87,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
@@ -87,7 +87,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
@@ -87,7 +87,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
@@ -87,7 +87,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
@@ -95,7 +95,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
@@ -95,7 +95,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
@@ -77,7 +77,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
@@ -77,7 +77,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
@@ -86,7 +86,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
@@ -86,7 +86,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
@@ -91,7 +91,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
@@ -91,7 +91,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
@@ -96,7 +96,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
@@ -96,7 +96,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
@@ -89,7 +89,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v2": 8
+                "cloud-tpus.google.com/preemptible-v2": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
@@ -89,7 +89,7 @@
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/preemptible-v3": 8
           "initContainers":
           - "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-r2.3-bert-mnli-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-bert-mnli-conv-v2-8.yaml
@@ -147,5 +147,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-bert-mnli-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-bert-mnli-conv-v3-8.yaml
@@ -147,5 +147,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-bert-squad-conv-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-bert-squad-conv-k80-x8.yaml
@@ -133,5 +133,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-k80"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-bert-squad-conv-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-bert-squad-conv-v100-x1.yaml
@@ -132,5 +132,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-bert-squad-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-bert-squad-conv-v100-x4.yaml
@@ -132,5 +132,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-efficientnet-conv-v2-8.yaml
@@ -156,5 +156,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-efficientnet-conv-v3-8.yaml
@@ -156,5 +156,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-classifier-resnet-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-resnet-conv-v100-x4.yaml
@@ -142,5 +142,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-classifier-resnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-resnet-conv-v2-8.yaml
@@ -156,5 +156,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-classifier-resnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-classifier-resnet-conv-v3-8.yaml
@@ -156,5 +156,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-maskrcnn-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-maskrcnn-conv-v100-x4.yaml
@@ -128,5 +128,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-maskrcnn-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-maskrcnn-conv-v2-8.yaml
@@ -158,5 +158,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-maskrcnn-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-maskrcnn-conv-v3-8.yaml
@@ -158,5 +158,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-mnist-conv-v2-8.yaml
@@ -140,5 +140,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-mnist-conv-v3-8.yaml
@@ -140,5 +140,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-resnet-ctl-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-resnet-ctl-conv-v2-8.yaml
@@ -149,5 +149,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-resnet-ctl-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-resnet-ctl-conv-v3-8.yaml
@@ -149,5 +149,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-retinanet-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-retinanet-conv-v100-x4.yaml
@@ -122,5 +122,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-retinanet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-retinanet-conv-v2-8.yaml
@@ -154,5 +154,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-retinanet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-retinanet-conv-v3-8.yaml
@@ -154,5 +154,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-shapemask-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-shapemask-conv-v2-8.yaml
@@ -159,5 +159,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-shapemask-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-shapemask-conv-v3-8.yaml
@@ -159,5 +159,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-transformer-translate-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-transformer-translate-conv-v100-x4.yaml
@@ -130,5 +130,5 @@
           "nodeSelector":
             "cloud.google.com/gke-accelerator": "nvidia-tesla-v100"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-transformer-translate-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-transformer-translate-conv-v2-8.yaml
@@ -152,5 +152,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/tf-r2.3-transformer-translate-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3-transformer-translate-conv-v3-8.yaml
@@ -152,5 +152,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 8 * * 0"
   "successfulJobsHistoryLimit": 1

--- a/templates/mixins.libsonnet
+++ b/templates/mixins.libsonnet
@@ -20,6 +20,9 @@ local timeouts = import "timeouts.libsonnet";
     timeout: timeouts.one_hour,
     # Run at midnight PST daily
     schedule: "0 8 * * *",
+    tpuSettings+: {
+      preemptible: true,
+    },
   },
   Convergence:: {
     mode: "conv",

--- a/templates/tpus.libsonnet
+++ b/templates/tpus.libsonnet
@@ -23,7 +23,6 @@ local base = import 'base.libsonnet';
     version: error "Must override `version`",
     size: error "Must override `size`",
     replicas: tpu.size / 8, # Each TPU replica has 8 cores
-    preemptible: false,
 
     PodTemplate(tpuSettings):: {
       metadata: {

--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -34,7 +34,7 @@ local volumes = import "templates/volumes.libsonnet";
   Functional:: mixins.Functional {
     # Run at 11AM PST daily.
     schedule: "0 19 * * *",
-    accelerator+: {
+    tpuSettings+: {
       preemptible: false,
     },
   },

--- a/tests/pytorch/r1.5/common.libsonnet
+++ b/tests/pytorch/r1.5/common.libsonnet
@@ -26,7 +26,7 @@ local volumes = import "templates/volumes.libsonnet";
   },
   Functional:: mixins.Functional {
     schedule: "0 23 * * *",
-    accelerator+: {
+    tpuSettings+: {
       preemptible: false,
     },
   },

--- a/tests/tensorflow/r2.3/bert-mnli.libsonnet
+++ b/tests/tensorflow/r2.3/bert-mnli.libsonnet
@@ -35,12 +35,12 @@ local tpus = import "templates/tpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       '--num_train_epochs=1',
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       '--num_train_epochs=6',
     ],

--- a/tests/tensorflow/r2.3/bert-squad.libsonnet
+++ b/tests/tensorflow/r2.3/bert-squad.libsonnet
@@ -32,13 +32,13 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--mode=train",
       "--num_train_epochs=1",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       "--num_train_epochs=2",
     ],

--- a/tests/tensorflow/r2.3/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/r2.3/classifier-efficientnet.libsonnet
@@ -46,7 +46,7 @@ local gpus = import "templates/gpus.libsonnet";
       "--params_override=%s" % std.manifestYamlDoc(self.paramsOverride) + "\n",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     paramsOverride+: {
       train+: {
         epochs: 1,
@@ -56,7 +56,7 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     paramsOverride+: {
       train+: {
         epochs: 350,

--- a/tests/tensorflow/r2.3/classifier-resnet.libsonnet
+++ b/tests/tensorflow/r2.3/classifier-resnet.libsonnet
@@ -46,7 +46,7 @@ local gpus = import "templates/gpus.libsonnet";
       "--params_override=%s" % std.manifestYamlDoc(self.paramsOverride) + "\n",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     paramsOverride+: {
       train+: {
         epochs: 1, 
@@ -56,7 +56,7 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     paramsOverride+: {
       train+: {
         epochs: 90, 

--- a/tests/tensorflow/r2.3/common.libsonnet
+++ b/tests/tensorflow/r2.3/common.libsonnet
@@ -40,6 +40,11 @@ local mixins = import "templates/mixins.libsonnet";
       },
     },
   },
+  Functional:: mixins.Functional {
+    tpuSettings+: {
+      preemptible: false,
+    },
+  },
   # Running convergence test once a week.
   Convergence:: mixins.Convergence {
     schedule: "0 8 * * 0",

--- a/tests/tensorflow/r2.3/maskrcnn.libsonnet
+++ b/tests/tensorflow/r2.3/maskrcnn.libsonnet
@@ -48,7 +48,7 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--mode=train",
     ],
@@ -58,7 +58,7 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     local config = self,
 
     command+: [

--- a/tests/tensorflow/r2.3/mnist.libsonnet
+++ b/tests/tensorflow/r2.3/mnist.libsonnet
@@ -27,13 +27,13 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--train_epochs=1",
       "--epochs_between_evals=1",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       "--train_epochs=10",
       "--epochs_between_evals=10",

--- a/tests/tensorflow/r2.3/resnet-ctl.libsonnet
+++ b/tests/tensorflow/r2.3/resnet-ctl.libsonnet
@@ -37,13 +37,13 @@ local tpus = import "templates/tpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--train_epochs=1",
       "--epochs_between_evals=1",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       "--train_epochs=90",
       "--epochs_between_evals=90",

--- a/tests/tensorflow/r2.3/retinanet.libsonnet
+++ b/tests/tensorflow/r2.3/retinanet.libsonnet
@@ -49,7 +49,7 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--mode=train",
     ],
@@ -59,7 +59,7 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     local config = self,
 
     command+: [

--- a/tests/tensorflow/r2.3/shapemask.libsonnet
+++ b/tests/tensorflow/r2.3/shapemask.libsonnet
@@ -57,7 +57,7 @@ local tpus = import "templates/tpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--mode=train",
     ],
@@ -67,7 +67,7 @@ local tpus = import "templates/tpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       "--mode=train",
     ],

--- a/tests/tensorflow/r2.3/transformer-translate.libsonnet
+++ b/tests/tensorflow/r2.3/transformer-translate.libsonnet
@@ -34,17 +34,17 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--train_steps=20000",
     ],
   },
-  local functional_short = mixins.Functional {
+  local functional_short = common.Functional {
     command+: [
       "--train_steps=5000",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     local config = self,
 
     command+: [


### PR DESCRIPTION
TF tests are currently crowding out the PyTorch functional tests since they share a resource limit for on-demand TPUs. Move nightly TF tests back to preemptible TPUs while we're running stable TF 2.3 tests. Also fix deprecated references to `accelerator.preemptible` and `schedule` in TF 2.3 tests.

This may increase flakiness for TF nightly tests.