### PR TITLE
Adjust timing of pytorch nightly tests.

### DIFF
--- a/k8s/europe-west4/gen/pt-nightly-mnist-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-mnist-conv-v2-32.yaml
@@ -167,5 +167,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 18 * * *"
+  "schedule": "0 17 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/pt-nightly-mnist-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-mnist-conv-v3-32.yaml
@@ -167,5 +167,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 18 * * *"
+  "schedule": "0 17 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/pt-nightly-resnet50-mp-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-resnet50-mp-func-v3-32.yaml
@@ -167,5 +167,5 @@
             "tpu-available": "true"
           "restartPolicy": "Never"
           "serviceAccountName": "pytorch-xla-pods"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v2-8.yaml
@@ -174,5 +174,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 18 * * *"
+  "schedule": "30 16 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v3-8.yaml
@@ -174,5 +174,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 18 * * *"
+  "schedule": "30 16 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v2-8.yaml
@@ -172,5 +172,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 18 * * *"
+  "schedule": "0 16 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v3-8.yaml
@@ -172,5 +172,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 18 * * *"
+  "schedule": "0 16 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-cpp-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cpp-ops-func-v2-8.yaml
@@ -128,5 +128,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-cpp-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cpp-ops-func-v3-8.yaml
@@ -128,5 +128,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-dlrm-mp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-mp-fwd-func-v3-8.yaml
@@ -198,5 +198,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-dlrm-mpdp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-mpdp-fwd-func-v3-8.yaml
@@ -198,5 +198,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-dlrm-onecore-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-onecore-func-v3-8.yaml
@@ -198,5 +198,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-dlrm-seq-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-seq-fwd-func-v3-8.yaml
@@ -198,5 +198,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-fs-checkpoint-gcs-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-checkpoint-gcs-func-v3-8.yaml
@@ -244,5 +244,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-fs-checkpoint-local-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-checkpoint-local-func-v3-8.yaml
@@ -241,5 +241,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-fs-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-transformer-func-v3-8.yaml
@@ -208,5 +208,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v2-8.yaml
@@ -172,5 +172,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 18 * * *"
+  "schedule": "30 17 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v3-8.yaml
@@ -172,5 +172,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 18 * * *"
+  "schedule": "30 17 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-conv-v2-8.yaml
@@ -172,5 +172,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 18 * * *"
+  "schedule": "0 17 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-conv-v3-8.yaml
@@ -172,5 +172,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 18 * * *"
+  "schedule": "0 17 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-python-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-python-ops-func-v2-8.yaml
@@ -128,5 +128,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-python-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-python-ops-func-v3-8.yaml
@@ -128,5 +128,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-resnet50-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-resnet50-func-v3-8.yaml
@@ -178,5 +178,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v3-8.yaml
@@ -178,5 +178,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-nightly-roberta-pre-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-roberta-pre-func-v3-8.yaml
@@ -170,5 +170,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 19 * * *"
+  "schedule": "0 18 * * *"
   "successfulJobsHistoryLimit": 1

--- a/tests/pytorch/nightly/cifar-inline.libsonnet
+++ b/tests/pytorch/nightly/cifar-inline.libsonnet
@@ -29,7 +29,7 @@ local tpus = import "templates/tpus.libsonnet";
   },
   local convergence = common.Convergence {
     # Run daily instead of 2x per week since convergence is fast.
-    schedule: "0 18 * * *",
+    schedule: "30 16 * * *",
     regressionTestConfig+: {
       metric_success_conditions+: {
         "Accuracy/test_final": {

--- a/tests/pytorch/nightly/cifar-tv.libsonnet
+++ b/tests/pytorch/nightly/cifar-tv.libsonnet
@@ -30,7 +30,7 @@ local tpus = import "templates/tpus.libsonnet";
   },
   local convergence = common.Convergence {
     # Run daily instead of 2x per week since convergence is fast.
-    schedule: "0 18 * * *",
+    schedule: "0 16 * * *",
     regressionTestConfig: {
       metric_subset_to_alert: [
         "ExecuteTime__Percentile_99_sec_final",

--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -39,8 +39,7 @@ local volumes = import "templates/volumes.libsonnet";
     imageTag: "nightly",
   },
   Functional:: mixins.Functional {
-    # Run at 11AM PST daily.
-    schedule: "0 19 * * *",
+    schedule: "0 18 * * *",
     tpuSettings+: {
       preemptible: false,
     },

--- a/tests/pytorch/nightly/mnist-3-7.libsonnet
+++ b/tests/pytorch/nightly/mnist-3-7.libsonnet
@@ -30,7 +30,7 @@ local tpus = import "templates/tpus.libsonnet";
 
   local convergence = common.Convergence {
     # Run daily instead of 2x per week since convergence is fast.
-    schedule: "0 18 * * *",
+    schedule: "30 17 * * *",
     regressionTestConfig+: {
       metric_success_conditions+: {
         "Accuracy/test_final": {

--- a/tests/pytorch/nightly/mnist.libsonnet
+++ b/tests/pytorch/nightly/mnist.libsonnet
@@ -37,7 +37,7 @@ local tpus = import "templates/tpus.libsonnet";
 
   local convergence = common.Convergence {
     # Run daily instead of 2x per week since convergence is fast.
-    schedule: "0 18 * * *",
+    schedule: "0 17 * * *",
     regressionTestConfig+: {
       metric_success_conditions+: {
         "Accuracy/test_final": {


### PR DESCRIPTION
Get lots of timeouts / spurious failures for these 8 pt-nightly tests:

1. cifar-tv v2-8
2. cifar-tv v3-8
3. cifar-inline v2-8
4. cifar-inline v3-8
5. mnist v2-8
6. mnist v3-8
7. mnist on python3.7 v2-8
8. mnist on python3.7 v3-8

All of these tests are pretty fast, so I wanted to try staggering their start times a bit to see if we get fewer cases of TPUs failing to become healthy.

Adjust other tests too since 18:00 UTC was now open