### PR TITLE
Fix dashboard job status

### DIFF
--- a/dashboard/app.yaml
+++ b/dashboard/app.yaml
@@ -33,7 +33,7 @@ resources:
 env_variables:
   REDISHOST: '10.25.27.107'
   REDISPORT: '6379'
-  TEST_NAME_PREFIXES: 'pt-nightly,pt-1.5,pt-1.6,pt-r1.7,tf-nightly,tf-r1.15.4,tf-r2.1.2,tf-r2.2.1,tf-r2.3.1,tf-r2.4.0'
+  TEST_NAME_PREFIXES: 'pt-nightly,pt-1.6,pt-r1.7,tf-nightly,tf-r1.15.4,tf-r2.2.1,tf-r2.3.1,tf-r2.4.0'
   JOB_HISTORY_TABLE_NAME: 'xl-ml-test.metrics_handler_dataset.job_history'
   METRIC_HISTORY_TABLE_NAME: 'xl-ml-test.metrics_handler_dataset.metric_history'
 

--- a/dashboard/main_heatmap.py
+++ b/dashboard/main_heatmap.py
@@ -116,6 +116,9 @@ def fetch_data(test_name_prefix, cutoff_timestamp):
   return combined_dataframe
 
 def process_dataframes(job_status_dataframe, metrics_dataframe):
+  if job_status_dataframe.empty or 'job_status' not in job_status_dataframe:
+    return pd.DataFrame()
+
   # Collect all test+date combinations where metrics were out of bounds.
   oob_tests = collections.defaultdict(list)
   def _test_date_key(test, date):

--- a/dashboard/main_heatmap_test.py
+++ b/dashboard/main_heatmap_test.py
@@ -110,6 +110,18 @@ class MainHeatmapTest(parameterized.TestCase):
     # If the command is already populated, it should be left alone.
     self.assertEqual(commands[0], 'my command')
 
+  def test_process_dataframes_no_job_status(self):
+    job_status_df = pd.DataFrame({
+        'test_name': pd.Series(['a', 'b']),
+        'run_date': pd.Series(['2020-04-10', '2020-04-11']),
+        'logs_link': pd.Series(['c', 'd']),
+        'logs_download_command': pd.Series(['e', 'f']),
+    })
+    df = main_heatmap.process_dataframes(job_status_df, pd.DataFrame())
+    self.assertTrue(df.empty)
+    df = main_heatmap.process_dataframes(pd.DataFrame(), pd.DataFrame())
+    self.assertTrue(df.empty)
+
   def test_make_plot(self):
     input_df = pd.DataFrame({
         'test_name': pd.Series(['test1', 'test2', 'test3']),


### PR DESCRIPTION
https://b.corp.google.com/issues/174754767

ran into some issues where old data from tests that haven't run for 30 days was stuck in the redis cache and was leading to cases the `job_status_dataframe` was non-empty but missing a required field.

I've already deployed the changes to `main_heatmap.py` and verified that the issue is fixed