### PR TITLE
Use top-level `cpu` and `memory` fields in PyTorchBaseTest

### DIFF
--- a/tests/pytorch/common.libsonnet
+++ b/tests/pytorch/common.libsonnet
@@ -64,6 +64,9 @@ local volumes = import "templates/volumes.libsonnet";
       },
     },
 
+    cpu: "4.5",
+    memory: "8Gi",
+
     jobSpec+:: {
       template+: {
         spec+: {
@@ -72,13 +75,7 @@ local volumes = import "templates/volumes.libsonnet";
               envMap+: {
                 XLA_USE_BF16: "0",
               },
-              resources+: {
-                requests+: {
-                  cpu: "4.5",
-                  memory: "8Gi",
-                },
-              },
-            },
+            }
           }
         }
       }

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -37,22 +37,8 @@ local utils = import "templates/utils.libsonnet";
     volumeMap+: {
       datasets: common.datasetsVolume
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: "13.0",
-                  memory: "40Gi",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
+    cpu: "13.0",
+    memory: "40Gi",
   },
 
   local resnet50_MP = common.PyTorchTest {


### PR DESCRIPTION
No-op for generated files.