### PR TITLE
PyTorch/XLA: Add 1.7 tests and remove 1.5 tests

### DIFF
--- a/k8s/europe-west4/gen/pt-r1.7-fs-transformer-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-fs-transformer-func-v3-32.yaml
@@ -15,18 +15,18 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-1.5-roberta-pre-conv-v3-8"
+  "name": "pt-r1.7-fs-transformer-func-v3-32"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 7200
-      "backoffLimit": 1
+      "activeDeadlineSeconds": 3600
+      "backoffLimit": 0
       "template":
         "metadata":
           "annotations":
-            "tf-version.cloud-tpus.google.com": "pytorch-1.5"
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":
           - "env":
@@ -49,37 +49,51 @@
               set -e
               set -x
               
-              pip install --editable tpu-examples/deps/fairseq
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
-                /datasets/wikitext-103 \
-                --tensorboard-logdir=$(MODEL_DIR) \
-                --task=masked_lm --criterion=masked_lm \
-                --arch=roberta_base --sample-break-mode=complete \
-                --tokens-per-sample=512 \
+                /datasets/wmt18_en_de_bpej32k \
+                --metrics_debug \
+                --arch=transformer_vaswani_wmt_en_de_big \
+                --max-target-positions=64 \
+                --attention-dropout=0.1 \
+                --no-progress-bar \
+                --criterion=label_smoothed_cross_entropy \
+                --source-lang=en \
+                --lr-scheduler=inverse_sqrt  \
+                --min-lr=1e-09 \
+                --skip-invalid-size-inputs-valid-test \
+                --target-lang=de \
+                --label-smoothing=0.1 \
+                --update-freq=1 \
                 --optimizer=adam \
                 --adam-betas='(0.9,0.98)' \
-                --adam-eps=1e-6 \
-                --clip-norm=0.0 \
-                --lr-scheduler=polynomial_decay \
+                --warmup-init-lr=1e-07 \
                 --lr=0.0005 \
-                --warmup-updates=10000 \
-                --dropout=0.1 \
-                --attention-dropout=0.1 \
-                --weight-decay=0.01 \
-                --update-freq=16 \
-                --log-format=simple \
-                --train-subset=train \
-                --valid-subset=valid \
+                --warmup-updates=4000 \
+                --share-all-embeddings \
+                --dropout=0.3 \
+                --weight-decay=0.0 \
                 --num_cores=8 \
-                --metrics_debug \
-                --save-dir=checkpoints \
-                --log_steps=30 \
-                --skip-invalid-size-inputs-valid-test \
-                --suppress_loss_report \
-                --input_shapes 16x512 18x480 21x384 \
-                --max-epoch=5
+                --no-save \
+                --max-epoch=1 \
+                --log_steps=10 \
+                --train-subset=valid \
+                --valid-subset=test \
+                --input_shapes=128x64
               
+            "command":
+            - "python3"
+            - "launch_k8s_workers.py"
+            - "--name=$(JOB_NAME)"
+            - "--image=gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            - "--owner_name=$(POD_NAME)"
+            - "--owner_uid=$(POD_UID)"
+            - "--namespace=$(POD_NAMESPACE)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--cpu=4"
+            - "--memory=4Gi"
+            - "--volumes=pytorch-datasets-claim:/datasets"
+            - "--"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -98,25 +112,20 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/roberta-pre/conv/v3-8/$(JOB_NAME)"
-            - "name": "XLA_USE_BF16"
-              "value": "0"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-transformer/func/v3-32/$(JOB_NAME)"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.5"
+            "image": "gcr.io/xl-ml-test/pytorch-pods:nightly"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
+                "cloud-tpus.google.com/v3": 32
               "requests":
                 "cpu": "9.0"
                 "memory": "30Gi"
             "volumeMounts":
-            - "mountPath": "/dev/shm"
-              "name": "dshm"
-              "readOnly": false
             - "mountPath": "/datasets"
               "name": "pytorch-datasets-claim"
               "readOnly": true
@@ -139,7 +148,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/roberta-pre/conv/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-transformer/func/v3-32/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -182,7 +191,7 @@
                    }
                   }
                  },
-                 "test_name": "pt-1.5-roberta-pre-conv-v3-8"
+                 "test_name": "pt-r1.7-fs-transformer-func-v3-32"
                 }
             "envFrom":
             - "configMapRef":
@@ -193,12 +202,10 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
+          "serviceAccountName": "pytorch-xla-pods"
           "volumes":
-          - "emptyDir":
-              "medium": "Memory"
-            "name": "dshm"
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 1 * * 1,6"
+  "schedule": "0 22 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/pt-r1.7-mnist-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-mnist-conv-v2-32.yaml
@@ -15,18 +15,18 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-1.5-fs-transformer-conv-v3-8"
+  "name": "pt-r1.7-mnist-conv-v2-32"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 90000
-      "backoffLimit": 1
+      "activeDeadlineSeconds": 36000
+      "backoffLimit": 0
       "template":
         "metadata":
           "annotations":
-            "tf-version.cloud-tpus.google.com": "pytorch-1.5"
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":
           - "env":
@@ -42,56 +42,9 @@
             "imagePullPolicy": "Always"
             "name": "monitor"
           - "args":
-            - "/bin/bash"
-            - "-c"
-            - |
-              set -u
-              set -e
-              set -x
-              
-              pip install --editable /tpu-examples/deps/fairseq
-              python3 \
-                /tpu-examples/deps/fairseq/train.py \
-                /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
-                --metrics_debug \
-                --arch=transformer_vaswani_wmt_en_de_big \
-                --max-target-positions=64 \
-                --attention-dropout=0.1 \
-                --no-progress-bar \
-                --criterion=label_smoothed_cross_entropy \
-                --source-lang=en \
-                --lr-scheduler=inverse_sqrt  \
-                --min-lr=1e-09 \
-                --skip-invalid-size-inputs-valid-test \
-                --target-lang=de \
-                --label-smoothing=0.1 \
-                --update-freq=1 \
-                --optimizer=adam \
-                --adam-betas='(0.9,0.98)' \
-                --warmup-init-lr=1e-07 \
-                --lr=0.0005 \
-                --warmup-updates=4000 \
-                --share-all-embeddings \
-                --dropout=0.3 \
-                --weight-decay=0.0 \
-                --num_cores=8 \
-                --save-interval=5 \
-                --save-dir=/tmp/checkpoints \
-                --max-epoch=25 \
-                --log_steps=200 \
-                --train-subset=train \
-                --valid-subset=valid \
-                --input_shapes 256x64 512x32 640x16
-              bleu=`fairseq-generate \
-                 /datasets/wmt18_en_de_bpej32k \
-                 --remove-bpe --quiet --lenpen 0.6 --beam 4 \
-                 --path /tmp/checkpoints/checkpoint25.pt \
-                 --skip-invalid-size-inputs-valid-test | grep BLEU \
-                 | grep -v loadi | tail -1 | cut -d '=' -f 3| cut -d'.' -f 1`
-              echo 'BLEU score is' $bleu
-              test $bleu -gt 26
-              
+            - "python3"
+            - "/usr/share/torch-xla-nightly/pytorch/xla/test/test_train_mp_mnist.py"
+            - "--logdir=$(MODEL_DIR)"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -110,28 +63,24 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/fs-transformer/conv/v3-8/$(JOB_NAME)"
-            - "name": "XLA_USE_BF16"
-              "value": "1"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist/conv/v2-32/$(JOB_NAME)"
+            - "name": "ACCELERATOR_TYPE"
+              "value": "v2-32"
+            - "name": "CONDA_ENV"
+              "value": "torch-xla-nightly"
+            - "name": "MACHINE_TYPE"
+              "value": "n1-standard-8"
+            - "name": "XLA_DIST_FLAGS"
+              "value": ""
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.5"
+            "image": "gcr.io/xl-ml-test/pytorch-pods:r1.7"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/v3": 8
-              "requests":
-                "cpu": "9.0"
-                "memory": "30Gi"
-            "volumeMounts":
-            - "mountPath": "/dev/shm"
-              "name": "dshm"
-              "readOnly": false
-            - "mountPath": "/datasets"
-              "name": "pytorch-datasets-claim"
-              "readOnly": true
+                "cloud-tpus.google.com/v2": 32
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -151,7 +100,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/fs-transformer/conv/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist/conv/v2-32/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -172,6 +121,12 @@
                    "aten_ops_sum_final"
                   ],
                   "metric_success_conditions": {
+                   "Accuracy/test_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 98
+                    }
+                   },
                    "ExecuteTime__Percentile_99_sec_final": {
                     "comparison": "less",
                     "success_threshold": {
@@ -191,16 +146,10 @@
                      "stddevs_from_mean": 5
                     },
                     "wait_for_n_points_of_history": 10
-                   },
-                   "train-wps_final": {
-                    "comparison": "greater",
-                    "success_threshold": {
-                     "fixed_value": 11700
-                    }
                    }
                   }
                  },
-                 "test_name": "pt-1.5-fs-transformer-conv-v3-8"
+                 "test_name": "pt-r1.7-mnist-conv-v2-32"
                 }
             "envFrom":
             - "configMapRef":
@@ -211,12 +160,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-          "volumes":
-          - "emptyDir":
-              "medium": "Memory"
-            "name": "dshm"
-          - "name": "pytorch-datasets-claim"
-            "persistentVolumeClaim":
-              "claimName": "pytorch-datasets-claim"
-  "schedule": "0 1 * * 1,6"
+  "schedule": "4 21 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/pt-r1.7-mnist-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-mnist-conv-v3-32.yaml
@@ -1,0 +1,164 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-mnist-conv-v3-32"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 36000
+      "backoffLimit": 0
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "python3"
+            - "/usr/share/torch-xla-nightly/pytorch/xla/test/test_train_mp_mnist.py"
+            - "--logdir=$(MODEL_DIR)"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist/conv/v3-32/$(JOB_NAME)"
+            - "name": "ACCELERATOR_TYPE"
+              "value": "v3-32"
+            - "name": "CONDA_ENV"
+              "value": "torch-xla-nightly"
+            - "name": "MACHINE_TYPE"
+              "value": "n1-standard-8"
+            - "name": "XLA_DIST_FLAGS"
+              "value": ""
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-pods:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 32
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist/conv/v3-32/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "Accuracy/test_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 98
+                    }
+                   },
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-mnist-conv-v3-32"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+  "schedule": "6 21 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/pt-r1.7-resnet50-mp-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-resnet50-mp-conv-v3-32.yaml
@@ -1,0 +1,173 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-resnet50-mp-conv-v3-32"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 36000
+      "backoffLimit": 0
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "python3"
+            - "/pytorch/xla/test/test_train_mp_imagenet.py"
+            - "--num_epochs=90"
+            - "--datadir=/datasets/imagenet"
+            - "--batch_size=128"
+            - "--log_steps=200"
+            "command":
+            - "python3"
+            - "launch_k8s_workers.py"
+            - "--name=$(JOB_NAME)"
+            - "--image=gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            - "--owner_name=$(POD_NAME)"
+            - "--owner_uid=$(POD_UID)"
+            - "--namespace=$(POD_NAMESPACE)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--cpu=36"
+            - "--memory=100Gi"
+            - "--volumes=pytorch-datasets-claim:/datasets"
+            - "--"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/resnet50-mp/conv/v3-32/$(JOB_NAME)"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-pods:nightly"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 32
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/resnet50-mp/conv/v3-32/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "Accuracy/test_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 75
+                    }
+                   },
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-resnet50-mp-conv-v3-32"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "serviceAccountName": "pytorch-xla-pods"
+  "schedule": "0 0 * * 0,2,4"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/pt-r1.7-resnet50-mp-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-resnet50-mp-func-v3-32.yaml
@@ -1,0 +1,165 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-resnet50-mp-func-v3-32"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 3600
+      "backoffLimit": 0
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "python3"
+            - "/pytorch/xla/test/test_train_mp_imagenet.py"
+            - "--fake_data"
+            - "--num_epochs=5"
+            "command":
+            - "python3"
+            - "launch_k8s_workers.py"
+            - "--name=$(JOB_NAME)"
+            - "--image=gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            - "--owner_name=$(POD_NAME)"
+            - "--owner_uid=$(POD_UID)"
+            - "--namespace=$(POD_NAMESPACE)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--cpu=8"
+            - "--memory=16Gi"
+            - "--volumes="
+            - "--"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/resnet50-mp/func/v3-32/$(JOB_NAME)"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-pods:nightly"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 32
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/resnet50-mp/func/v3-32/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-resnet50-mp-func-v3-32"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "serviceAccountName": "pytorch-xla-pods"
+  "schedule": "0 22 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/pt-r1.7-roberta-pre-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-roberta-pre-func-v3-32.yaml
@@ -1,0 +1,181 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-roberta-pre-func-v3-32"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 3600
+      "backoffLimit": 0
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              pip install --editable tpu-examples/deps/fairseq
+              python3 \
+                /tpu-examples/deps/fairseq/train.py \
+                /datasets/wikitext-103 \
+                --task=masked_lm --criterion=masked_lm \
+                --arch=roberta_base --sample-break-mode=complete \
+                --tokens-per-sample=512 \
+                --optimizer=adam \
+                --adam-betas='(0.9,0.98)' \
+                --adam-eps=1e-6 \
+                --clip-norm=0.0 \
+                --lr-scheduler=polynomial_decay \
+                --lr=0.0005 \
+                --warmup-updates=10000 \
+                --dropout=0.1 \
+                --attention-dropout=0.1 \
+                --weight-decay=0.01 \
+                --update-freq=16 \
+                --log-format=simple \
+                --train-subset=train \
+                --valid-subset=valid \
+                --num_cores=8 \
+                --metrics_debug \
+                --save-dir=checkpoints \
+                --log_steps=30 \
+                --skip-invalid-size-inputs-valid-test \
+                --suppress_loss_report \
+                --input_shapes 16x512 18x480 21x384 \
+                --max-epoch=1
+              
+            "command":
+            - "python3"
+            - "launch_k8s_workers.py"
+            - "--name=$(JOB_NAME)"
+            - "--image=gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            - "--owner_name=$(POD_NAME)"
+            - "--owner_uid=$(POD_UID)"
+            - "--namespace=$(POD_NAMESPACE)"
+            - "--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)"
+            - "--cpu=4"
+            - "--memory=4Gi"
+            - "--volumes=pytorch-datasets-claim:/datasets"
+            - "--"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/roberta-pre/func/v3-32/$(JOB_NAME)"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-pods:nightly"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 32
+              "requests":
+                "cpu": "9.0"
+                "ephemeral-storage": "10Gi"
+                "memory": "30Gi"
+            "volumeMounts":
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/roberta-pre/func/v3-32/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": null,
+                 "test_name": "pt-r1.7-roberta-pre-func-v3-32"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "serviceAccountName": "pytorch-xla-pods"
+          "volumes":
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 22 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-cpp-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-cpp-ops-func-v2-8.yaml
@@ -15,18 +15,18 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-1.5-resnet50-mp-conv-v3-8"
+  "name": "pt-r1.7-cpp-ops-func-v2-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 93600
+      "activeDeadlineSeconds": 14400
       "backoffLimit": 1
       "template":
         "metadata":
           "annotations":
-            "tf-version.cloud-tpus.google.com": "pytorch-1.5"
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":
           - "env":
@@ -42,15 +42,8 @@
             "imagePullPolicy": "Always"
             "name": "monitor"
           - "args":
-            - "python3"
-            - "pytorch/xla/test/test_train_mp_imagenet.py"
-            - "--logdir=$(MODEL_DIR)"
-            - "--model=resnet50"
-            - "--num_workers=8"
-            - "--batch_size=128"
-            - "--log_steps=200"
-            - "--num_epochs=90"
-            - "--datadir=/datasets/imagenet"
+            - "bash"
+            - "pytorch/xla/test/cpp/run_tests.sh"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -69,28 +62,25 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/resnet50-mp/conv/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/cpp-ops/func/v2-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.5"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
-                "cloud-tpus.google.com/preemptible-v3": 8
+                "cloud-tpus.google.com/v2": 8
               "requests":
-                "cpu": "90.0"
-                "memory": "400Gi"
+                "cpu": "4.5"
+                "memory": "8Gi"
             "volumeMounts":
             - "mountPath": "/dev/shm"
               "name": "dshm"
               "readOnly": false
-            - "mountPath": "/datasets"
-              "name": "pytorch-datasets-claim"
-              "readOnly": true
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -110,7 +100,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/resnet50-mp/conv/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/cpp-ops/func/v2-8/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -123,43 +113,8 @@
                   ],
                   "write_to_bigquery": true
                  },
-                 "regression_test_config": {
-                  "metric_subset_to_alert": [
-                   "ExecuteTime__Percentile_99_sec_final",
-                   "total_wall_time",
-                   "Accuracy/test_final",
-                   "aten_ops_sum_final"
-                  ],
-                  "metric_success_conditions": {
-                   "Accuracy/test_final": {
-                    "comparison": "greater",
-                    "success_threshold": {
-                     "fixed_value": 75
-                    }
-                   },
-                   "ExecuteTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
-                   "aten_ops_sum_final": {
-                    "comparison": "less_or_equal",
-                    "success_threshold": {
-                     "stddevs_from_mean": 0
-                    }
-                   },
-                   "total_wall_time": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   }
-                  }
-                 },
-                 "test_name": "pt-1.5-resnet50-mp-conv-v3-8"
+                 "regression_test_config": null,
+                 "test_name": "pt-r1.7-cpp-ops-func-v2-8"
                 }
             "envFrom":
             - "configMapRef":
@@ -174,8 +129,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-          - "name": "pytorch-datasets-claim"
-            "persistentVolumeClaim":
-              "claimName": "pytorch-datasets-claim"
-  "schedule": "0 1 * * 1,6"
+  "schedule": "0 22 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-cpp-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-cpp-ops-func-v3-8.yaml
@@ -15,18 +15,18 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-1.5-roberta-pre-func-v3-8"
+  "name": "pt-r1.7-cpp-ops-func-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 3600
+      "activeDeadlineSeconds": 14400
       "backoffLimit": 1
       "template":
         "metadata":
           "annotations":
-            "tf-version.cloud-tpus.google.com": "pytorch-1.5"
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":
           - "env":
@@ -42,44 +42,8 @@
             "imagePullPolicy": "Always"
             "name": "monitor"
           - "args":
-            - "/bin/bash"
-            - "-c"
-            - |
-              set -u
-              set -e
-              set -x
-              
-              pip install --editable tpu-examples/deps/fairseq
-              python3 \
-                /tpu-examples/deps/fairseq/train.py \
-                /datasets/wikitext-103 \
-                --tensorboard-logdir=$(MODEL_DIR) \
-                --task=masked_lm --criterion=masked_lm \
-                --arch=roberta_base --sample-break-mode=complete \
-                --tokens-per-sample=512 \
-                --optimizer=adam \
-                --adam-betas='(0.9,0.98)' \
-                --adam-eps=1e-6 \
-                --clip-norm=0.0 \
-                --lr-scheduler=polynomial_decay \
-                --lr=0.0005 \
-                --warmup-updates=10000 \
-                --dropout=0.1 \
-                --attention-dropout=0.1 \
-                --weight-decay=0.01 \
-                --update-freq=16 \
-                --log-format=simple \
-                --train-subset=train \
-                --valid-subset=valid \
-                --num_cores=8 \
-                --metrics_debug \
-                --save-dir=checkpoints \
-                --log_steps=30 \
-                --skip-invalid-size-inputs-valid-test \
-                --suppress_loss_report \
-                --input_shapes 16x512 18x480 21x384 \
-                --max-epoch=1
-              
+            - "bash"
+            - "pytorch/xla/test/cpp/run_tests.sh"
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -98,28 +62,25 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/roberta-pre/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/cpp-ops/func/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.5"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
                 "cloud-tpus.google.com/v3": 8
               "requests":
-                "cpu": "9.0"
-                "memory": "30Gi"
+                "cpu": "4.5"
+                "memory": "8Gi"
             "volumeMounts":
             - "mountPath": "/dev/shm"
               "name": "dshm"
               "readOnly": false
-            - "mountPath": "/datasets"
-              "name": "pytorch-datasets-claim"
-              "readOnly": true
           "initContainers":
           - "env":
             - "name": "POD_NAME"
@@ -139,7 +100,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/roberta-pre/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/cpp-ops/func/v3-8/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -153,7 +114,7 @@
                   "write_to_bigquery": true
                  },
                  "regression_test_config": null,
-                 "test_name": "pt-1.5-roberta-pre-func-v3-8"
+                 "test_name": "pt-r1.7-cpp-ops-func-v3-8"
                 }
             "envFrom":
             - "configMapRef":
@@ -168,8 +129,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-          - "name": "pytorch-datasets-claim"
-            "persistentVolumeClaim":
-              "claimName": "pytorch-datasets-claim"
-  "schedule": "0 23 * * *"
+  "schedule": "0 22 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-dlrm-convergence-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-dlrm-convergence-conv-v3-8.yaml
@@ -1,0 +1,203 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-dlrm-convergence-conv-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 21600
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              apt-get install -y bc
+              pip install onnx
+              git clone --recursive https://github.com/pytorch-tpu/examples.git
+              python examples/deps/dlrm/dlrm_tpu_runner.py \
+                  --arch-sparse-feature-size=16 \
+                  --arch-mlp-bot="13-512-256-64-16" \
+                  --arch-mlp-top="512-256-1" \
+                  --data-generation=dataset \
+                  --data-set=kaggle \
+                  --raw-data-file=/datasets/criteo-kaggle/train.txt \
+                  --processed-data-file=/datasets/criteo-kaggle/kaggleAdDisplayChallenge_processed.npz \
+                  --loss-function=bce \
+                  --round-targets=True \
+                  --learning-rate=0.1 \
+                  --mini-batch-size=128 \
+                  --print-freq=1024 \
+                  --print-time \
+                  --test-mini-batch-size=16384 \
+                  --test-num-workers=4 \
+                  --test-freq=101376 \
+                      --use-tpu \
+                      --num-indices-per-lookup=1 \
+                      --num-indices-per-lookup-fixed \
+                      --tpu-model-parallel-group-len 8 \
+                      --tpu-metrics-debug \
+                      --tpu-cores=8 |& tee dlrm_logs.txt
+              acc=`grep Testing dlrm_logs.txt | tail -1 | grep -oP 'best \K[+-]?([0-9]*[.])?[0-9]+'`
+              echo 'Accuracy is' $acc
+              test $(echo $acc'>'78.75 | bc -l) -eq 1  # assert cls acc higher than 78.75
+              
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/dlrm-convergence/conv/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "40.0"
+                "memory": "500Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/dlrm-convergence/conv/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-dlrm-convergence-conv-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 0 * * 0,2,4"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-dlrm-mpdp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-dlrm-mpdp-fwd-func-v3-8.yaml
@@ -1,0 +1,195 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-dlrm-mpdp-fwd-func-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 10800
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              pip install onnx
+              git clone --recursive https://github.com/pytorch-tpu/examples.git
+              python examples/deps/dlrm/dlrm_tpu_runner.py \
+                --arch-sparse-feature-size=64 \
+                --arch-mlp-bot=512-512-64 \
+                --arch-mlp-top=1024-1024-1024-1 \
+                --arch-interaction-op=dot \
+                --lr-num-warmup-steps 10 \
+                --lr-decay-start-step 10 \
+                --num-batches=1000 \
+                --data-generation="random" \
+                --numpy-rand-seed=727 \
+                --print-freq 100 \
+                --num-indices-per-lookup=100 \
+                --use-tpu \
+                --metrics-debug \
+                --num-indices-per-lookup-fixed \
+                --mini-batch-size=2048 \
+                --arch-embedding-size=1000000-1000000-1000000-1000000-1000000-1000000-1000000-1000000 \
+                --tpu-model-parallel-group-len 4 \
+                --tpu-cores=8
+              
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/dlrm-mpdp-fwd/func/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "9.0"
+                "memory": "30Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/dlrm-mpdp-fwd/func/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-dlrm-mpdp-fwd-func-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 22 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-fs-checkpoint-gcs-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-fs-checkpoint-gcs-func-v3-8.yaml
@@ -15,7 +15,7 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-1.5-fs-checkpoint-gcs-func-v3-8"
+  "name": "pt-r1.7-fs-checkpoint-gcs-func-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
@@ -26,7 +26,7 @@
       "template":
         "metadata":
           "annotations":
-            "tf-version.cloud-tpus.google.com": "pytorch-1.5"
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":
           - "env":
@@ -52,7 +52,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --metrics_debug \
                 --arch=transformer_vaswani_wmt_en_de_big \
                 --max-target-positions=64 \
@@ -86,7 +85,6 @@
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --metrics_debug \
                 --arch=transformer_vaswani_wmt_en_de_big \
                 --max-target-positions=64 \
@@ -137,13 +135,13 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/fs-checkpoint-gcs/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-checkpoint-gcs/func/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "1"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.5"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
@@ -178,7 +176,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/fs-checkpoint-gcs/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-checkpoint-gcs/func/v3-8/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -221,7 +219,7 @@
                    }
                   }
                  },
-                 "test_name": "pt-1.5-fs-checkpoint-gcs-func-v3-8"
+                 "test_name": "pt-r1.7-fs-checkpoint-gcs-func-v3-8"
                 }
             "envFrom":
             - "configMapRef":
@@ -239,5 +237,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 23 * * *"
+  "schedule": "0 22 * * *"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-fs-checkpoint-local-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-fs-checkpoint-local-func-v3-8.yaml
@@ -1,0 +1,238 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-fs-checkpoint-local-func-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 7200
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              python3 \
+                /tpu-examples/deps/fairseq/train.py \
+                /datasets/wmt18_en_de_bpej32k \
+                --metrics_debug \
+                --arch=transformer_vaswani_wmt_en_de_big \
+                --max-target-positions=64 \
+                --attention-dropout=0.1 \
+                --no-progress-bar \
+                --criterion=label_smoothed_cross_entropy \
+                --source-lang=en \
+                --lr-scheduler=inverse_sqrt  \
+                --min-lr=1e-09 \
+                --skip-invalid-size-inputs-valid-test \
+                --target-lang=de \
+                --label-smoothing=0.1 \
+                --update-freq=1 \
+                --optimizer=adam \
+                --adam-betas='(0.9,0.98)' \
+                --warmup-init-lr=1e-07 \
+                --lr=0.0005 \
+                --warmup-updates=4000 \
+                --share-all-embeddings \
+                --dropout=0.3 \
+                --weight-decay=0.0 \
+                --num_cores=8 \
+                --log_steps=10 \
+                --train-subset=test \
+                --valid-subset=valid \
+                --save-interval=1 \
+                --input_shapes=128x64 \
+                --max-epoch=1 \
+                --save-dir=/tmp/checkpoints
+              python3 \
+                /tpu-examples/deps/fairseq/train.py \
+                /datasets/wmt18_en_de_bpej32k \
+                --metrics_debug \
+                --arch=transformer_vaswani_wmt_en_de_big \
+                --max-target-positions=64 \
+                --attention-dropout=0.1 \
+                --no-progress-bar \
+                --criterion=label_smoothed_cross_entropy \
+                --source-lang=en \
+                --lr-scheduler=inverse_sqrt  \
+                --min-lr=1e-09 \
+                --skip-invalid-size-inputs-valid-test \
+                --target-lang=de \
+                --label-smoothing=0.1 \
+                --update-freq=1 \
+                --optimizer=adam \
+                --adam-betas='(0.9,0.98)' \
+                --warmup-init-lr=1e-07 \
+                --lr=0.0005 \
+                --warmup-updates=4000 \
+                --share-all-embeddings \
+                --dropout=0.3 \
+                --weight-decay=0.0 \
+                --num_cores=8 \
+                --log_steps=10 \
+                --train-subset=test \
+                --valid-subset=valid \
+                --save-interval=1 \
+                --input_shapes=128x64 \
+                --max-epoch=2 \
+                --save-dir=/tmp/checkpoints
+              
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-checkpoint-local/func/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "9.0"
+                "memory": "30Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-checkpoint-local/func/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-fs-checkpoint-local-func-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 22 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-fs-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-fs-transformer-conv-v3-8.yaml
@@ -15,18 +15,18 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-1.5-fs-checkpoint-local-func-v3-8"
+  "name": "pt-r1.7-fs-transformer-conv-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
   "jobTemplate":
     "spec":
-      "activeDeadlineSeconds": 7200
+      "activeDeadlineSeconds": 90000
       "backoffLimit": 1
       "template":
         "metadata":
           "annotations":
-            "tf-version.cloud-tpus.google.com": "pytorch-1.5"
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":
           - "env":
@@ -49,10 +49,10 @@
               set -e
               set -x
               
+              pip install --editable /tpu-examples/deps/fairseq
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
                 /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
                 --metrics_debug \
                 --arch=transformer_vaswani_wmt_en_de_big \
                 --max-target-positions=64 \
@@ -75,46 +75,21 @@
                 --dropout=0.3 \
                 --weight-decay=0.0 \
                 --num_cores=8 \
-                --log_steps=10 \
-                --train-subset=test \
+                --save-interval=5 \
+                --save-dir=/tmp/checkpoints \
+                --max-epoch=25 \
+                --log_steps=200 \
+                --train-subset=train \
                 --valid-subset=valid \
-                --save-interval=1 \
-                --input_shapes=128x64 \
-                --max-epoch=1 \
-                --save-dir=/tmp/checkpoints
-              python3 \
-                /tpu-examples/deps/fairseq/train.py \
-                /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
-                --metrics_debug \
-                --arch=transformer_vaswani_wmt_en_de_big \
-                --max-target-positions=64 \
-                --attention-dropout=0.1 \
-                --no-progress-bar \
-                --criterion=label_smoothed_cross_entropy \
-                --source-lang=en \
-                --lr-scheduler=inverse_sqrt  \
-                --min-lr=1e-09 \
-                --skip-invalid-size-inputs-valid-test \
-                --target-lang=de \
-                --label-smoothing=0.1 \
-                --update-freq=1 \
-                --optimizer=adam \
-                --adam-betas='(0.9,0.98)' \
-                --warmup-init-lr=1e-07 \
-                --lr=0.0005 \
-                --warmup-updates=4000 \
-                --share-all-embeddings \
-                --dropout=0.3 \
-                --weight-decay=0.0 \
-                --num_cores=8 \
-                --log_steps=10 \
-                --train-subset=test \
-                --valid-subset=valid \
-                --save-interval=1 \
-                --input_shapes=128x64 \
-                --max-epoch=2 \
-                --save-dir=/tmp/checkpoints
+                --input_shapes 256x64 512x32
+              bleu=`fairseq-generate \
+                 /datasets/wmt18_en_de_bpej32k \
+                 --remove-bpe --quiet --lenpen 0.6 --beam 4 \
+                 --path /tmp/checkpoints/checkpoint25.pt \
+                 --skip-invalid-size-inputs-valid-test | grep BLEU \
+                 | grep -v loadi | tail -1 | cut -d '=' -f 3| cut -d'.' -f 1`
+              echo 'BLEU score is' $bleu
+              test $bleu -gt 27
               
             "env":
             - "name": "POD_NAME"
@@ -134,13 +109,13 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/fs-checkpoint-local/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-transformer/conv/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
-              "value": "0"
+              "value": "1"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.5"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
@@ -175,7 +150,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/fs-checkpoint-local/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-transformer/conv/v3-8/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -215,10 +190,16 @@
                      "stddevs_from_mean": 5
                     },
                     "wait_for_n_points_of_history": 10
+                   },
+                   "train-wps_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 11700
+                    }
                    }
                   }
                  },
-                 "test_name": "pt-1.5-fs-checkpoint-local-func-v3-8"
+                 "test_name": "pt-r1.7-fs-transformer-conv-v3-8"
                 }
             "envFrom":
             - "configMapRef":
@@ -236,5 +217,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 23 * * *"
+  "schedule": "0 0 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-fs-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-fs-transformer-func-v3-8.yaml
@@ -1,0 +1,205 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-fs-transformer-func-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 3600
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              python3 \
+                /tpu-examples/deps/fairseq/train.py \
+                /datasets/wmt18_en_de_bpej32k \
+                --metrics_debug \
+                --arch=transformer_vaswani_wmt_en_de_big \
+                --max-target-positions=64 \
+                --attention-dropout=0.1 \
+                --no-progress-bar \
+                --criterion=label_smoothed_cross_entropy \
+                --source-lang=en \
+                --lr-scheduler=inverse_sqrt  \
+                --min-lr=1e-09 \
+                --skip-invalid-size-inputs-valid-test \
+                --target-lang=de \
+                --label-smoothing=0.1 \
+                --update-freq=1 \
+                --optimizer=adam \
+                --adam-betas='(0.9,0.98)' \
+                --warmup-init-lr=1e-07 \
+                --lr=0.0005 \
+                --warmup-updates=4000 \
+                --share-all-embeddings \
+                --dropout=0.3 \
+                --weight-decay=0.0 \
+                --num_cores=8 \
+                --no-save \
+                --max-epoch=1 \
+                --log_steps=10 \
+                --train-subset=valid \
+                --valid-subset=test \
+                --input_shapes=128x64
+              
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-transformer/func/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "9.0"
+                "memory": "30Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/fs-transformer/func/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-fs-transformer-func-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 22 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-hf-glue-bert-b-c-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-glue-bert-b-c-conv-v2-8.yaml
@@ -1,0 +1,216 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-hf-glue-bert-b-c-conv-v2-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 7200
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              git clone https://github.com/huggingface/transformers.git
+              cd transformers && pip install .
+              git log -1
+              python examples/xla_spawn.py \
+                --num_cores 8 \
+                examples/text-classification/run_glue.py \
+                --logging_dir=./tensorboard-metrics \
+                --task_name MNLI \
+                --data_dir /datasets/glue/MNLI \
+                --cache_dir ./cache_dir \
+                --do_train \
+                --do_eval \
+                --num_train_epochs 3 \
+                --max_seq_length 128 \
+                --learning_rate 3e-5 \
+                --output_dir MNLI \
+                --overwrite_output_dir \
+                --logging_steps 100 \
+                --save_steps 3000 \
+                --overwrite_cache \
+                --tpu_metrics_debug \
+               --model_name_or_path bert-base-cased \
+              --per_device_train_batch_size 64 \
+              --per_device_eval_batch_size 64
+              gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
+              
+              
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-glue-bert-b-c/conv/v2-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v2": 8
+              "requests":
+                "cpu": "12.0"
+                "memory": "80Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-glue-bert-b-c/conv/v2-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "eval_mnli-mm/acc": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 0.80000000000000004
+                    }
+                   },
+                   "eval_mnli/acc": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 0.80000000000000004
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  },
+                  "required_metrics": [
+                   "eval_mnli/acc",
+                   "eval_mnli-mm/acc"
+                  ]
+                 },
+                 "test_name": "pt-r1.7-hf-glue-bert-b-c-conv-v2-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 0 * * 0,2,4"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-hf-glue-bert-b-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-glue-bert-b-c-conv-v3-8.yaml
@@ -15,7 +15,7 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-1.5-resnet50-mp-func-v3-8"
+  "name": "pt-r1.7-hf-glue-bert-b-c-conv-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
@@ -26,7 +26,7 @@
       "template":
         "metadata":
           "annotations":
-            "tf-version.cloud-tpus.google.com": "pytorch-1.5"
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":
           - "env":
@@ -42,15 +42,40 @@
             "imagePullPolicy": "Always"
             "name": "monitor"
           - "args":
-            - "python3"
-            - "pytorch/xla/test/test_train_mp_imagenet.py"
-            - "--logdir=$(MODEL_DIR)"
-            - "--model=resnet50"
-            - "--num_workers=8"
-            - "--batch_size=128"
-            - "--log_steps=200"
-            - "--num_epochs=2"
-            - "--datadir=/datasets/imagenet-mini"
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              git clone https://github.com/huggingface/transformers.git
+              cd transformers && pip install .
+              git log -1
+              python examples/xla_spawn.py \
+                --num_cores 8 \
+                examples/text-classification/run_glue.py \
+                --logging_dir=./tensorboard-metrics \
+                --task_name MNLI \
+                --data_dir /datasets/glue/MNLI \
+                --cache_dir ./cache_dir \
+                --do_train \
+                --do_eval \
+                --num_train_epochs 3 \
+                --max_seq_length 128 \
+                --learning_rate 3e-5 \
+                --output_dir MNLI \
+                --overwrite_output_dir \
+                --logging_steps 100 \
+                --save_steps 3000 \
+                --overwrite_cache \
+                --tpu_metrics_debug \
+               --model_name_or_path bert-base-cased \
+              --per_device_train_batch_size 64 \
+              --per_device_eval_batch_size 64
+              gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
+              
+              
             "env":
             - "name": "POD_NAME"
               "valueFrom":
@@ -69,21 +94,21 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/resnet50-mp/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-glue-bert-b-c/conv/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.5"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
               "limits":
                 "cloud-tpus.google.com/v3": 8
               "requests":
-                "cpu": "90.0"
-                "memory": "400Gi"
+                "cpu": "12.0"
+                "memory": "80Gi"
             "volumeMounts":
             - "mountPath": "/dev/shm"
               "name": "dshm"
@@ -110,7 +135,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/resnet50-mp/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-glue-bert-b-c/conv/v3-8/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -144,6 +169,18 @@
                      "stddevs_from_mean": 0
                     }
                    },
+                   "eval_mnli-mm/acc": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 0.80000000000000004
+                    }
+                   },
+                   "eval_mnli/acc": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 0.80000000000000004
+                    }
+                   },
                    "total_wall_time": {
                     "comparison": "less",
                     "success_threshold": {
@@ -151,9 +188,13 @@
                     },
                     "wait_for_n_points_of_history": 10
                    }
-                  }
+                  },
+                  "required_metrics": [
+                   "eval_mnli/acc",
+                   "eval_mnli-mm/acc"
+                  ]
                  },
-                 "test_name": "pt-1.5-resnet50-mp-func-v3-8"
+                 "test_name": "pt-r1.7-hf-glue-bert-b-c-conv-v3-8"
                 }
             "envFrom":
             - "configMapRef":
@@ -171,5 +212,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 23 * * *"
+  "schedule": "0 0 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-fine-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-fine-conv-v3-8.yaml
@@ -1,0 +1,208 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-hf-mlm-roberta-b-fine-conv-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 10800
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              git clone https://github.com/huggingface/transformers.git
+              cd transformers && pip install .
+              git log -1
+              python examples/xla_spawn.py \
+                --num_cores 8 \
+                examples/language-modeling/run_language_modeling.py \
+                --logging_dir ./tensorboard-metrics \
+                --cache_dir ./cache_dir \
+                --train_data_file /datasets/wikitext-103-raw/wiki.train.raw \
+                --do_train \
+                --do_eval \
+                --eval_data_file /datasets/wikitext-103-raw/wiki.valid.raw \
+                --overwrite_output_dir \
+                --output_dir language-modeling \
+                --logging_steps 100 \
+                --save_steps 3000 \
+                --overwrite_cache \
+                --tpu_metrics_debug \
+               --mlm --model_type=roberta \
+              --model_name_or_path roberta-base \
+              --num_train_epochs 3 \
+              --per_device_train_batch_size 8 \
+              --per_device_eval_batch_size 8
+              gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
+              
+              
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-mlm-roberta-b-fine/conv/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "12.0"
+                "memory": "80Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-mlm-roberta-b-fine/conv/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "eval_loss": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "fixed_value": 1.5
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  },
+                  "required_metrics": [
+                   "eval_loss"
+                  ]
+                 },
+                 "test_name": "pt-r1.7-hf-mlm-roberta-b-fine-conv-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 0 * * 0,2,4"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-pre-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-pre-conv-v2-8.yaml
@@ -1,0 +1,208 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-hf-mlm-roberta-b-pre-conv-v2-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 18000
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              git clone https://github.com/huggingface/transformers.git
+              cd transformers && pip install .
+              git log -1
+              python examples/xla_spawn.py \
+                --num_cores 8 \
+                examples/language-modeling/run_language_modeling.py \
+                --logging_dir ./tensorboard-metrics \
+                --cache_dir ./cache_dir \
+                --train_data_file /datasets/wikitext-103-raw/wiki.train.raw \
+                --do_train \
+                --do_eval \
+                --eval_data_file /datasets/wikitext-103-raw/wiki.valid.raw \
+                --overwrite_output_dir \
+                --output_dir language-modeling \
+                --logging_steps 100 \
+                --save_steps 3000 \
+                --overwrite_cache \
+                --tpu_metrics_debug \
+               --mlm --model_type=roberta \
+              --tokenizer=roberta-base \
+              --num_train_epochs 5 \
+              --per_device_train_batch_size 8 \
+              --per_device_eval_batch_size 8
+              gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
+              
+              
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-mlm-roberta-b-pre/conv/v2-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v2": 8
+              "requests":
+                "cpu": "12.0"
+                "memory": "80Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-mlm-roberta-b-pre/conv/v2-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "eval_loss": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "fixed_value": 6.5
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  },
+                  "required_metrics": [
+                   "eval_loss"
+                  ]
+                 },
+                 "test_name": "pt-r1.7-hf-mlm-roberta-b-pre-conv-v2-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 0 * * 0,2,4"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-pre-conv-v3-8.yaml
@@ -1,0 +1,208 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-hf-mlm-roberta-b-pre-conv-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 14400
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              git clone https://github.com/huggingface/transformers.git
+              cd transformers && pip install .
+              git log -1
+              python examples/xla_spawn.py \
+                --num_cores 8 \
+                examples/language-modeling/run_language_modeling.py \
+                --logging_dir ./tensorboard-metrics \
+                --cache_dir ./cache_dir \
+                --train_data_file /datasets/wikitext-103-raw/wiki.train.raw \
+                --do_train \
+                --do_eval \
+                --eval_data_file /datasets/wikitext-103-raw/wiki.valid.raw \
+                --overwrite_output_dir \
+                --output_dir language-modeling \
+                --logging_steps 100 \
+                --save_steps 3000 \
+                --overwrite_cache \
+                --tpu_metrics_debug \
+               --mlm --model_type=roberta \
+              --tokenizer=roberta-base \
+              --num_train_epochs 5 \
+              --per_device_train_batch_size 8 \
+              --per_device_eval_batch_size 8
+              gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
+              
+              
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-mlm-roberta-b-pre/conv/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "12.0"
+                "memory": "80Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/hf-mlm-roberta-b-pre/conv/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "eval_loss": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "fixed_value": 6.5
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  },
+                  "required_metrics": [
+                   "eval_loss"
+                  ]
+                 },
+                 "test_name": "pt-r1.7-hf-mlm-roberta-b-pre-conv-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 0 * * 0,2,4"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-mnist-3-7-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-mnist-3-7-conv-v2-8.yaml
@@ -1,0 +1,169 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-mnist-3-7-conv-v2-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 3600
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "python3"
+            - "pytorch/xla/test/test_train_mp_mnist.py"
+            - "--logdir=$(MODEL_DIR)"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist-3-7/conv/v2-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7_3.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v2": 8
+              "requests":
+                "cpu": "4.5"
+                "memory": "8Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist-3-7/conv/v2-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "Accuracy/test_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 98
+                    }
+                   },
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-mnist-3-7-conv-v2-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+  "schedule": "30 21 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-mnist-3-7-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-mnist-3-7-conv-v3-8.yaml
@@ -1,0 +1,169 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-mnist-3-7-conv-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 3600
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "python3"
+            - "pytorch/xla/test/test_train_mp_mnist.py"
+            - "--logdir=$(MODEL_DIR)"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist-3-7/conv/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7_3.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "4.5"
+                "memory": "8Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist-3-7/conv/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "Accuracy/test_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 98
+                    }
+                   },
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-mnist-3-7-conv-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+  "schedule": "30 21 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-mnist-conv-v2-8.yaml
@@ -1,0 +1,169 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-mnist-conv-v2-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 3600
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "python3"
+            - "pytorch/xla/test/test_train_mp_mnist.py"
+            - "--logdir=$(MODEL_DIR)"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist/conv/v2-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v2": 8
+              "requests":
+                "cpu": "4.5"
+                "memory": "8Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist/conv/v2-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "Accuracy/test_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 98
+                    }
+                   },
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-mnist-conv-v2-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+  "schedule": "0 21 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-mnist-conv-v3-8.yaml
@@ -1,0 +1,169 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-mnist-conv-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 3600
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "python3"
+            - "pytorch/xla/test/test_train_mp_mnist.py"
+            - "--logdir=$(MODEL_DIR)"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist/conv/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "4.5"
+                "memory": "8Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/mnist/conv/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "Accuracy/test_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 98
+                    }
+                   },
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-mnist-conv-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+  "schedule": "2 21 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-python-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-python-ops-func-v2-8.yaml
@@ -1,0 +1,133 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-python-ops-func-v2-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 7200
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "bash"
+            - "pytorch/xla/test/run_tests.sh"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/python-ops/func/v2-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v2": 8
+              "requests":
+                "cpu": "4.5"
+                "memory": "8Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/python-ops/func/v2-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": null,
+                 "test_name": "pt-r1.7-python-ops-func-v2-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+  "schedule": "0 22 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-python-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-python-ops-func-v3-8.yaml
@@ -1,0 +1,133 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-python-ops-func-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 7200
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "bash"
+            - "pytorch/xla/test/run_tests.sh"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/python-ops/func/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "4.5"
+                "memory": "8Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/python-ops/func/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": null,
+                 "test_name": "pt-r1.7-python-ops-func-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+  "schedule": "0 22 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-resnet50-mp-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-resnet50-mp-conv-v3-8.yaml
@@ -1,0 +1,181 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-resnet50-mp-conv-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 93600
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "python3"
+            - "pytorch/xla/test/test_train_mp_imagenet.py"
+            - "--logdir=$(MODEL_DIR)"
+            - "--model=resnet50"
+            - "--num_workers=8"
+            - "--batch_size=128"
+            - "--log_steps=200"
+            - "--num_epochs=90"
+            - "--datadir=/datasets/imagenet"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/resnet50-mp/conv/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/preemptible-v3": 8
+              "requests":
+                "cpu": "90.0"
+                "memory": "400Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/resnet50-mp/conv/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "Accuracy/test_final": {
+                    "comparison": "greater",
+                    "success_threshold": {
+                     "fixed_value": 75
+                    }
+                   },
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-resnet50-mp-conv-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 0 * * 0,2,4"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-resnet50-mp-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-resnet50-mp-func-v3-8.yaml
@@ -1,0 +1,175 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-resnet50-mp-func-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 7200
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "python3"
+            - "pytorch/xla/test/test_train_mp_imagenet.py"
+            - "--logdir=$(MODEL_DIR)"
+            - "--model=resnet50"
+            - "--num_workers=8"
+            - "--batch_size=128"
+            - "--log_steps=200"
+            - "--num_epochs=2"
+            - "--datadir=/datasets/imagenet-mini"
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/resnet50-mp/func/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "90.0"
+                "memory": "400Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/resnet50-mp/func/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-resnet50-mp-func-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 22 * * *"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-roberta-pre-conv-v3-8.yaml
@@ -1,0 +1,204 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"apiVersion": "batch/v1beta1"
+"kind": "CronJob"
+"metadata":
+  "name": "pt-r1.7-roberta-pre-conv-v3-8"
+  "namespace": "automated"
+"spec":
+  "concurrencyPolicy": "Forbid"
+  "jobTemplate":
+    "spec":
+      "activeDeadlineSeconds": 7200
+      "backoffLimit": 1
+      "template":
+        "metadata":
+          "annotations":
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
+        "spec":
+          "containers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            "image": "gcr.io/xl-ml-test/health-monitor:stable"
+            "imagePullPolicy": "Always"
+            "name": "monitor"
+          - "args":
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -u
+              set -e
+              set -x
+              
+              pip install --editable tpu-examples/deps/fairseq
+              python3 \
+                /tpu-examples/deps/fairseq/train.py \
+                /datasets/wikitext-103 \
+                --task=masked_lm --criterion=masked_lm \
+                --arch=roberta_base --sample-break-mode=complete \
+                --tokens-per-sample=512 \
+                --optimizer=adam \
+                --adam-betas='(0.9,0.98)' \
+                --adam-eps=1e-6 \
+                --clip-norm=0.0 \
+                --lr-scheduler=polynomial_decay \
+                --lr=0.0005 \
+                --warmup-updates=10000 \
+                --dropout=0.1 \
+                --attention-dropout=0.1 \
+                --weight-decay=0.01 \
+                --update-freq=16 \
+                --log-format=simple \
+                --train-subset=train \
+                --valid-subset=valid \
+                --num_cores=8 \
+                --metrics_debug \
+                --save-dir=checkpoints \
+                --log_steps=30 \
+                --skip-invalid-size-inputs-valid-test \
+                --suppress_loss_report \
+                --input_shapes 16x512 18x480 21x384 \
+                --max-epoch=5
+              
+            "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/roberta-pre/conv/v3-8/$(JOB_NAME)"
+            - "name": "XLA_USE_BF16"
+              "value": "0"
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
+            "imagePullPolicy": "Always"
+            "name": "train"
+            "resources":
+              "limits":
+                "cloud-tpus.google.com/v3": 8
+              "requests":
+                "cpu": "9.0"
+                "ephemeral-storage": "10Gi"
+                "memory": "30Gi"
+            "volumeMounts":
+            - "mountPath": "/dev/shm"
+              "name": "dshm"
+              "readOnly": false
+            - "mountPath": "/datasets"
+              "name": "pytorch-datasets-claim"
+              "readOnly": true
+          "initContainers":
+          - "env":
+            - "name": "POD_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.name"
+            - "name": "POD_UID"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.uid"
+            - "name": "POD_NAMESPACE"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.namespace"
+            - "name": "JOB_NAME"
+              "valueFrom":
+                "fieldRef":
+                  "fieldPath": "metadata.labels['job-name']"
+            - "name": "MODEL_DIR"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/roberta-pre/conv/v3-8/$(JOB_NAME)"
+            - "name": "METRIC_CONFIG"
+              "value": |
+                {
+                 "metric_collection_config": {
+                  "default_aggregation_strategies": [
+                   "final"
+                  ],
+                  "tags_to_ignore": [
+                   "LearningRate"
+                  ],
+                  "write_to_bigquery": true
+                 },
+                 "regression_test_config": {
+                  "metric_subset_to_alert": [
+                   "ExecuteTime__Percentile_99_sec_final",
+                   "total_wall_time",
+                   "Accuracy/test_final",
+                   "aten_ops_sum_final"
+                  ],
+                  "metric_success_conditions": {
+                   "ExecuteTime__Percentile_99_sec_final": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   },
+                   "aten_ops_sum_final": {
+                    "comparison": "less_or_equal",
+                    "success_threshold": {
+                     "stddevs_from_mean": 0
+                    }
+                   },
+                   "total_wall_time": {
+                    "comparison": "less",
+                    "success_threshold": {
+                     "stddevs_from_mean": 5
+                    },
+                    "wait_for_n_points_of_history": 10
+                   }
+                  }
+                 },
+                 "test_name": "pt-r1.7-roberta-pre-conv-v3-8"
+                }
+            "envFrom":
+            - "configMapRef":
+                "name": "gcs-buckets"
+            "image": "gcr.io/xl-ml-test/publisher:stable"
+            "imagePullPolicy": "Always"
+            "name": "publisher"
+          "nodeSelector":
+            "tpu-available": "true"
+          "restartPolicy": "Never"
+          "volumes":
+          - "emptyDir":
+              "medium": "Memory"
+            "name": "dshm"
+          - "name": "pytorch-datasets-claim"
+            "persistentVolumeClaim":
+              "claimName": "pytorch-datasets-claim"
+  "schedule": "0 0 * * 0,2,4"
+  "successfulJobsHistoryLimit": 1

--- a/k8s/us-central1/gen/pt-r1.7-roberta-pre-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-roberta-pre-func-v3-8.yaml
@@ -15,7 +15,7 @@
 "apiVersion": "batch/v1beta1"
 "kind": "CronJob"
 "metadata":
-  "name": "pt-1.5-fs-transformer-func-v3-8"
+  "name": "pt-r1.7-roberta-pre-func-v3-8"
   "namespace": "automated"
 "spec":
   "concurrencyPolicy": "Forbid"
@@ -26,7 +26,7 @@
       "template":
         "metadata":
           "annotations":
-            "tf-version.cloud-tpus.google.com": "pytorch-1.5"
+            "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":
           - "env":
@@ -49,38 +49,35 @@
               set -e
               set -x
               
+              pip install --editable tpu-examples/deps/fairseq
               python3 \
                 /tpu-examples/deps/fairseq/train.py \
-                /datasets/wmt18_en_de_bpej32k \
-                --tensorboard-logdir=$(MODEL_DIR) \
-                --metrics_debug \
-                --arch=transformer_vaswani_wmt_en_de_big \
-                --max-target-positions=64 \
-                --attention-dropout=0.1 \
-                --no-progress-bar \
-                --criterion=label_smoothed_cross_entropy \
-                --source-lang=en \
-                --lr-scheduler=inverse_sqrt  \
-                --min-lr=1e-09 \
-                --skip-invalid-size-inputs-valid-test \
-                --target-lang=de \
-                --label-smoothing=0.1 \
-                --update-freq=1 \
+                /datasets/wikitext-103 \
+                --task=masked_lm --criterion=masked_lm \
+                --arch=roberta_base --sample-break-mode=complete \
+                --tokens-per-sample=512 \
                 --optimizer=adam \
                 --adam-betas='(0.9,0.98)' \
-                --warmup-init-lr=1e-07 \
+                --adam-eps=1e-6 \
+                --clip-norm=0.0 \
+                --lr-scheduler=polynomial_decay \
                 --lr=0.0005 \
-                --warmup-updates=4000 \
-                --share-all-embeddings \
-                --dropout=0.3 \
-                --weight-decay=0.0 \
+                --warmup-updates=10000 \
+                --dropout=0.1 \
+                --attention-dropout=0.1 \
+                --weight-decay=0.01 \
+                --update-freq=16 \
+                --log-format=simple \
+                --train-subset=train \
+                --valid-subset=valid \
                 --num_cores=8 \
-                --no-save \
-                --max-epoch=1 \
-                --log_steps=10 \
-                --train-subset=valid \
-                --valid-subset=test \
-                --input_shapes=128x64
+                --metrics_debug \
+                --save-dir=checkpoints \
+                --log_steps=30 \
+                --skip-invalid-size-inputs-valid-test \
+                --suppress_loss_report \
+                --input_shapes 16x512 18x480 21x384 \
+                --max-epoch=1
               
             "env":
             - "name": "POD_NAME"
@@ -100,13 +97,13 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/fs-transformer/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/roberta-pre/func/v3-8/$(JOB_NAME)"
             - "name": "XLA_USE_BF16"
               "value": "0"
             "envFrom":
             - "configMapRef":
                 "name": "gcs-buckets"
-            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.5"
+            "image": "gcr.io/xl-ml-test/pytorch-xla:r1.7"
             "imagePullPolicy": "Always"
             "name": "train"
             "resources":
@@ -114,6 +111,7 @@
                 "cloud-tpus.google.com/v3": 8
               "requests":
                 "cpu": "9.0"
+                "ephemeral-storage": "10Gi"
                 "memory": "30Gi"
             "volumeMounts":
             - "mountPath": "/dev/shm"
@@ -141,7 +139,7 @@
                 "fieldRef":
                   "fieldPath": "metadata.labels['job-name']"
             - "name": "MODEL_DIR"
-              "value": "$(OUTPUT_BUCKET)/pt-1.5/fs-transformer/func/v3-8/$(JOB_NAME)"
+              "value": "$(OUTPUT_BUCKET)/pt-r1.7/roberta-pre/func/v3-8/$(JOB_NAME)"
             - "name": "METRIC_CONFIG"
               "value": |
                 {
@@ -154,37 +152,8 @@
                   ],
                   "write_to_bigquery": true
                  },
-                 "regression_test_config": {
-                  "metric_subset_to_alert": [
-                   "ExecuteTime__Percentile_99_sec_final",
-                   "total_wall_time",
-                   "Accuracy/test_final",
-                   "aten_ops_sum_final"
-                  ],
-                  "metric_success_conditions": {
-                   "ExecuteTime__Percentile_99_sec_final": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   },
-                   "aten_ops_sum_final": {
-                    "comparison": "less_or_equal",
-                    "success_threshold": {
-                     "stddevs_from_mean": 0
-                    }
-                   },
-                   "total_wall_time": {
-                    "comparison": "less",
-                    "success_threshold": {
-                     "stddevs_from_mean": 5
-                    },
-                    "wait_for_n_points_of_history": 10
-                   }
-                  }
-                 },
-                 "test_name": "pt-1.5-fs-transformer-func-v3-8"
+                 "regression_test_config": null,
+                 "test_name": "pt-r1.7-roberta-pre-func-v3-8"
                 }
             "envFrom":
             - "configMapRef":
@@ -202,5 +171,5 @@
           - "name": "pytorch-datasets-claim"
             "persistentVolumeClaim":
               "claimName": "pytorch-datasets-claim"
-  "schedule": "0 23 * * *"
+  "schedule": "0 22 * * *"
   "successfulJobsHistoryLimit": 1

--- a/tests/pytorch/r1.7/common.libsonnet
+++ b/tests/pytorch/r1.7/common.libsonnet
@@ -18,20 +18,35 @@ local volumes = import "templates/volumes.libsonnet";
 
 {
   PyTorchTest:: common.PyTorchTest {
-    frameworkPrefix: "pt-1.5",
+    frameworkPrefix: "pt-r1.7",
     tpuSettings+: {
-      softwareVersion: "pytorch-1.5",
+      softwareVersion: "pytorch-1.7",
     },
-    imageTag: "r1.5",
+    imageTag: "r1.7",
+  },
+  PyTorchXlaDistPodTest:: common.PyTorchXlaDistPodTest {
+    frameworkPrefix: "pt-r1.7",
+    tpuSettings+: {
+      softwareVersion: "pytorch-1.7"
+    },
+    imageTag: "r1.7",
+  },
+  PyTorchGkePodTest:: common.PyTorchGkePodTest {
+    frameworkPrefix: "pt-r1.7",
+    tpuSettings+: {
+      softwareVersion: "pytorch-1.7"
+    },
+    imageTag: "r1.7",
   },
   Functional:: mixins.Functional {
-    schedule: "0 23 * * *",
+    schedule: "0 22 * * *",
     tpuSettings+: {
       preemptible: false,
     },
   },
   Convergence:: mixins.Convergence {
-    schedule: "0 1 * * 1,6",
+    # Run 3 times/week.
+    schedule: "0 0 * * 0,2,4",
   },
   datasetsVolume: volumes.PersistentVolumeSpec {
     name: "pytorch-datasets-claim",

--- a/tests/pytorch/r1.7/cpp-ops.libsonnet
+++ b/tests/pytorch/r1.7/cpp-ops.libsonnet
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+local common = import "common.libsonnet";
+local timeouts = import "templates/timeouts.libsonnet";
+local tpus = import "templates/tpus.libsonnet";
+
+{
+  local operations = common.PyTorchTest {
+    modelName: "cpp-ops",
+    command: [
+      "bash",
+      "pytorch/xla/test/cpp/run_tests.sh",
+    ],
+    regressionTestConfig: null,
+  },
+  local v2_8 = {
+    accelerator: tpus.v2_8,
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+
+  configs: [
+    operations + v2_8 + common.Functional + timeouts.Hours(4),
+    operations + v3_8 + common.Functional + timeouts.Hours(4),
+  ],
+}

--- a/tests/pytorch/r1.7/dlrm.libsonnet
+++ b/tests/pytorch/r1.7/dlrm.libsonnet
@@ -1,0 +1,139 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+local common = import "common.libsonnet";
+local timeouts = import "templates/timeouts.libsonnet";
+local tpus = import "templates/tpus.libsonnet";
+local utils = import "templates/utils.libsonnet";
+
+{
+  local command_common = |||
+    pip install onnx
+    git clone --recursive https://github.com/pytorch-tpu/examples.git
+    python examples/deps/dlrm/dlrm_tpu_runner.py \
+      --arch-sparse-feature-size=64 \
+      --arch-mlp-bot=512-512-64 \
+      --arch-mlp-top=1024-1024-1024-1 \
+      --arch-interaction-op=dot \
+      --lr-num-warmup-steps 10 \
+      --lr-decay-start-step 10 \
+      --num-batches=1000 \
+      --data-generation="random" \
+      --numpy-rand-seed=727 \
+      --print-freq 100 \
+      --num-indices-per-lookup=100 \
+      --use-tpu \
+      --metrics-debug \
+      --num-indices-per-lookup-fixed \
+  |||,
+  local dlrm = common.PyTorchTest {
+    modelName: "dlrm",
+    schedule: "2 22 * * *",
+    volumeMap+: {
+      datasets: common.datasetsVolume,
+    },
+    jobSpec+:: {
+      template+: {
+        spec+: {
+          containerMap+: {
+            train+: {
+              resources+: {
+                requests: {
+                  cpu: "9.0",
+                  memory: "30Gi",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  local dlrm_convergence = common.PyTorchTest {
+    modelName: "dlrm-convergence",
+    schedule: "4 22 * * *",
+    volumeMap+: {
+      datasets: common.datasetsVolume,
+    },
+    jobSpec+:: {
+      template+: {
+        spec+: {
+          containerMap+: {
+            train+: {
+              resources+: {
+                requests: {
+                  cpu: "40.0",
+                  memory: "500Gi",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  local mp_dp_fwd = common.Functional {
+    modelName: "dlrm-mpdp-fwd",
+    command: utils.scriptCommand(
+      |||
+        %(command_common)s  --mini-batch-size=2048 \
+          --arch-embedding-size=1000000-1000000-1000000-1000000-1000000-1000000-1000000-1000000 \
+          --tpu-model-parallel-group-len 4 \
+          --tpu-cores=8
+      ||| % command_common
+    ),
+  },
+  local criteo_kaggle = common.Convergence {
+    command: utils.scriptCommand(
+      |||
+        apt-get install -y bc
+        pip install onnx
+        git clone --recursive https://github.com/pytorch-tpu/examples.git
+        python examples/deps/dlrm/dlrm_tpu_runner.py \
+            --arch-sparse-feature-size=16 \
+            --arch-mlp-bot="13-512-256-64-16" \
+            --arch-mlp-top="512-256-1" \
+            --data-generation=dataset \
+            --data-set=kaggle \
+            --raw-data-file=/datasets/criteo-kaggle/train.txt \
+            --processed-data-file=/datasets/criteo-kaggle/kaggleAdDisplayChallenge_processed.npz \
+            --loss-function=bce \
+            --round-targets=True \
+            --learning-rate=0.1 \
+            --mini-batch-size=128 \
+            --print-freq=1024 \
+            --print-time \
+            --test-mini-batch-size=16384 \
+            --test-num-workers=4 \
+            --test-freq=101376 \
+                --use-tpu \
+                --num-indices-per-lookup=1 \
+                --num-indices-per-lookup-fixed \
+                --tpu-model-parallel-group-len 8 \
+                --tpu-metrics-debug \
+                --tpu-cores=8 |& tee dlrm_logs.txt
+        acc=`grep Testing dlrm_logs.txt | tail -1 | grep -oP 'best \K[+-]?([0-9]*[.])?[0-9]+'`
+        echo 'Accuracy is' $acc
+        test $(echo $acc'>'78.75 | bc -l) -eq 1  # assert cls acc higher than 78.75
+      |||
+    ),
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+  configs: [
+    dlrm + v3_8 + mp_dp_fwd + timeouts.Hours(3),
+    dlrm_convergence + v3_8 + criteo_kaggle + timeouts.Hours(6),
+  ]
+}

--- a/tests/pytorch/r1.7/dlrm.libsonnet
+++ b/tests/pytorch/r1.7/dlrm.libsonnet
@@ -43,22 +43,8 @@ local utils = import "templates/utils.libsonnet";
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: "9.0",
-                  memory: "30Gi",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
+    cpu: "9.0",
+    memory: "30Gi",
   },
   local dlrm_convergence = common.PyTorchTest {
     modelName: "dlrm-convergence",
@@ -66,22 +52,8 @@ local utils = import "templates/utils.libsonnet";
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: "40.0",
-                  memory: "500Gi",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
+    cpu: "40.0",
+    memory: "500Gi",
   },
   local mp_dp_fwd = common.Functional {
     modelName: "dlrm-mpdp-fwd",

--- a/tests/pytorch/r1.7/hf-glue.libsonnet
+++ b/tests/pytorch/r1.7/hf-glue.libsonnet
@@ -1,0 +1,93 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+local common = import "common.libsonnet";
+local timeouts = import "templates/timeouts.libsonnet";
+local tpus = import "templates/tpus.libsonnet";
+local utils = import "templates/utils.libsonnet";
+
+{
+  local command_common = |||
+    git clone https://github.com/huggingface/transformers.git
+    cd transformers && pip install .
+    git log -1
+    python examples/xla_spawn.py \
+      --num_cores 8 \
+      examples/text-classification/run_glue.py \
+      --logging_dir=./tensorboard-metrics \
+      --task_name MNLI \
+      --data_dir /datasets/glue/MNLI \
+      --cache_dir ./cache_dir \
+      --do_train \
+      --do_eval \
+      --num_train_epochs 3 \
+      --max_seq_length 128 \
+      --learning_rate 3e-5 \
+      --output_dir MNLI \
+      --overwrite_output_dir \
+      --logging_steps 100 \
+      --save_steps 3000 \
+      --overwrite_cache \
+      --tpu_metrics_debug \
+  |||,
+  local command_copy_metrics = |||
+    gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
+  |||,
+  local bert_base_cased = common.Convergence {
+    modelName: "hf-glue-bert-b-c",
+    command: utils.scriptCommand(
+      |||
+        %(common)s --model_name_or_path bert-base-cased \
+        --per_device_train_batch_size 64 \
+        --per_device_eval_batch_size 64
+        %(common_copy)s
+      ||| % {common: command_common, common_copy: command_copy_metrics}
+    ),
+    regressionTestConfig+: {
+      required_metrics: ['eval_mnli/acc', 'eval_mnli-mm/acc'],
+      metric_success_conditions+: {
+        "eval_mnli/acc": {
+          success_threshold: {
+            fixed_value: 0.80,
+          },
+          comparison: "greater",
+        },
+        "eval_mnli-mm/acc": {
+          success_threshold: {
+            fixed_value: 0.80,
+          },
+          comparison: "greater",
+        },
+      },
+    },
+  },
+  local hf_glue = common.PyTorchTest {
+    modelName: "hf-glue",
+    volumeMap+: {
+      datasets: common.datasetsVolume,
+    },
+    cpu: "12.0",
+    memory: "80Gi",
+  },
+  local v2_8 = {
+    accelerator: tpus.v2_8,
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+  configs: [
+    hf_glue + v3_8 + bert_base_cased + timeouts.Hours(2),
+    hf_glue + v2_8 + bert_base_cased + timeouts.Hours(2),
+  ],
+}

--- a/tests/pytorch/r1.7/hf-lm.libsonnet
+++ b/tests/pytorch/r1.7/hf-lm.libsonnet
@@ -1,0 +1,111 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+local common = import "common.libsonnet";
+local timeouts = import "templates/timeouts.libsonnet";
+local tpus = import "templates/tpus.libsonnet";
+local utils = import "templates/utils.libsonnet";
+
+{
+  local command_common = |||
+    git clone https://github.com/huggingface/transformers.git
+    cd transformers && pip install .
+    git log -1
+    python examples/xla_spawn.py \
+      --num_cores 8 \
+      examples/language-modeling/run_language_modeling.py \
+      --logging_dir ./tensorboard-metrics \
+      --cache_dir ./cache_dir \
+      --train_data_file /datasets/wikitext-103-raw/wiki.train.raw \
+      --do_train \
+      --do_eval \
+      --eval_data_file /datasets/wikitext-103-raw/wiki.valid.raw \
+      --overwrite_output_dir \
+      --output_dir language-modeling \
+      --logging_steps 100 \
+      --save_steps 3000 \
+      --overwrite_cache \
+      --tpu_metrics_debug \
+  |||,
+  local command_copy_metrics = |||
+    gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
+  |||,
+  local roberta_base_fine = common.Convergence {
+    modelName: "hf-mlm-roberta-b-fine",
+    command: utils.scriptCommand(
+      |||
+        %(common)s --mlm --model_type=roberta \
+        --model_name_or_path roberta-base \
+        --num_train_epochs 3 \
+        --per_device_train_batch_size 8 \
+        --per_device_eval_batch_size 8
+        %(common_copy)s
+      ||| % {common: command_common, common_copy: command_copy_metrics}
+    ),
+    regressionTestConfig+: {
+      required_metrics: ['eval_loss'],
+      metric_success_conditions+: {
+        "eval_loss": {
+          success_threshold: {
+            fixed_value: 1.5,
+          },
+          comparison: "less",
+        },
+      },
+    },
+  },
+  local roberta_base_pre = common.Convergence {
+    modelName: "hf-mlm-roberta-b-pre",
+    command: utils.scriptCommand(
+      |||
+        %(common)s --mlm --model_type=roberta \
+        --tokenizer=roberta-base \
+        --num_train_epochs 5 \
+        --per_device_train_batch_size 8 \
+        --per_device_eval_batch_size 8
+        %(common_copy)s
+      ||| % {common: command_common, common_copy: command_copy_metrics}
+    ),
+    regressionTestConfig+: {
+      required_metrics: ['eval_loss'],
+      metric_success_conditions+: {
+        "eval_loss": {
+          success_threshold: {
+            fixed_value: 6.5,
+          },
+          comparison: "less",
+        },
+      },
+    },
+  },
+  local hf_lm = common.PyTorchTest {
+    modelName: "hf-lm",
+    volumeMap+: {
+      datasets: common.datasetsVolume,
+    },
+    cpu: "12.0",
+    memory: "80Gi",
+  },
+  local v2_8 = {
+    accelerator: tpus.v2_8,
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+  configs: [
+    hf_lm + v3_8 + roberta_base_pre + timeouts.Hours(4),
+    hf_lm + v2_8 + roberta_base_pre + timeouts.Hours(5),
+    hf_lm + v3_8 + roberta_base_fine + timeouts.Hours(3),
+  ],
+}

--- a/tests/pytorch/r1.7/mnist-3-7.libsonnet
+++ b/tests/pytorch/r1.7/mnist-3-7.libsonnet
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+local common = import "common.libsonnet";
+local mixins = import "templates/mixins.libsonnet";
+local timeouts = import "templates/timeouts.libsonnet";
+local tpus = import "templates/tpus.libsonnet";
+
+{
+  local mnist = common.PyTorchTest {
+    imageTag: "r1.7_3.7",
+    modelName: "mnist-3-7",
+    command: [
+      "python3",
+      "pytorch/xla/test/test_train_mp_mnist.py",
+      "--logdir=$(MODEL_DIR)",
+    ],
+  },
+
+  local convergence = common.Convergence {
+    # Run daily instead of 2x per week since convergence is fast.
+    schedule: "30 21 * * *",
+    regressionTestConfig+: {
+      metric_success_conditions+: {
+        "Accuracy/test_final": {
+          success_threshold: {
+            fixed_value: 98.0,
+          },
+          comparison: "greater",
+        },
+      },
+    },
+  },
+
+  local v2_8 = {
+    accelerator: tpus.v2_8,
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+  configs: [
+    mnist + v2_8 + convergence + timeouts.Hours(1),
+    mnist + v3_8 + convergence + timeouts.Hours(1),
+  ],
+}

--- a/tests/pytorch/r1.7/mnist.libsonnet
+++ b/tests/pytorch/r1.7/mnist.libsonnet
@@ -1,0 +1,75 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+local common = import "common.libsonnet";
+local mixins = import "templates/mixins.libsonnet";
+local timeouts = import "templates/timeouts.libsonnet";
+local tpus = import "templates/tpus.libsonnet";
+local utils = import "templates/utils.libsonnet";
+
+{
+  local mnist = common.PyTorchTest {
+    modelName: "mnist",
+    command: [
+      "python3",
+      "pytorch/xla/test/test_train_mp_mnist.py",
+      "--logdir=$(MODEL_DIR)",
+    ],
+  },
+
+  local mnist_pod = common.PyTorchXlaDistPodTest {
+    modelName: "mnist",
+    command: [
+      "python3",
+      "/usr/share/torch-xla-nightly/pytorch/xla/test/test_train_mp_mnist.py",
+      "--logdir=$(MODEL_DIR)",
+    ],
+  },
+
+  local convergence = common.Convergence {
+    regressionTestConfig+: {
+      metric_success_conditions+: {
+        "Accuracy/test_final": {
+          success_threshold: {
+            fixed_value: 98.0,
+          },
+          comparison: "greater",
+        },
+      },
+    },
+  },
+
+  local v2_8 = {
+    accelerator: tpus.v2_8,
+    schedule: "0 21 * * *",
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+    schedule: "2 21 * * *",
+  },
+  local v2_32 = {
+    accelerator: tpus.v2_32,
+    schedule: "4 21 * * *",
+  },
+  local v3_32 = {
+    accelerator: tpus.v3_32,
+    schedule: "6 21 * * *",
+  },
+  configs: [
+    mnist + convergence + v2_8 + timeouts.Hours(1),
+    mnist + convergence + v3_8 + timeouts.Hours(1),
+    mnist_pod + convergence + v2_32,
+    mnist_pod + convergence + v3_32 ,
+  ],
+}

--- a/tests/pytorch/r1.7/python-ops.libsonnet
+++ b/tests/pytorch/r1.7/python-ops.libsonnet
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+local common = import "common.libsonnet";
+local timeouts = import "templates/timeouts.libsonnet";
+local tpus = import "templates/tpus.libsonnet";
+
+{
+  local operations = common.PyTorchTest {
+    modelName: "python-ops",
+    command: [
+      "bash",
+      "pytorch/xla/test/run_tests.sh",
+    ],
+    regressionTestConfig: null,
+  },
+  local v2_8 = {
+    accelerator: tpus.v2_8,
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+
+  configs: [
+    operations + v2_8 + common.Functional + timeouts.Hours(2),
+    operations + v3_8 + common.Functional + timeouts.Hours(2),
+  ],
+}

--- a/tests/pytorch/r1.7/resnet50-mp.libsonnet
+++ b/tests/pytorch/r1.7/resnet50-mp.libsonnet
@@ -1,0 +1,72 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+local common = import "common.libsonnet";
+local timeouts = import "templates/timeouts.libsonnet";
+local tpus = import "templates/tpus.libsonnet";
+local mixins = import "templates/mixins.libsonnet";
+local utils = import "templates/utils.libsonnet";
+
+{
+  local resnet50_MP = common.PyTorchTest {
+    modelName: "resnet50-mp",
+    command: [
+      "python3",
+      "pytorch/xla/test/test_train_mp_imagenet.py",
+      "--logdir=$(MODEL_DIR)",
+      "--model=resnet50",
+      "--num_workers=8",
+      "--batch_size=128",
+      "--log_steps=200",
+    ],
+    volumeMap+: {
+      datasets: common.datasetsVolume
+    },
+    cpu: "90.0",
+    memory: "400Gi",
+  },
+
+  local functional = common.Functional {
+    command+: [
+      "--num_epochs=2",
+      "--datadir=/datasets/imagenet-mini",
+    ],
+  },
+  local convergence = common.Convergence {
+    command+: [
+      "--num_epochs=90",
+      "--datadir=/datasets/imagenet",
+    ],
+    regressionTestConfig+: {
+      metric_success_conditions+: {
+        "Accuracy/test_final": {
+          success_threshold: {
+            fixed_value: 75.0,
+          },
+          comparison: "greater",
+        },
+      },
+    },
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+  local v3_32 = {
+    accelerator: tpus.v3_32,
+  },
+  configs: [
+    resnet50_MP + v3_8 + convergence + timeouts.Hours(26) + mixins.PreemptibleTpu,
+    resnet50_MP + v3_8 + functional + timeouts.Hours(2),
+  ],
+}

--- a/tests/pytorch/r1.7/roberta-pre.libsonnet
+++ b/tests/pytorch/r1.7/roberta-pre.libsonnet
@@ -18,7 +18,7 @@ local tpus = import "templates/tpus.libsonnet";
 local utils = import "templates/utils.libsonnet";
 
 {
-  local roberta = common.PyTorchTest {
+  local roberta = {
     modelName: "roberta-pre",
     paramsOverride: {
       maxEpoch: error "Must set `maxEpoch`",
@@ -29,7 +29,6 @@ local utils = import "templates/utils.libsonnet";
         python3 \
           /tpu-examples/deps/fairseq/train.py \
           /datasets/wikitext-103 \
-          --tensorboard-logdir=$(MODEL_DIR) \
           --task=masked_lm --criterion=masked_lm \
           --arch=roberta_base --sample-break-mode=complete \
           --tokens-per-sample=512 \
@@ -69,6 +68,7 @@ local utils = import "templates/utils.libsonnet";
                 requests: {
                   cpu: "9.0",
                   memory: "30Gi",
+		  "ephemeral-storage": "10Gi",
                 },
               },
             },
@@ -91,8 +91,12 @@ local utils = import "templates/utils.libsonnet";
   local v3_8 = {
     accelerator: tpus.v3_8,
   },
+  local v3_32 = {
+    accelerator: tpus.v3_32,
+  },
   configs: [
-    roberta + v3_8 + functional + timeouts.Hours(1),
-    roberta + v3_8 + convergence + timeouts.Hours(2),
+    common.PyTorchGkePodTest + roberta + v3_32 + functional + timeouts.Hours(1),
+    common.PyTorchTest + roberta + v3_8 + functional + timeouts.Hours(1),
+    common.PyTorchTest + roberta + v3_8 + convergence + timeouts.Hours(2),
   ],
 }

--- a/tests/pytorch/r1.7/targets.jsonnet
+++ b/tests/pytorch/r1.7/targets.jsonnet
@@ -12,13 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+local cppOperations = import "cpp-ops.libsonnet";
+local dlrm = import "dlrm.libsonnet";
 local fairseqRobertaPretrain = import "roberta-pre.libsonnet";
 local fairseqTransformer = import "fs-transformer.libsonnet";
+local mnist = import "mnist.libsonnet";
+local mnist_3_7 = import "mnist-3-7.libsonnet";
+local pythonOperations = import "python-ops.libsonnet";
 local resnet50_mp = import "resnet50-mp.libsonnet";
+local resnet50_pod = import "resnet50-pod.libsonnet";
+local huggingfaceGlue = import "hf-glue.libsonnet";
+local huggingfaceLanguageModeling = import "hf-lm.libsonnet";
 
 # Add new models here
 std.flattenArrays([
+  cppOperations.configs,
+  dlrm.configs,
   fairseqRobertaPretrain.configs,
   fairseqTransformer.configs,
+  mnist.configs,
+  mnist_3_7.configs,
+  pythonOperations.configs,
   resnet50_mp.configs,
+  resnet50_pod.configs,
+  huggingfaceGlue.configs,
+  huggingfaceLanguageModeling.configs,
 ])

--- a/tests/pytorch/targets.jsonnet
+++ b/tests/pytorch/targets.jsonnet
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 local nightly = import "nightly/targets.jsonnet";
-local r1_5 = import "r1.5/targets.jsonnet";
 local r1_6 = import "r1.6/targets.jsonnet";
+local r1_7 = import "r1.7/targets.jsonnet";
 
 // Add new versions here
 std.flattenArrays([
   nightly,
-  r1_5,
   r1_6,
+  r1_7,
 ])


### PR DESCRIPTION
I tried out mnist, c++ unit tests, and python unit tests on v2-8 and v3-8 and all passed

e.g. [logs](https://pantheon.corp.google.com/logs/viewer?interval=NO_LIMIT&organizationId=433637338589&project=xl-ml-test&minLogLevel=0&expandAll=false&timestamp=2020-10-23T19:46:06.277000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22xl-ml-test%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22xl-ml-test-europe-west4%22%0Aresource.labels.namespace_name%3D%22automated%22%0Aresource.labels.pod_name:%22pt-r1.7-python-ops-func-v3-8-manual-%22%0Aresource.labels.container_name%3D%22train%22&scrollTimestamp=2020-10-23T18:09:37.336328097Z)

`schedule` chosen with help from `scripts/find_busy_times.py`