### PR TITLE
Disable Tensorboard for Pytorch Roberta pretraining test.

### DIFF
--- a/k8s/us-central1/gen/pt-nightly-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-roberta-pre-conv-v3-8.yaml
@@ -53,7 +53,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wikitext-103 \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --task=masked_lm --criterion=masked_lm \
                 --arch=roberta_base --sample-break-mode=complete \
                 --tokens-per-sample=512 \

--- a/k8s/us-central1/gen/pt-nightly-roberta-pre-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-roberta-pre-func-v3-8.yaml
@@ -53,7 +53,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wikitext-103 \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --task=masked_lm --criterion=masked_lm \
                 --arch=roberta_base --sample-break-mode=complete \
                 --tokens-per-sample=512 \

--- a/tests/pytorch/nightly/roberta-pre.libsonnet
+++ b/tests/pytorch/nightly/roberta-pre.libsonnet
@@ -29,7 +29,6 @@ local utils = import "templates/utils.libsonnet";
         python3 \
           /tpu-examples/deps/fairseq/train.py \
           /datasets/wikitext-103 \
-          --tensorboard-logdir=$(MODEL_DIR) \
           --task=masked_lm --criterion=masked_lm \
           --arch=roberta_base --sample-break-mode=complete \
           --tokens-per-sample=512 \


### PR DESCRIPTION
Was seeing the same issue for this fairseq roberta test that I saw with fairseq transformer: https://b.corp.google.com/issues/162248420

Training just gets stuck at some point, though the amount of time until getting stuck is variable.

I have a bug to re-enable Tensorboard later but for now neither this nor the transformer test was using any alerts based on Tensorboard metrics