### PR TITLE
Remove steps_per_loop from ResNet CTL test. This fixes the current breakage.

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v2-32.yaml
@@ -47,7 +47,6 @@
             - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--distribution_strategy=tpu"
-            - "--steps_per_loop=500"
             - "--use_synthetic_data=false"
             - "--dtype=fp32"
             - "--enable_eager=true"

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v3-32.yaml
@@ -47,7 +47,6 @@
             - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--distribution_strategy=tpu"
-            - "--steps_per_loop=500"
             - "--use_synthetic_data=false"
             - "--dtype=fp32"
             - "--enable_eager=true"

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
@@ -47,7 +47,6 @@
             - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--distribution_strategy=tpu"
-            - "--steps_per_loop=500"
             - "--use_synthetic_data=false"
             - "--dtype=fp32"
             - "--enable_eager=true"

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
@@ -47,7 +47,6 @@
             - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--distribution_strategy=tpu"
-            - "--steps_per_loop=500"
             - "--use_synthetic_data=false"
             - "--dtype=fp32"
             - "--enable_eager=true"

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v2-8.yaml
@@ -47,7 +47,6 @@
             - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--distribution_strategy=tpu"
-            - "--steps_per_loop=500"
             - "--use_synthetic_data=false"
             - "--dtype=fp32"
             - "--enable_eager=true"

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v3-8.yaml
@@ -47,7 +47,6 @@
             - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--distribution_strategy=tpu"
-            - "--steps_per_loop=500"
             - "--use_synthetic_data=false"
             - "--dtype=fp32"
             - "--enable_eager=true"

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
@@ -47,7 +47,6 @@
             - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--distribution_strategy=tpu"
-            - "--steps_per_loop=500"
             - "--use_synthetic_data=false"
             - "--dtype=fp32"
             - "--enable_eager=true"

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
@@ -47,7 +47,6 @@
             - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
             - "--data_dir=$(IMAGENET_DIR)"
             - "--distribution_strategy=tpu"
-            - "--steps_per_loop=500"
             - "--use_synthetic_data=false"
             - "--dtype=fp32"
             - "--enable_eager=true"

--- a/tests/tensorflow/nightly/resnet-ctl.libsonnet
+++ b/tests/tensorflow/nightly/resnet-ctl.libsonnet
@@ -26,7 +26,6 @@ local tpus = import "templates/tpus.libsonnet";
       "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)",
       "--data_dir=$(IMAGENET_DIR)",
       "--distribution_strategy=tpu",
-      "--steps_per_loop=500",
       "--use_synthetic_data=false",
       "--dtype=fp32",
       "--enable_eager=true",


### PR DESCRIPTION
Couldn't run the test manually because I kept running into BackoffLimitExceeded. This fixes on BCT though and shouldn't break on XLML.

https://github.com/tensorflow/models/commit/81cf6368adc15091c5fe0abdf2267b2699e03c95 for context