### PR TITLE
Add --tag=-failspod to keras API pod tests

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod aaa_connection
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i aaa_connection
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i aaa_connection
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod aaa_connection
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod aaa_connection
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i aaa_connection
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i aaa_connection
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod aaa_connection
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod custom_training_loop
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i custom_training_loop
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i custom_training_loop
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod custom_training_loop
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod custom_training_loop
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i custom_training_loop
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i custom_training_loop
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod custom_training_loop
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-custom-layers-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-custom-layers-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i custom_layers_model
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod custom_layers_model
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-custom-layers-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-custom-layers-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod custom_layers_model
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i custom_layers_model
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-feature-column-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-feature-column-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i feature_column
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod feature_column
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-feature-column-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-feature-column-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod feature_column
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i feature_column
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-preprocess-layers-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-preprocess-layers-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod preprocessing_layers
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i preprocessing_layers
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-preprocess-layers-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-preprocess-layers-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i preprocessing_layers
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod preprocessing_layers
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-rnn-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-rnn-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i rnn
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod rnn
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-rnn-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-rnn-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod rnn
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i rnn
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-save-and-load-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-save-and-load-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i save_and_load
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod save_and_load
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-save-and-load-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-save-and-load-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod save_and_load
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i save_and_load
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-save-load-localhost-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-save-load-localhost-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i save_and_load_io_device_local_drive
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod save_and_load_io_device_local_drive
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-save-load-localhost-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-save-load-localhost-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod save_and_load_io_device_local_drive
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i save_and_load_io_device_local_drive
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i train_and_evaluate
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod train_and_evaluate
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v2-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod train_and_evaluate
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i train_and_evaluate
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i train_and_evaluate
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod train_and_evaluate
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod train_and_evaluate
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i train_and_evaluate
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-train-eval-dataset-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-train-eval-dataset-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i train_validation_dataset
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod train_validation_dataset
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-train-eval-dataset-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-train-eval-dataset-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod train_validation_dataset
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i train_validation_dataset
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-transfer-learning-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-transfer-learning-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod transfer_learning
+              behave -e ipynb_checkpoints --tags=-fails --tags=-failspod -i transfer_learning
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-transfer-learning-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-transfer-learning-v3-32.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i transfer_learning
+              behave -e ipynb_checkpoints --tags=-fails -i --tags=-failspod transfer_learning
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-connection-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-connection-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i aaa_connection
+              behave -e ipynb_checkpoints --tags=-fails  -i aaa_connection
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-connection-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-connection-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i aaa_connection
+              behave -e ipynb_checkpoints --tags=-fails  -i aaa_connection
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-ctl-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-ctl-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i custom_training_loop
+              behave -e ipynb_checkpoints --tags=-fails  -i custom_training_loop
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-ctl-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-ctl-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i custom_training_loop
+              behave -e ipynb_checkpoints --tags=-fails  -i custom_training_loop
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i custom_layers_model
+              behave -e ipynb_checkpoints --tags=-fails  -i custom_layers_model
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i custom_layers_model
+              behave -e ipynb_checkpoints --tags=-fails  -i custom_layers_model
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i feature_column
+              behave -e ipynb_checkpoints --tags=-fails  -i feature_column
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i feature_column
+              behave -e ipynb_checkpoints --tags=-fails  -i feature_column
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-preprocess-layers-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-preprocess-layers-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i preprocessing_layers
+              behave -e ipynb_checkpoints --tags=-fails  -i preprocessing_layers
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-preprocess-layers-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-preprocess-layers-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i preprocessing_layers
+              behave -e ipynb_checkpoints --tags=-fails  -i preprocessing_layers
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i rnn
+              behave -e ipynb_checkpoints --tags=-fails  -i rnn
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i rnn
+              behave -e ipynb_checkpoints --tags=-fails  -i rnn
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-save-and-load-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-save-and-load-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i save_and_load
+              behave -e ipynb_checkpoints --tags=-fails  -i save_and_load
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-save-and-load-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-save-and-load-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i save_and_load
+              behave -e ipynb_checkpoints --tags=-fails  -i save_and_load
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-save-load-localhost-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-save-load-localhost-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i save_and_load_io_device_local_drive
+              behave -e ipynb_checkpoints --tags=-fails  -i save_and_load_io_device_local_drive
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-save-load-localhost-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-save-load-localhost-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i save_and_load_io_device_local_drive
+              behave -e ipynb_checkpoints --tags=-fails  -i save_and_load_io_device_local_drive
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i train_and_evaluate
+              behave -e ipynb_checkpoints --tags=-fails  -i train_and_evaluate
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i train_and_evaluate
+              behave -e ipynb_checkpoints --tags=-fails  -i train_and_evaluate
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i train_validation_dataset
+              behave -e ipynb_checkpoints --tags=-fails  -i train_validation_dataset
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i train_validation_dataset
+              behave -e ipynb_checkpoints --tags=-fails  -i train_validation_dataset
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i transfer_learning
+              behave -e ipynb_checkpoints --tags=-fails  -i transfer_learning
               
             "env":
             - "name": "POD_NAME"

--- a/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
@@ -53,7 +53,7 @@
               gcloud source repos clone tf2-api-tests --project=xl-ml-test
               cd tf2-api-tests
               pip3 install behave
-              behave -e ipynb_checkpoints --tags=-fails -i transfer_learning
+              behave -e ipynb_checkpoints --tags=-fails  -i transfer_learning
               
             "env":
             - "name": "POD_NAME"

--- a/tests/tensorflow/nightly/keras-api.libsonnet
+++ b/tests/tensorflow/nightly/keras-api.libsonnet
@@ -29,8 +29,8 @@ local utils = import "templates/utils.libsonnet";
         gcloud source repos clone tf2-api-tests --project=xl-ml-test
         cd tf2-api-tests
         pip3 install behave
-        behave -e ipynb_checkpoints --tags=-fails -i %s%s
-      ||| % [if self.isTPUPod then "--tags=-failspod " else "", self.testFeature]
+        behave -e ipynb_checkpoints --tags=-fails %s -i %s
+      ||| % [if self.isTPUPod then "--tags=-failspod" else "", self.testFeature]
     ),
     regressionTestConfig: {
       alert_for_failed_jobs: true,

--- a/tests/tensorflow/nightly/keras-api.libsonnet
+++ b/tests/tensorflow/nightly/keras-api.libsonnet
@@ -22,14 +22,15 @@ local utils = import "templates/utils.libsonnet";
   local keras_test = common.ModelGardenTest {
     testFeature:: error "Must override `testFeature`",
     modelName: "keras-api",
+    isTPUPod:: error "Must set `isTPUPod`",
     command: utils.scriptCommand(
       |||
         export PATH=$PATH:/root/google-cloud-sdk/bin
         gcloud source repos clone tf2-api-tests --project=xl-ml-test
         cd tf2-api-tests
         pip3 install behave
-        behave -e ipynb_checkpoints --tags=-fails -i %s
-      ||| % self.testFeature
+        behave -e ipynb_checkpoints --tags=-fails -i %s%s
+      ||| % [if self.isTPUPod then "--tags=-failspod " else "", self.testFeature]
     ),
     regressionTestConfig: {
       alert_for_failed_jobs: true,
@@ -113,15 +114,19 @@ local utils = import "templates/utils.libsonnet";
 
   local v2_8 = {
     accelerator: tpus.v2_8,
+    isTPUPod: false,
   },
   local v3_8 = {
     accelerator: tpus.v3_8,
+    isTPUPod: false,
   },
   local v2_32 = {
     accelerator: tpus.v2_32,
+    isTPUPod: true,
   },
   local v3_32 = {
     accelerator: tpus.v3_32,
+    isTPUPod: true,
   },
 
   configs: [


### PR DESCRIPTION
From [here](https://source.cloud.google.com/xl-ml-test/tf2-api-tests/+/master:README.txt;l=15?q=failspod&ss=xl-ml-test%2Ftf2-api-tests), the tag `failspod` skips tests that are expected to fail on Pods.

train_and_eval tests on pods time out on a test marked with failspod so this should get this test passing by skipping that test case.

Test logs: https://pantheon.corp.google.com/logs/viewer?advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22xl-ml-test%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22xl-ml-test-europe-west4%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fcontroller-uid%3D%22139d5647-9f6f-464e-bf25-d7d7075b65a7%22&interval=NO_LIMIT&project=xl-ml-test