### PR TITLE
Fewer epochs for resnet50 pytorch functional test.

### DIFF
--- a/k8s/europe-west4/gen/pt-1.6-resnet50-mp-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-resnet50-mp-func-v3-32.yaml
@@ -45,6 +45,7 @@
             - "python3"
             - "/pytorch/xla/test/test_train_mp_imagenet.py"
             - "--fake_data"
+            - "--num_epochs=5"
             "command":
             - "python3"
             - "launch_k8s_workers.py"

--- a/k8s/europe-west4/gen/pt-nightly-resnet50-mp-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-resnet50-mp-func-v3-32.yaml
@@ -45,6 +45,7 @@
             - "python3"
             - "/pytorch/xla/test/test_train_mp_imagenet.py"
             - "--fake_data"
+            - "--num_epochs=5"
             "command":
             - "python3"
             - "launch_k8s_workers.py"

--- a/tests/pytorch/nightly/resnet50-pod.libsonnet
+++ b/tests/pytorch/nightly/resnet50-pod.libsonnet
@@ -28,6 +28,7 @@ local mixins = import "templates/mixins.libsonnet";
   local functional = common.Functional {
     command+: [
       "--fake_data",
+      "--num_epochs=5",
     ],
 
     workerCpu: "8",

--- a/tests/pytorch/r1.6/resnet50-pod.libsonnet
+++ b/tests/pytorch/r1.6/resnet50-pod.libsonnet
@@ -28,6 +28,7 @@ local mixins = import "templates/mixins.libsonnet";
   local functional = common.Functional {
     command+: [
       "--fake_data",
+      "--num_epochs=5",
     ],
 
     workerCpu: "8",


### PR DESCRIPTION
These tests will change from 18 epochs to 5.

These functional tests are not asserting on `accuracy` so this should not cause any metrics alerts to fire