### PR TITLE
Increase timeout for v2-8 HF RoBERTa pretraining

### DIFF
--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v2-8.yaml
@@ -21,7 +21,7 @@
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 14400
+      "activeDeadlineSeconds": 18000
       "backoffLimit": 1
       "template":
         "metadata":

--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -119,7 +119,7 @@ local utils = import "templates/utils.libsonnet";
   },
   configs: [
     hf_lm + v3_8 + roberta_base_pre + timeouts.Hours(4),
-    hf_lm + v2_8 + roberta_base_pre + timeouts.Hours(4),
+    hf_lm + v2_8 + roberta_base_pre + timeouts.Hours(5),
     hf_lm + v3_8 + roberta_base_fine + timeouts.Hours(3),
   ],
 }


### PR DESCRIPTION
Not a regression, but timeout set too short from the beginning for v2-8.