### PR TITLE
Stagger pytorch 1.6 test start times.

### DIFF
--- a/k8s/europe-west4/gen/pt-1.6-resnet50-mp-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-resnet50-mp-conv-v3-32.yaml
@@ -176,5 +176,5 @@
             "tpu-available": "true"
           "restartPolicy": "Never"
           "serviceAccountName": "pytorch-xla-pods"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-fs-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-fs-transformer-conv-v3-8.yaml
@@ -224,5 +224,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v2-8.yaml
@@ -216,5 +216,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v3-8.yaml
@@ -216,5 +216,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-distilbert-b-uc-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-distilbert-b-uc-conv-v3-8.yaml
@@ -216,5 +216,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-roberta-l-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-roberta-l-conv-v3-8.yaml
@@ -216,5 +216,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-xlnet-l-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-xlnet-l-c-conv-v3-8.yaml
@@ -216,5 +216,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v2-8.yaml
@@ -172,5 +172,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 1 * * *"
+  "schedule": "30 1 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v3-8.yaml
@@ -172,5 +172,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 1 * * *"
+  "schedule": "30 1 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-resnet50-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-resnet50-conv-v3-8.yaml
@@ -184,5 +184,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-resnet50-mp-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-resnet50-mp-conv-v3-8.yaml
@@ -184,5 +184,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-1.6-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-roberta-pre-conv-v3-8.yaml
@@ -207,5 +207,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 2 * * 2,4"
+  "schedule": "30 2 * * 2,4"
   "successfulJobsHistoryLimit": 1

--- a/tests/pytorch/r1.6/common.libsonnet
+++ b/tests/pytorch/r1.6/common.libsonnet
@@ -46,8 +46,8 @@ local volumes = import "templates/volumes.libsonnet";
     },
   },
   Convergence:: mixins.Convergence {
-    # Run at 2:00 UTC on Tuesday and Friday.
-    schedule: "0 2 * * 2,4",
+    # Run at 2:30 UTC on Tuesday and Friday.
+    schedule: "30 2 * * 2,4",
   },
   datasetsVolume: volumes.PersistentVolumeSpec {
     name: "pytorch-datasets-claim",

--- a/tests/pytorch/r1.6/mnist-3-7.libsonnet
+++ b/tests/pytorch/r1.6/mnist-3-7.libsonnet
@@ -30,7 +30,7 @@ local tpus = import "templates/tpus.libsonnet";
 
   local convergence = common.Convergence {
     # Run daily instead of 2x per week since convergence is fast.
-    schedule: "0 1 * * *",
+    schedule: "30 1 * * *",
     regressionTestConfig+: {
       metric_success_conditions+: {
         "Accuracy/test_final": {


### PR DESCRIPTION
Reduce the number of jobs starting up at the same time. I feel like this cuts down on cases where tests fail due to TPU never starting up