### PR TITLE
Remove PyTorch check on CompileTime

### DIFF
--- a/k8s/europe-west4/gen/pt-1.6-mnist-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-mnist-conv-v2-32.yaml
@@ -116,7 +116,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -127,13 +126,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/europe-west4/gen/pt-1.6-mnist-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-mnist-conv-v3-32.yaml
@@ -116,7 +116,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -127,13 +126,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/europe-west4/gen/pt-1.6-resnet50-mp-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-resnet50-mp-conv-v3-32.yaml
@@ -124,7 +124,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -135,13 +134,6 @@
                     "success_threshold": {
                      "fixed_value": 75
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/europe-west4/gen/pt-1.6-resnet50-mp-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-resnet50-mp-func-v3-32.yaml
@@ -122,19 +122,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/europe-west4/gen/pt-nightly-mnist-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-mnist-conv-v2-32.yaml
@@ -116,7 +116,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -127,13 +126,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/europe-west4/gen/pt-nightly-mnist-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-mnist-conv-v3-32.yaml
@@ -116,7 +116,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -127,13 +126,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/europe-west4/gen/pt-nightly-resnet50-mp-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-resnet50-mp-conv-v3-32.yaml
@@ -124,7 +124,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -135,13 +134,6 @@
                     "success_threshold": {
                      "fixed_value": 75
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/europe-west4/gen/pt-nightly-resnet50-mp-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-resnet50-mp-func-v3-32.yaml
@@ -122,19 +122,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.5-fs-checkpoint-gcs-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.5-fs-checkpoint-gcs-func-v3-8.yaml
@@ -194,19 +194,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.5-fs-checkpoint-local-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.5-fs-checkpoint-local-func-v3-8.yaml
@@ -191,19 +191,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.5-fs-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.5-fs-transformer-conv-v3-8.yaml
@@ -167,19 +167,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.5-fs-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.5-fs-transformer-func-v3-8.yaml
@@ -157,19 +157,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.5-resnet50-mp-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.5-resnet50-mp-conv-v3-8.yaml
@@ -126,7 +126,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -137,13 +136,6 @@
                     "success_threshold": {
                      "fixed_value": 75
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-1.5-resnet50-mp-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.5-resnet50-mp-func-v3-8.yaml
@@ -126,19 +126,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.5-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.5-roberta-pre-conv-v3-8.yaml
@@ -155,19 +155,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-dlrm-mp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-dlrm-mp-fwd-func-v3-8.yaml
@@ -146,19 +146,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-dlrm-mpdp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-dlrm-mpdp-fwd-func-v3-8.yaml
@@ -146,19 +146,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-dlrm-onecore-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-dlrm-onecore-func-v3-8.yaml
@@ -146,19 +146,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-dlrm-seq-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-dlrm-seq-fwd-func-v3-8.yaml
@@ -146,19 +146,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-fs-checkpoint-gcs-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-fs-checkpoint-gcs-func-v3-8.yaml
@@ -192,19 +192,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-fs-checkpoint-local-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-fs-checkpoint-local-func-v3-8.yaml
@@ -189,19 +189,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-fs-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-fs-transformer-conv-v3-8.yaml
@@ -166,19 +166,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-fs-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-fs-transformer-func-v3-8.yaml
@@ -156,19 +156,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v2-8.yaml
@@ -152,19 +152,11 @@
                   "alert_for_failed_jobs": false,
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v3-8.yaml
@@ -152,19 +152,11 @@
                   "alert_for_failed_jobs": false,
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-distilbert-b-uc-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-distilbert-b-uc-conv-v3-8.yaml
@@ -152,19 +152,11 @@
                   "alert_for_failed_jobs": false,
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-roberta-l-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-roberta-l-conv-v3-8.yaml
@@ -152,19 +152,11 @@
                   "alert_for_failed_jobs": false,
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-xlnet-l-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-xlnet-l-c-conv-v3-8.yaml
@@ -152,19 +152,11 @@
                   "alert_for_failed_jobs": false,
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v2-8.yaml
@@ -117,7 +117,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -128,13 +127,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v3-8.yaml
@@ -117,7 +117,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -128,13 +127,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-1.6-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-conv-v2-8.yaml
@@ -117,7 +117,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -128,13 +127,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-1.6-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-conv-v3-8.yaml
@@ -117,7 +117,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -128,13 +127,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-1.6-resnet50-mp-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-resnet50-mp-conv-v3-8.yaml
@@ -126,7 +126,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -137,13 +136,6 @@
                     "success_threshold": {
                      "fixed_value": 75
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-1.6-resnet50-mp-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-resnet50-mp-func-v3-8.yaml
@@ -126,19 +126,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-roberta-pre-conv-v3-8.yaml
@@ -155,19 +155,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-1.6-tpu-mem-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-tpu-mem-func-v3-8.yaml
@@ -129,19 +129,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v2-8.yaml
@@ -119,7 +119,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -130,13 +129,6 @@
                     "success_threshold": {
                      "fixed_value": 72
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v3-8.yaml
@@ -119,7 +119,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -130,13 +129,6 @@
                     "success_threshold": {
                      "fixed_value": 72
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-nightly-dlrm-convergence-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-convergence-conv-v3-8.yaml
@@ -154,19 +154,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-dlrm-mp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-mp-fwd-func-v3-8.yaml
@@ -146,19 +146,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-dlrm-mpdp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-mpdp-fwd-func-v3-8.yaml
@@ -146,19 +146,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-dlrm-onecore-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-onecore-func-v3-8.yaml
@@ -146,19 +146,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-dlrm-seq-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-seq-fwd-func-v3-8.yaml
@@ -146,19 +146,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-fs-checkpoint-gcs-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-checkpoint-gcs-func-v3-8.yaml
@@ -192,19 +192,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-fs-checkpoint-local-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-checkpoint-local-func-v3-8.yaml
@@ -189,19 +189,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-fs-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-transformer-conv-v3-8.yaml
@@ -166,19 +166,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-fs-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-transformer-func-v3-8.yaml
@@ -156,19 +156,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-bert-b-c-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-bert-b-c-conv-v2-8.yaml
@@ -151,19 +151,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-bert-b-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-bert-b-c-conv-v3-8.yaml
@@ -151,19 +151,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-distilbert-b-uc-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-distilbert-b-uc-conv-v3-8.yaml
@@ -151,19 +151,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-roberta-l-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-roberta-l-conv-v3-8.yaml
@@ -151,19 +151,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-xlnet-l-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-xlnet-l-c-conv-v3-8.yaml
@@ -151,19 +151,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-bert-b-fine-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-bert-b-fine-conv-v3-8.yaml
@@ -150,19 +150,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-bert-b-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-bert-b-pre-conv-v3-8.yaml
@@ -150,19 +150,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-fine-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-fine-conv-v3-8.yaml
@@ -150,19 +150,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v2-8.yaml
@@ -150,19 +150,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v3-8.yaml
@@ -150,19 +150,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v2-8.yaml
@@ -117,7 +117,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -128,13 +127,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v3-8.yaml
@@ -117,7 +117,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -128,13 +127,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-nightly-mnist-conv-v100-x1.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-conv-v100-x1.yaml
@@ -110,7 +110,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -121,13 +120,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-nightly-mnist-conv-v100-x4.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-conv-v100-x4.yaml
@@ -110,7 +110,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -121,13 +120,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-nightly-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-conv-v2-8.yaml
@@ -117,7 +117,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -128,13 +127,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-nightly-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-conv-v3-8.yaml
@@ -117,7 +117,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -128,13 +127,6 @@
                     "success_threshold": {
                      "fixed_value": 98
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-nightly-resnet50-mp-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-resnet50-mp-conv-v3-8.yaml
@@ -126,7 +126,6 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
@@ -137,13 +136,6 @@
                     "success_threshold": {
                      "fixed_value": 75
                     }
-                   },
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
                    },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",

--- a/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v100-x1.yaml
+++ b/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v100-x1.yaml
@@ -119,19 +119,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v100-x4.yaml
+++ b/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v100-x4.yaml
@@ -119,19 +119,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v3-8.yaml
@@ -126,19 +126,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/k8s/us-central1/gen/pt-nightly-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-roberta-pre-conv-v3-8.yaml
@@ -155,19 +155,11 @@
                  "regression_test_config": {
                   "metric_subset_to_alert": [
                    "ExecuteTime__Percentile_99_sec_final",
-                   "CompileTime__Percentile_99_sec_final",
                    "total_wall_time",
                    "Accuracy/test_final",
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
-                   "CompileTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {

--- a/tests/pytorch/common.libsonnet
+++ b/tests/pytorch/common.libsonnet
@@ -20,20 +20,12 @@ local volumes = import "templates/volumes.libsonnet";
     regressionTestConfig+: {
       metric_subset_to_alert: [
         "ExecuteTime__Percentile_99_sec_final",
-        "CompileTime__Percentile_99_sec_final",
         "total_wall_time",
         "Accuracy/test_final",
         "aten_ops_sum_final",
       ],
       metric_success_conditions+: {
         "ExecuteTime__Percentile_99_sec_final": {
-          success_threshold: {
-            stddevs_from_mean: 5.0,
-          },
-          comparison: "less",
-          wait_for_n_points_of_history: 10,
-        },
-        "CompileTime__Percentile_99_sec_final": {
           success_threshold: {
             stddevs_from_mean: 5.0,
           },


### PR DESCRIPTION
Variations here can be large without affecting `total_wall_time`, so there's nothing to do when this alert fires