### PR TITLE
Scrape metrics from perfzero summary JSON when available.

### DIFF
--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -533,7 +533,7 @@ def _process_pubsub_message(msg, status_handler, logger):
         'job_status was `{}` for test `{}`'.format(
             job_status['final_status'], test_name),
         debug_info=debug_info)
-  
+
   raw_metrics, aggregated_metrics = handler.get_metrics_from_events_dir()
   perfzero_metrics = handler.get_metrics_from_perfzero_summary()
   # Extra computed metrics (e.g. wall_time) are provided by PerfZero.


### PR DESCRIPTION
Give preference to PerfZero metrics when available, including for "computed" values like wall time. No-op for non-perfzero tests.