### PR TITLE
Add hyphen to test prefixes.

### DIFF
--- a/dashboard/main_heatmap.py
+++ b/dashboard/main_heatmap.py
@@ -89,7 +89,7 @@ def _get_query_config(test_name_prefix, cutoff_timestamp):
         {
           'name': 'test_name_prefix',
           'parameterType': {'type': 'STRING'},
-          'parameterValue': {'value': '{}%'.format(test_name_prefix)},
+          'parameterValue': {'value': '{}-%'.format(test_name_prefix)},
         },
         {
           'name': 'cutoff_timestamp',


### PR DESCRIPTION
Previously, we would query for e.g. `tf-r2.3%`, which will also find `tf-r.2.3.1` tests. This hyphen switches the query to `WHERE test_name like 'tf-r.2.3-%' ` so the tab won't also include `tf.r.2.3.1` tests

cc @aman2930 