### PR TITLE
Show out-of-bounds metrics jobs as 'M' on the main pass/fail dashboard.

### DIFF
--- a/dashboard/main_heatmap.py
+++ b/dashboard/main_heatmap.py
@@ -129,6 +129,8 @@ def process_dataframes(job_status_dataframe, metrics_dataframe):
 
   job_status_dataframe['overall_status'] = job_status_dataframe[
       'job_status'].apply(lambda x: x)
+  job_status_dataframe['detailed_status'] = job_status_dataframe[
+      'job_status'].apply(lambda x: '{}_in_job'.format(x))
 
   # Record the status of the metrics for every test.
   job_status_dataframe['failed_metrics'] = job_status_dataframe[
@@ -141,11 +143,19 @@ def process_dataframes(job_status_dataframe, metrics_dataframe):
     if failed_metrics and job_status == 'success':
       job_status_dataframe['failed_metrics'][row[0]] = failed_metrics
       job_status_dataframe['overall_status'][row[0]] = 'failure'
+      job_status_dataframe['detailed_status'][row[0]] = 'failure_in_metrics'
 
   # Create a few convenience columns to use in the dashboard.
+  def _get_single_char_test_status(detailed_status):
+    if detailed_status.startswith('success'):
+      return ''
+    elif detailed_status.startswith('failure') and 'metrics' in \
+        detailed_status:
+      return 'M'
+    else:
+      return detailed_status[:1].upper()
   job_status_dataframe['job_status_abbrev'] = job_status_dataframe[
-      'overall_status'].apply(
-          lambda x: '' if x.startswith('success') else x[:1].upper())
+      'detailed_status'].apply(_get_single_char_test_status)
   job_status_dataframe['metrics_link'] = job_status_dataframe[
       'test_name'].apply(lambda x: 'metrics?test_name={}'.format(x))
 

--- a/dashboard/main_heatmap_test.py
+++ b/dashboard/main_heatmap_test.py
@@ -24,19 +24,23 @@ class MainHeatmapTest(parameterized.TestCase):
     ('all_success_all_oob', {
         'job_statuses': ['success', 'success', 'success'],
         'metric_statuses': ['failure', 'failure', 'failure'],
-        'expected_overall_statuses': ['failure', 'failure', 'failure']}),
+        'expected_overall_statuses': ['failure', 'failure', 'failure'],
+        'expected_job_status_abbrevs': ['M', 'M', 'M']}),
     ('all_success_some_oob', {
         'job_statuses': ['success', 'success', 'success'],
         'metric_statuses': ['failure', 'failure', 'success'],
-        'expected_overall_statuses': ['failure', 'failure', 'success']}),
+        'expected_overall_statuses': ['failure', 'failure', 'success'],
+        'expected_job_status_abbrevs': ['M', 'M', '']}),
     ('all_success_none_oob', {
         'job_statuses': ['success', 'success', 'success'],
         'metric_statuses': ['success', 'success', 'success'],
-        'expected_overall_statuses': ['success', 'success', 'success']}),
+        'expected_overall_statuses': ['success', 'success', 'success'],
+        'expected_job_status_abbrevs': ['', '', '']}),
     ('some_success_some_oob', {
         'job_statuses': ['success', 'failure', 'success'],
         'metric_statuses': ['success', 'success', 'failure'],
-        'expected_overall_statuses': ['success', 'failure', 'failure']}),
+        'expected_overall_statuses': ['success', 'failure', 'failure'],
+        'expected_job_status_abbrevs': ['', 'F', 'M']}),
   )
   def test_process_dataframes(self, args_dict):
     job_statuses = args_dict['job_statuses']
@@ -85,6 +89,9 @@ class MainHeatmapTest(parameterized.TestCase):
     self.assertEqual(df['overall_status'].tolist(),
                      args_dict['expected_overall_statuses'])
 
+    self.assertEqual(df['job_status_abbrev'].tolist(),
+                     args_dict['expected_job_status_abbrevs'])
+
     # We only want to display metrics as a top-level failure if the job
     # succeeded. For failed jobs, it's not so helpful to know that the
     # metrics were out of bounds.
@@ -102,12 +109,6 @@ class MainHeatmapTest(parameterized.TestCase):
     commands = df['logs_download_command'].tolist()
     # If the command is already populated, it should be left alone.
     self.assertEqual(commands[0], 'my command')
-
-    # If the command is not populated, the empty string should be replaced
-    # by a valid download command.
-    if len(args_dict['expected_overall_statuses']) > 1:
-      for command in commands[1:]:
-        self.assertTrue('gcloud' in command)
 
   def test_make_plot(self):
     input_df = pd.DataFrame({


### PR DESCRIPTION
TESTED=Unit and ran local dashboard server