### PR TITLE
Relax throughput bounds on TF nightly functional tests.

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
@@ -132,7 +132,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
@@ -132,7 +132,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
@@ -135,7 +135,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
@@ -135,7 +135,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
@@ -135,7 +135,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
@@ -135,7 +135,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
@@ -143,7 +143,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
@@ -143,7 +143,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-ncf-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-ncf-func-v3-32.yaml
@@ -139,7 +139,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
@@ -133,7 +133,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
@@ -133,7 +133,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
@@ -139,7 +139,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
@@ -139,7 +139,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
@@ -157,7 +157,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
@@ -157,7 +157,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
@@ -137,7 +137,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
@@ -137,7 +137,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
@@ -132,7 +132,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
@@ -132,7 +132,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-k80-x8.yaml
@@ -119,7 +119,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x1.yaml
@@ -118,7 +118,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x4.yaml
@@ -118,7 +118,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
@@ -134,7 +134,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
@@ -134,7 +134,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
@@ -135,7 +135,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
@@ -135,7 +135,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x1.yaml
@@ -123,7 +123,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-k80-x8.yaml
@@ -124,7 +124,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x1.yaml
@@ -121,7 +121,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
@@ -135,7 +135,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
@@ -135,7 +135,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-k80-x8.yaml
@@ -122,7 +122,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x1.yaml
@@ -121,7 +121,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-func-v100-x4.yaml
@@ -121,7 +121,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-k80-x8.yaml
@@ -128,7 +128,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x1.yaml
@@ -127,7 +127,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v100-x4.yaml
@@ -127,7 +127,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
@@ -143,7 +143,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
@@ -143,7 +143,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v100-x1.yaml
@@ -109,7 +109,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
@@ -125,7 +125,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
@@ -125,7 +125,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-k80-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-k80-x1.yaml
@@ -124,7 +124,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-k80-x8.yaml
@@ -124,7 +124,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-v100-x1.yaml
@@ -124,7 +124,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-v100-x4.yaml
@@ -124,7 +124,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-v2-8.yaml
@@ -139,7 +139,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
@@ -133,7 +133,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
@@ -133,7 +133,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-k80-x8.yaml
@@ -122,7 +122,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
@@ -139,7 +139,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
@@ -139,7 +139,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
@@ -157,7 +157,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
@@ -157,7 +157,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x1.yaml
@@ -116,7 +116,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-k80-x8.yaml
@@ -117,7 +117,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v100-x1.yaml
@@ -116,7 +116,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
@@ -137,7 +137,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
@@ -137,7 +137,7 @@
                    "examples_per_second_average": {
                     "comparison": "greater_or_equal",
                     "success_threshold": {
-                     "stddevs_from_mean": 2
+                     "stddevs_from_mean": 4
                     }
                    },
                    "total_wall_time": {

--- a/tests/tensorflow/nightly/bert-mnli.libsonnet
+++ b/tests/tensorflow/nightly/bert-mnli.libsonnet
@@ -35,12 +35,12 @@ local tpus = import "templates/tpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       '--num_train_epochs=1',
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       '--num_train_epochs=6',
     ],

--- a/tests/tensorflow/nightly/bert-squad.libsonnet
+++ b/tests/tensorflow/nightly/bert-squad.libsonnet
@@ -32,13 +32,13 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--mode=train",
       "--num_train_epochs=1",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       "--num_train_epochs=2",
     ],

--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -46,7 +46,7 @@ local gpus = import "templates/gpus.libsonnet";
       "--params_override=%s" % std.manifestYamlDoc(self.paramsOverride) + "\n",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     paramsOverride+: {
       train+: {
         epochs: 1, 
@@ -56,7 +56,7 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     paramsOverride+: {
       train+: {
         epochs: 350, 

--- a/tests/tensorflow/nightly/classifier-resnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnet.libsonnet
@@ -46,7 +46,7 @@ local gpus = import "templates/gpus.libsonnet";
       "--params_override=%s" % std.manifestYamlDoc(self.paramsOverride) + "\n",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     paramsOverride+: {
       train+: {
         epochs: 1, 
@@ -56,7 +56,7 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     paramsOverride+: {
       train+: {
         epochs: 90, 

--- a/tests/tensorflow/nightly/common.libsonnet
+++ b/tests/tensorflow/nightly/common.libsonnet
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 local common = import "../common.libsonnet";
+local mixins = import "templates/mixins.libsonnet";
 
 {
- ModelGardenTest:: common.ModelGardenTest {
+  ModelGardenTest:: common.ModelGardenTest {
     frameworkPrefix: "tf-nightly",
     tpuSettings+: {
       softwareVersion: "nightly",
@@ -28,6 +29,30 @@ local common = import "../common.libsonnet";
       },
       use_run_name_prefix: true,
     },
+    regressionTestConfig+: {
+      metric_success_conditions+: {
+        "examples_per_second_average": {
+          comparison: "greater_or_equal",
+          success_threshold: {
+            stddevs_from_mean: 2.0,
+          },
+        },
+      },
+    },
+  },
+  Functional:: mixins.Functional {
+    regressionTestConfig+: {
+      metric_success_conditions+: {
+        "examples_per_second_average": {
+          comparison: "greater_or_equal",
+          success_threshold: {
+            stddevs_from_mean: 4.0,
+          },
+        },
+      },
+    },
+  },
+  Convergence:: mixins.Convergence {
     regressionTestConfig+: {
       metric_success_conditions+: {
         "examples_per_second_average": {

--- a/tests/tensorflow/nightly/maskrcnn.libsonnet
+++ b/tests/tensorflow/nightly/maskrcnn.libsonnet
@@ -48,7 +48,7 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--mode=train",
     ],
@@ -58,7 +58,7 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     local config = self,
 
     command+: [

--- a/tests/tensorflow/nightly/mnist.libsonnet
+++ b/tests/tensorflow/nightly/mnist.libsonnet
@@ -27,13 +27,13 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--train_epochs=1",
       "--epochs_between_evals=1",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       "--train_epochs=10",
       "--epochs_between_evals=10",

--- a/tests/tensorflow/nightly/ncf.libsonnet
+++ b/tests/tensorflow/nightly/ncf.libsonnet
@@ -42,13 +42,13 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--train_epochs=1",
       "--ml_perf=true",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       "--train_epochs=14",
       "--ml_perf=false",

--- a/tests/tensorflow/nightly/resnet-ctl.libsonnet
+++ b/tests/tensorflow/nightly/resnet-ctl.libsonnet
@@ -36,13 +36,13 @@ local tpus = import "templates/tpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--train_epochs=1",
       "--epochs_between_evals=1",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     command+: [
       "--train_epochs=90",
       "--epochs_between_evals=90",

--- a/tests/tensorflow/nightly/retinanet.libsonnet
+++ b/tests/tensorflow/nightly/retinanet.libsonnet
@@ -49,7 +49,7 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--mode=train",
     ],
@@ -59,7 +59,7 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     local config = self,
 
     command+: [

--- a/tests/tensorflow/nightly/shapemask.libsonnet
+++ b/tests/tensorflow/nightly/shapemask.libsonnet
@@ -58,7 +58,7 @@ local utils = import "templates/utils.libsonnet";
       },
     },
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     local config = self,
     paramsOverride+: {
       train+: {
@@ -72,7 +72,7 @@ local utils = import "templates/utils.libsonnet";
         ||| % {common: command_common, params_override: std.manifestYamlDoc(config.paramsOverride)}
     ),
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     local config = self,
     paramsOverride+: {
       train+: {

--- a/tests/tensorflow/nightly/transformer-translate.libsonnet
+++ b/tests/tensorflow/nightly/transformer-translate.libsonnet
@@ -34,17 +34,17 @@ local gpus = import "templates/gpus.libsonnet";
       "--model_dir=$(MODEL_DIR)",
     ],
   },
-  local functional = mixins.Functional {
+  local functional = common.Functional {
     command+: [
       "--train_steps=20000",
     ],
   },
-  local functional_short = mixins.Functional {
+  local functional_short = common.Functional {
     command+: [
       "--train_steps=10000",
     ],
   },
-  local convergence = mixins.Convergence {
+  local convergence = common.Convergence {
     local config = self,
 
     command+: [


### PR DESCRIPTION
TF nightly functional tests can be quite noisy and are setting off a ton of false alarms. Increase bounds to 4 standard deviations from mean. This should still catch substantial drops in throughput. More subtle drops in throughput should be caught in end-to-end convergence tests.