### PR TITLE
Skip dashboard tabs if there is no data.

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -73,7 +73,8 @@ cutoff_timestamp = (datetime.datetime.now() - datetime.timedelta(
 all_data = parallel_fetch_data(test_name_prefixes, cutoff_timestamp)
 for test_prefix, data in all_data.items():
   plot = main_heatmap.make_plot(data)
-  all_tabs.append(Panel(child=plot, title=test_prefix))
+  if plot:
+    all_tabs.append(Panel(child=plot, title=test_prefix))
 
 curdoc().title = "Test pass/fail Dashboard"
 curdoc().add_root(column(children=[row(timer), row(Tabs(tabs=all_tabs))]))

--- a/dashboard/main_heatmap.py
+++ b/dashboard/main_heatmap.py
@@ -170,7 +170,11 @@ def process_dataframes(job_status_dataframe, metrics_dataframe):
 
 def make_plot(dataframe):
   source = ColumnDataSource(data=dataframe)
+  if 'run_date' not in source.data:
+    return None  # No dates to render.
   all_dates = np.unique(source.data['run_date']).tolist()
+  if not all_dates:
+    return None  # No dates to render.
 
   # The heatmap doesn't render correctly if there are very few dates.
   MIN_DATES_TO_RENDER = 15

--- a/dashboard/main_heatmap_test.py
+++ b/dashboard/main_heatmap_test.py
@@ -123,6 +123,11 @@ class MainHeatmapTest(parameterized.TestCase):
     plot = main_heatmap.make_plot(input_df)
     self.assertTrue(plot is not None and len(plot.renderers) > 0)
 
+  def test_make_plot_empty_data(self):
+    input_df = pd.DataFrame()
+    # Make sure nothing crashes.
+    plot = main_heatmap.make_plot(input_df)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
This should prevent the dashboard from crashing if a test prefix is requested that has no data

Tested by running `bokeh` locally with `TEST_NAME_PREFIXES` including some tabs with no data