### PR TITLE
Remove Tensorboard logging from Fairseq Transformer test.

### DIFF
--- a/k8s/us-central1/gen/pt-nightly-fs-checkpoint-gcs-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-checkpoint-gcs-func-v3-8.yaml
@@ -52,7 +52,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --metrics_debug \
                 --arch=transformer_vaswani_wmt_en_de_big \
                 --max-target-positions=64 \
@@ -86,7 +85,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --metrics_debug \
                 --arch=transformer_vaswani_wmt_en_de_big \
                 --max-target-positions=64 \

--- a/k8s/us-central1/gen/pt-nightly-fs-checkpoint-local-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-checkpoint-local-func-v3-8.yaml
@@ -52,7 +52,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --metrics_debug \
                 --arch=transformer_vaswani_wmt_en_de_big \
                 --max-target-positions=64 \
@@ -85,7 +84,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --metrics_debug \
                 --arch=transformer_vaswani_wmt_en_de_big \
                 --max-target-positions=64 \

--- a/k8s/us-central1/gen/pt-nightly-fs-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-transformer-conv-v3-8.yaml
@@ -53,7 +53,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --metrics_debug \
                 --arch=transformer_vaswani_wmt_en_de_big \
                 --max-target-positions=64 \

--- a/k8s/us-central1/gen/pt-nightly-fs-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-transformer-func-v3-8.yaml
@@ -52,7 +52,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --metrics_debug \
                 --arch=transformer_vaswani_wmt_en_de_big \
                 --max-target-positions=64 \

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -22,7 +22,6 @@ local utils = import "templates/utils.libsonnet";
     python3 \
       /tpu-examples/deps/fairseq/train.py \
       /datasets/wmt18_en_de_bpej32k \
-      --tensorboard-logdir=$(MODEL_DIR) \
       --metrics_debug \
       --arch=transformer_vaswani_wmt_en_de_big \
       --max-target-positions=64 \


### PR DESCRIPTION
This logging was causing the test to freeze. Filed a bug to re-enable the logging