### PR TITLE
Email after n

### DIFF
--- a/metrics_handler/README.md
+++ b/metrics_handler/README.md
@@ -159,7 +159,12 @@ Full config options:
 
   # (Optional) Defaults to True. If set to False, this test will not create
   # any alerts emails if the test crashes or times out.
-  "alert_for_failed_jobs": "True"
+  "alert_for_failed_jobs": "True",
+
+  # (Optional) Defaults to True. If set to False, this test will send alerts
+  # for every failure. If set to True, this test will wait for 2 failures in
+  # a row before sending an alert.
+  "alert_after_second_test_failure": "True"
 }
 ```
 ## Config "Recipes"

--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -395,7 +395,6 @@ class CloudMetricsHandler(object):
     Returns:
       bool: True if alerting should be skipped for any oob metrics.
     """
-    # Skip alerts if disabled by config.
     if not self.regression_test_config.get('alert_for_oob_metrics', True):
       return True
     # Skip alerts if job failed since metrics are unreliable for partial runs.

--- a/metrics_handler/metrics.py
+++ b/metrics_handler/metrics.py
@@ -293,8 +293,8 @@ def metric_bounds(value_history, threshold, comparison):
     comparison (string): Comparison to given threshold.
 
   Returns:
-    tuple(is_within_bounds (bool), lower_bound (float), upper_bound (float)).
-      lower_bound and/or upper_bound can be None.
+    lower_bound (float): Lower boundary that this metric should be above.
+    upper_bound (float): Upper boundary that this metric should be below.
 
   Raises:
     ValueError if the regression test config is invalid.


### PR DESCRIPTION
Add a metrics handler config option "alert_after_second_test_failure". If true, then the metrics handler will wait for 2 failures in a row before sending an email alert for a failed test or a metrics regression.

Included unit tests cover almost all cases, but I also did some manual testing of the path that hits Bigquery. Tried deploying temporarily in prod and didn't see any issues