### PR TITLE
Skip rows with nan as value. Use math.isnan to catch some versions of…

### DIFF
--- a/metrics_handler/main.py
+++ b/metrics_handler/main.py
@@ -263,6 +263,13 @@ class CloudMetricsHandler(object):
     for metric_name, metric_point in aggregated_metrics_dict.items():
       lower_bound, upper_bound = metric_name_to_visual_bounds.get(
           metric_name, (None, None))
+      if not util.is_valid_bigquery_value(metric_point.metric_value):
+        self.logger.warning(
+            'Found metric row with invalid value: {} {} {}'.format(
+                self.test_name,
+                metric_name,
+                metric_point.metric_value))
+        continue
       metric_history_rows.append([
         unique_key,
         self.test_name,

--- a/metrics_handler/util.py
+++ b/metrics_handler/util.py
@@ -87,6 +87,24 @@ def workload_link(job_name, job_namespace, location, cluster, project):
   return link
 
 
+def is_valid_bigquery_value(v):
+  """Return True if value is valid for writing to BigQuery.
+
+  Args:
+    v (float): Value to check.
+
+  Returns:
+    Bool, True if v is valid and False otherwise.
+
+  """
+  invalid_values = [math.inf, -math.inf, math.nan]
+  if v in invalid_values:
+    return False
+  if math.isnan(v):
+    return False
+  return True
+
+
 def replace_invalid_values(row):
   """Replace float values that are not available in BigQuery.
 
@@ -96,5 +114,4 @@ def replace_invalid_values(row):
   Returns:
     List, `row` with invalid values replaced with `None`.
   """
-  invalid_values = [math.inf, -math.inf, math.nan]
-  return [x if x not in invalid_values else None for x in row]
+  return [x if is_valid_bigquery_value(x) else None for x in row]

--- a/metrics_handler/util_test.py
+++ b/metrics_handler/util_test.py
@@ -65,8 +65,11 @@ class UtilTest(parameterized.TestCase):
 
   @parameterized.named_parameters(
     ('inf', [1, 2, 3, math.inf, 4, 5], [1, 2, 3, None, 4, 5]),
+    ('inf_parsed', [1, 2, 3, float('inf'), 4, 5], [1, 2, 3, None, 4, 5]),
     ('-inf', [1, 2, 3, -math.inf, 4, 5], [1, 2, 3, None, 4, 5]),
     ('nan', [1, 2, 3, math.nan, 4, 5], [1, 2, 3, None, 4, 5]),
+    ('nan_parsed', [1, 2, 3, float("nan"), 4, 5], [1, 2, 3, None, 4, 5]),
+    ('nan_cap_parsed', [1, 2, 3, float("NAN"), 4, 5], [1, 2, 3, None, 4, 5]),
     ('all', [math.inf, -math.inf, math.nan], [None, None, None]),
     ('one_element', [math.inf], [None]),
     ('empty', [], []),
@@ -74,6 +77,21 @@ class UtilTest(parameterized.TestCase):
   def test_replace_invalid_values(self, row, expected_row):
     clean_row = util.replace_invalid_values(row)
     self.assertSequenceEqual(clean_row, expected_row)
+
+  @parameterized.named_parameters(
+    ('inf', math.inf, False),
+    ('-inf', -math.inf, False),
+    ('inf_parsed', float('inf'), False),
+    ('-inf_parsed', float('-inf'), False),
+    ('nan_parsed', float('nan'), False),
+    ('nan_cap_parsed', float('NAN'), False),
+    ('int', 9, True),
+    ('int_parsed', float('9'), True),
+    ('float', 9.0, True),
+    ('float_parsed', float('9.0'), True),
+  )
+  def test_is_valid_bigquery_value(self, value, expected_bool):
+    self.assertEqual(util.is_valid_bigquery_value(value), expected_bool)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
… NaN

TIL:
```
>>> a = [math.nan]
>>> math.nan in a
True
>>> float('nan') in a
False
>>> math.isnan(math.nan)
True
>>> math.isnan(float('nan'))
True
```

So we should use `math.isnan` to catch NaN that has been parsed using `float`

Also skip rows entirely if the metric value is NaN since they will just be noise