### PR TITLE
Suspend TF nightly functional tests by default.

### DIFF
--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
@@ -161,3 +161,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
@@ -161,3 +161,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
@@ -164,3 +164,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
@@ -164,3 +164,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
@@ -164,3 +164,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
@@ -164,3 +164,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
@@ -172,3 +172,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
@@ -172,3 +172,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-ncf-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-ncf-func-v3-32.yaml
@@ -168,3 +168,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
@@ -162,3 +162,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
@@ -162,3 +162,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
@@ -168,3 +168,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
@@ -168,3 +168,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
@@ -186,3 +186,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
@@ -186,3 +186,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
@@ -166,3 +166,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
@@ -166,3 +166,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
@@ -161,3 +161,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
@@ -161,3 +161,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-k80-x8.yaml
@@ -148,3 +148,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x1.yaml
@@ -147,3 +147,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v100-x4.yaml
@@ -147,3 +147,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
@@ -163,3 +163,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
@@ -163,3 +163,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
@@ -164,3 +164,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
@@ -164,3 +164,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v100-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v100-x8.yaml
@@ -134,7 +134,7 @@
                    "validation/epoch_accuracy_final": {
                     "comparison": "greater",
                     "success_threshold": {
-                     "fixed_value": 0.76
+                     "fixed_value": 0.76000000000000001
                     }
                    }
                   }

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v100-x8.yaml
@@ -150,3 +150,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": false

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
@@ -164,3 +164,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
@@ -164,3 +164,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
@@ -172,3 +172,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
@@ -172,3 +172,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v100-x1.yaml
@@ -138,3 +138,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
@@ -154,3 +154,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
@@ -154,3 +154,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-k80-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-k80-x1.yaml
@@ -153,3 +153,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-k80-x8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-k80-x8.yaml
@@ -153,3 +153,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-v100-x1.yaml
@@ -153,3 +153,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-v100-x4.yaml
@@ -153,3 +153,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-v2-8.yaml
@@ -168,3 +168,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
@@ -162,3 +162,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
@@ -162,3 +162,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
@@ -168,3 +168,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
@@ -168,3 +168,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
@@ -186,3 +186,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
@@ -186,3 +186,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
@@ -166,3 +166,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
@@ -166,3 +166,4 @@
             "name": "dshm"
   "schedule": "0 8 * * *"
   "successfulJobsHistoryLimit": 1
+  "suspend": true

--- a/templates/mixins.libsonnet
+++ b/templates/mixins.libsonnet
@@ -45,4 +45,11 @@ local timeouts = import "timeouts.libsonnet";
       },
     },
   },
+  Unsuspended:: {
+    cronJob+:: {
+      spec+: {
+        suspend: false,
+      },
+    },
+  },
 }

--- a/tests/tensorflow/nightly/classifier-resnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnet.libsonnet
@@ -146,7 +146,7 @@ local gpus = import "templates/gpus.libsonnet";
     resnet + v100 + functional + timeouts.Hours(3) + mixins.Suspended,
     resnet + v100x4 + functional + mixins.Experimental,
     resnet + v100x4 + convergence + mixins.Experimental,
-    resnet + v100x8 + functional,
+    resnet + v100x8 + functional + mixins.Unsuspended,
     resnet + v100x8 + convergence,
     resnet + v2_8 + functional,
     resnet + v3_8 + functional,

--- a/tests/tensorflow/nightly/common.libsonnet
+++ b/tests/tensorflow/nightly/common.libsonnet
@@ -40,7 +40,7 @@ local mixins = import "templates/mixins.libsonnet";
       },
     },
   },
-  Functional:: mixins.Functional {
+  Functional:: mixins.Functional + mixins.Suspended {
     regressionTestConfig+: {
       metric_success_conditions+: {
         "examples_per_second_average": {


### PR DESCRIPTION
Rely on PerfZero tests for quick feedback. No-op for convergence tests and custom modes (e.g. Keras API tests). Explicitly un-suspend ResNet v100x8 functional test (#291).

Add "Unsuspended" mixin to easily undo "Suspended".

Tests can still be manually triggered from `kubectl` or GKE UI. 