### PR TITLE
Reservation tests

### DIFF
--- a/k8s/europe-west4/gen/pt-1.6-mnist-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-mnist-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-1.6-mnist-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-mnist-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-1.6-resnet50-mp-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-resnet50-mp-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-1.6-resnet50-mp-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-1.6-resnet50-mp-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-nightly-fs-transformer-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-fs-transformer-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-nightly-mnist-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-mnist-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-nightly-mnist-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-mnist-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-nightly-resnet50-mp-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-resnet50-mp-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-nightly-resnet50-mp-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-resnet50-mp-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-nightly-roberta-pre-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-nightly-roberta-pre-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-r1.7-fs-transformer-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-fs-transformer-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-r1.7-mnist-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-mnist-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-r1.7-mnist-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-mnist-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-r1.7-resnet50-mp-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-resnet50-mp-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-r1.7-resnet50-mp-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-resnet50-mp-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/pt-r1.7-roberta-pre-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/pt-r1.7-roberta-pre-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":
@@ -172,5 +173,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "54 21 * * 1,3,5,6"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-bert-mnli-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v2-32.yaml
@@ -34,11 +34,12 @@
         "mode": "conv"
         "model": "classifier-efficientnet"
     "spec":
-      "activeDeadlineSeconds": 108000
+      "activeDeadlineSeconds": 36000
       "backoffLimit": 1
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":
@@ -184,5 +185,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 7 * * 1,3,5,6"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-efficientnet-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":
@@ -181,5 +182,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "7 11 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-classifier-resnet-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-efficientnet-perfzero-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-efficientnet-perfzero-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-connection-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-ctl-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-custom-layers-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-custom-layers-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-feature-column-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-feature-column-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-preprocess-layers-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-preprocess-layers-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-rnn-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-rnn-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-save-and-load-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-save-and-load-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-save-load-localhost-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-save-load-localhost-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-train-and-evaluate-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-train-eval-dataset-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-train-eval-dataset-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-keras-api-transfer-learning-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-keras-api-transfer-learning-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":
@@ -183,5 +184,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "0 22 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-maskrcnn-perfzero-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-maskrcnn-perfzero-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/europe-west4/gen/tf-nightly-ncf-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-ncf-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":
@@ -185,5 +186,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "20 15 * * 1,3,5,6"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-nightly-ncf-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-ncf-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "test_nightly_direct_path_non_distrib_cache"
         "spec":
           "containers":
@@ -173,5 +174,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "20 8 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "test_nightly_direct_path_non_distrib_cache"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "test_nightly_direct_path_non_distrib_cache"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet-ctl-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "test_nightly_direct_path_non_distrib_cache"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-resnet50-cfit-perfzero-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet50-cfit-perfzero-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/europe-west4/gen/tf-nightly-resnet50-ctl-perfzero-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-resnet50-ctl-perfzero-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":
@@ -179,5 +180,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "47 19 * * 1,3,5,6"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-retinanet-perfzero-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-retinanet-perfzero-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-shapemask-perfzero-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-shapemask-perfzero-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/europe-west4/gen/tf-nightly-transformer-perfzero-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-perfzero-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":
@@ -177,5 +178,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "10 20 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-transformer-translate-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-nightly-xlnet-imdb-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-xlnet-imdb-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":
@@ -184,5 +185,5 @@
           - "emptyDir":
               "medium": "Memory"
             "name": "dshm"
-  "schedule": "0 6 * * 0,5"
+  "schedule": "54 20 * * 1,3,5,6"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-nightly-xlnet-imdb-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-nightly-xlnet-imdb-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-bert-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-bert-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":
@@ -152,5 +153,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * 0"
+  "schedule": "12 23 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r1.15.4-bert-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-bert-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-efficientnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-efficientnet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-efficientnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-efficientnet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-mask-rcnn-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-mask-rcnn-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":
@@ -152,5 +153,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * 0"
+  "schedule": "10 4 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r1.15.4-mask-rcnn-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-mask-rcnn-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-mnasnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-mnasnet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-mnasnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-mnasnet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-resnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-resnet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":
@@ -142,5 +143,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * 6"
+  "schedule": "59 15 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r1.15.4-resnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-resnet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-retinanet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-retinanet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":
@@ -150,5 +151,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * 0"
+  "schedule": "37 13 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r1.15.4-retinanet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-retinanet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-shapemask-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-shapemask-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":
@@ -164,5 +165,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * 0"
+  "schedule": "0 0 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r1.15.4-shapemask-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-shapemask-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-transformer-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-transformer-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":
@@ -144,5 +145,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * 0"
+  "schedule": "13 18 * * 0,2,4"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r1.15.4-transformer-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-transformer-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r1.15.4-unet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-unet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": "true"
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":
@@ -151,5 +152,5 @@
           "nodeSelector":
             "tpu-available": "true"
           "restartPolicy": "Never"
-  "schedule": "0 8 * * 0"
+  "schedule": "0 1 * * 1,3,5,6"
   "successfulJobsHistoryLimit": 1

--- a/k8s/europe-west4/gen/tf-r1.15.4-unet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r1.15.4-unet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.2.1-resnet-ctl-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.2.1-resnet-ctl-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.2.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.2.1-resnet-ctl-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.2.1-resnet-ctl-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.2.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-bert-mnli-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-bert-mnli-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-bert-mnli-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-bert-mnli-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-classifier-efficientnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-classifier-efficientnet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-classifier-efficientnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-classifier-efficientnet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-classifier-resnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-classifier-resnet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-classifier-resnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-classifier-resnet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-maskrcnn-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-maskrcnn-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-maskrcnn-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-maskrcnn-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-ncf-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-ncf-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-resnet-ctl-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-resnet-ctl-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-resnet-ctl-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-resnet-ctl-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-retinanet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-retinanet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-retinanet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-retinanet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-shapemask-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-shapemask-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-transformer-translate-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-transformer-translate-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.3.1-transformer-translate-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.3.1-transformer-translate-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-bert-mnli-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-bert-mnli-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-bert-mnli-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-bert-mnli-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-bert-mnli-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-bert-mnli-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-bert-mnli-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-bert-mnli-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-classifier-efficientnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-classifier-efficientnet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-classifier-efficientnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-classifier-efficientnet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-classifier-efficientnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-classifier-efficientnet-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-classifier-efficientnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-classifier-efficientnet-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-classifier-resnet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-classifier-resnet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-classifier-resnet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-classifier-resnet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-classifier-resnet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-classifier-resnet-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-classifier-resnet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-classifier-resnet-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-connection-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-connection-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-connection-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-connection-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-ctl-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-ctl-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-ctl-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-ctl-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-custom-layers-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-custom-layers-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-feature-column-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-feature-column-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-preprocess-layers-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-preprocess-layers-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-rnn-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-rnn-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-save-and-load-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-save-and-load-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-save-load-localhost-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-save-load-localhost-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-train-and-evaluate-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-train-and-evaluate-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-train-and-evaluate-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-train-and-evaluate-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-train-eval-dataset-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-train-eval-dataset-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-keras-api-transfer-learning-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-keras-api-transfer-learning-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-maskrcnn-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-maskrcnn-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-maskrcnn-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-maskrcnn-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-maskrcnn-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-maskrcnn-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-maskrcnn-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-maskrcnn-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-ncf-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-ncf-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-ncf-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-ncf-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-resnet-ctl-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-resnet-ctl-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-resnet-ctl-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-resnet-ctl-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-resnet-ctl-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-resnet-ctl-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-resnet-ctl-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-resnet-ctl-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-retinanet-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-retinanet-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-retinanet-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-retinanet-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-retinanet-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-retinanet-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-retinanet-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-retinanet-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-shapemask-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-shapemask-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-shapemask-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-shapemask-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-shapemask-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-shapemask-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-transformer-translate-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-transformer-translate-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-transformer-translate-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-transformer-translate-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-transformer-translate-func-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-transformer-translate-func-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-transformer-translate-func-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-transformer-translate-func-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-xlnet-imdb-conv-v2-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-xlnet-imdb-conv-v2-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/europe-west4/gen/tf-r2.4.0-xlnet-imdb-conv-v3-32.yaml
+++ b/k8s/europe-west4/gen/tf-r2.4.0-xlnet-imdb-conv-v3-32.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-cpp-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-cpp-ops-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-cpp-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-cpp-ops-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-dlrm-mp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-dlrm-mp-fwd-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-dlrm-mpdp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-dlrm-mpdp-fwd-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-dlrm-onecore-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-dlrm-onecore-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-dlrm-seq-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-dlrm-seq-fwd-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-fs-checkpoint-gcs-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-fs-checkpoint-gcs-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-fs-checkpoint-local-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-fs-checkpoint-local-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-fs-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-fs-transformer-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-fs-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-fs-transformer-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-bert-b-c-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-distilbert-b-uc-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-distilbert-b-uc-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-roberta-l-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-roberta-l-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-hf-glue-xlnet-l-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-hf-glue-xlnet-l-c-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-3-7-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-mnist-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-python-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-python-ops-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-python-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-python-ops-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-resnet50-mp-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-resnet50-mp-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-resnet50-mp-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-resnet50-mp-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-roberta-pre-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-roberta-pre-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-roberta-pre-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-1.6-tpu-mem-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-1.6-tpu-mem-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.6"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-inline-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cifar-tv-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-cpp-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cpp-ops-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-cpp-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-cpp-ops-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-dlrm-convergence-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-convergence-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-dlrm-mp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-mp-fwd-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-dlrm-mpdp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-mpdp-fwd-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-dlrm-onecore-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-onecore-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-dlrm-seq-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-dlrm-seq-fwd-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-fs-checkpoint-gcs-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-checkpoint-gcs-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-fs-checkpoint-local-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-checkpoint-local-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-fs-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-transformer-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-fs-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-fs-transformer-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-bert-b-c-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-bert-b-c-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-bert-b-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-bert-b-c-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-distilbert-b-uc-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-distilbert-b-uc-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-roberta-l-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-roberta-l-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-glue-xlnet-l-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-glue-xlnet-l-c-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-bert-b-fine-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-bert-b-fine-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-bert-b-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-bert-b-pre-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-fine-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-fine-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-hf-mlm-roberta-b-pre-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-3-7-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-mnist-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-python-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-python-ops-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-python-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-python-ops-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-resnet50-mp-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-resnet50-mp-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-resnet50-mp-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-roberta-pre-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-nightly-roberta-pre-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-nightly-roberta-pre-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-cpp-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-cpp-ops-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-cpp-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-cpp-ops-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-dlrm-convergence-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-dlrm-convergence-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-dlrm-mpdp-fwd-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-dlrm-mpdp-fwd-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-fs-checkpoint-gcs-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-fs-checkpoint-gcs-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-fs-checkpoint-local-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-fs-checkpoint-local-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-fs-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-fs-transformer-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-fs-transformer-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-fs-transformer-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-hf-glue-bert-b-c-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-glue-bert-b-c-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-hf-glue-bert-b-c-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-glue-bert-b-c-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-fine-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-fine-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-pre-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-pre-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-hf-mlm-roberta-b-pre-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-mnist-3-7-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-mnist-3-7-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-mnist-3-7-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-mnist-3-7-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-mnist-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-mnist-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-python-ops-func-v2-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-python-ops-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-python-ops-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-python-ops-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-resnet50-mp-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-resnet50-mp-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-resnet50-mp-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-resnet50-mp-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-roberta-pre-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-roberta-pre-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/pt-r1.7-roberta-pre-func-v3-8.yaml
+++ b/k8s/us-central1/gen/pt-r1.7-roberta-pre-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "pytorch-1.7"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-mnli-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-bert-squad-perfzero-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-bert-squad-perfzero-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-hbm-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-efficientnet-hbm-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-classifier-resnet-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-efficientnet-perfzero-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-efficientnet-perfzero-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/us-central1/gen/tf-nightly-keras-api-connection-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-connection-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-connection-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-connection-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-ctl-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-ctl-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-ctl-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-ctl-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-custom-layers-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-feature-column-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-preprocess-layers-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-preprocess-layers-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-preprocess-layers-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-preprocess-layers-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-rnn-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-save-and-load-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-save-and-load-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-save-and-load-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-save-and-load-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-save-load-localhost-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-save-load-localhost-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-save-load-localhost-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-save-load-localhost-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-and-evaluate-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-train-eval-dataset-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-keras-api-transfer-learning-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-maskrcnn-perfzero-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-maskrcnn-perfzero-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/us-central1/gen/tf-nightly-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-mnist-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-ncf-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-ncf-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-ncf-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "test_nightly_direct_path_non_distrib_cache"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "test_nightly_direct_path_non_distrib_cache"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "test_nightly_direct_path_non_distrib_cache"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet-ctl-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "test_nightly_direct_path_non_distrib_cache"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-resnet50-cfit-perfzero-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet50-cfit-perfzero-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/us-central1/gen/tf-nightly-resnet50-ctl-perfzero-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-resnet50-ctl-perfzero-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-retinanet-perfzero-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-retinanet-perfzero-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/us-central1/gen/tf-nightly-shapemask-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-shapemask-perfzero-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-shapemask-perfzero-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/us-central1/gen/tf-nightly-transformer-perfzero-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-perfzero-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "activeDeadlineSeconds": 3600

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-transformer-translate-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-xlnet-imdb-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-xlnet-imdb-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-xlnet-imdb-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-xlnet-imdb-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-xlnet-imdb-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-xlnet-imdb-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-xlnet-squad-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-xlnet-squad-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-nightly-xlnet-squad-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-nightly-xlnet-squad-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "nightly"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-bert-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-bert-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-bert-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-bert-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-efficientnet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-efficientnet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-mask-rcnn-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-mask-rcnn-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-mask-rcnn-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-mask-rcnn-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-mnasnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-mnasnet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-mnasnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-mnasnet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-resnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-resnet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-resnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-resnet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-retinanet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-retinanet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-retinanet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-retinanet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-shapemask-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-shapemask-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-shapemask-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-shapemask-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-transformer-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-transformer-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-transformer-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-transformer-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r1.15.4-unet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r1.15.4-unet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "1.15.4"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.2.1-resnet-ctl-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.2.1-resnet-ctl-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.2.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.2.1-resnet-ctl-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.2.1-resnet-ctl-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.2.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-bert-mnli-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-bert-mnli-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-bert-mnli-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-bert-mnli-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-classifier-efficientnet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-classifier-efficientnet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-classifier-resnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-classifier-resnet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-classifier-resnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-classifier-resnet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-keras-api-train-and-evaluate-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-keras-api-train-and-evaluate-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-keras-api-train-eval-dataset-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-keras-api-train-eval-dataset-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-keras-api-transfer-learning-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-keras-api-transfer-learning-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-keras-api-transfer-learning-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-keras-api-transfer-learning-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-maskrcnn-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-maskrcnn-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-maskrcnn-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-maskrcnn-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-mnist-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-mnist-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-ncf-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-ncf-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-resnet-ctl-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-resnet-ctl-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-resnet-ctl-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-resnet-ctl-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-retinanet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-retinanet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-retinanet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-retinanet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-shapemask-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-shapemask-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-transformer-translate-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-transformer-translate-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.3.1-transformer-translate-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.3.1-transformer-translate-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.3.1"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-bert-mnli-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-bert-mnli-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-bert-mnli-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-bert-mnli-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-bert-mnli-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-bert-mnli-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-bert-mnli-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-bert-mnli-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-bert-squad-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-bert-squad-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-bert-squad-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-bert-squad-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-hbm-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-classifier-efficientnet-hbm-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-classifier-resnet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-classifier-resnet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-classifier-resnet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-classifier-resnet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-classifier-resnet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-classifier-resnet-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-classifier-resnet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-classifier-resnet-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-connection-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-connection-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-connection-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-connection-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-ctl-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-ctl-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-ctl-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-ctl-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-custom-layers-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-custom-layers-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-custom-layers-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-custom-layers-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-feature-column-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-feature-column-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-feature-column-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-feature-column-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-preprocess-layers-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-preprocess-layers-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-preprocess-layers-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-preprocess-layers-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-rnn-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-rnn-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-rnn-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-rnn-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-save-and-load-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-save-and-load-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-save-and-load-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-save-and-load-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-save-load-localhost-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-save-load-localhost-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-save-load-localhost-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-save-load-localhost-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-train-and-evaluate-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-train-and-evaluate-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-train-and-evaluate-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-train-and-evaluate-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-train-eval-dataset-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-train-eval-dataset-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-train-eval-dataset-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-train-eval-dataset-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-transfer-learning-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-transfer-learning-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-keras-api-transfer-learning-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-keras-api-transfer-learning-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-maskrcnn-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-maskrcnn-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-maskrcnn-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-maskrcnn-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-maskrcnn-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-maskrcnn-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-maskrcnn-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-maskrcnn-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-mnist-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-mnist-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-mnist-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-mnist-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-mnist-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-mnist-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-mnist-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-mnist-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-ncf-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-ncf-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-ncf-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-ncf-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-resnet-ctl-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-resnet-ctl-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-resnet-ctl-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-resnet-ctl-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-resnet-ctl-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-resnet-ctl-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-resnet-ctl-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-resnet-ctl-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-retinanet-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-retinanet-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-retinanet-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-retinanet-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-retinanet-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-retinanet-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-retinanet-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-retinanet-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-shapemask-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-shapemask-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-shapemask-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-shapemask-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-shapemask-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-shapemask-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-transformer-translate-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-transformer-translate-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-transformer-translate-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-transformer-translate-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-transformer-translate-func-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-transformer-translate-func-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-transformer-translate-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-transformer-translate-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-xlnet-imdb-conv-v2-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-xlnet-imdb-conv-v2-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-xlnet-imdb-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-xlnet-imdb-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-xlnet-imdb-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-xlnet-imdb-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-xlnet-squad-conv-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-xlnet-squad-conv-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/k8s/us-central1/gen/tf-r2.4.0-xlnet-squad-func-v3-8.yaml
+++ b/k8s/us-central1/gen/tf-r2.4.0-xlnet-squad-func-v3-8.yaml
@@ -39,6 +39,7 @@
       "template":
         "metadata":
           "annotations":
+            "reserved.cloud-tpus.google.com": false
             "tf-version.cloud-tpus.google.com": "2.4.0"
         "spec":
           "containers":

--- a/templates/base.libsonnet
+++ b/templates/base.libsonnet
@@ -49,6 +49,9 @@ local volumes = import 'volumes.libsonnet';
 
       # Whether to use a preemptible TPU.
       preemptible: false,
+
+      # Whether to use a TPU reservation.
+      reserved: false,
     },
 
     # CPU/memory resource requests for the `train` container.

--- a/templates/tpus.libsonnet
+++ b/templates/tpus.libsonnet
@@ -28,13 +28,14 @@ local base = import 'base.libsonnet';
       metadata: {
         annotations: {
           "tf-version.cloud-tpus.google.com": tpuSettings.softwareVersion,
+	  "reserved.cloud-tpus.google.com": tpuSettings.reserved,
         },
       },
       spec+: {
         containerMap+: {
           train+: {
             resources+: {
-              local preemptiblePrefix = 
+              local preemptiblePrefix =
                 if tpuSettings.preemptible then
                   "preemptible-"
                 else

--- a/templates/tpus.libsonnet
+++ b/templates/tpus.libsonnet
@@ -66,5 +66,4 @@ local base = import 'base.libsonnet';
   v3_8: self.TpuSpec { version: 3, size: 8 },
   v2_32: self.TpuSpec { version: 2, size: 32 },
   v3_32: self.TpuSpec { version: 3, size: 32 },
-
 }

--- a/templates/tpus.libsonnet
+++ b/templates/tpus.libsonnet
@@ -25,10 +25,11 @@ local base = import 'base.libsonnet';
     replicas: tpu.size / 8, # Each TPU replica has 8 cores
 
     PodTemplate(tpuSettings):: {
+      assert !(tpuSettings.preemptible == "true" && tpuSettings.reserved == "true"): ("TPU cannot be both reserved and preemptible"),
       metadata: {
         annotations: {
           "tf-version.cloud-tpus.google.com": tpuSettings.softwareVersion,
-	  "reserved.cloud-tpus.google.com": tpuSettings.reserved,
+          "reserved.cloud-tpus.google.com": tpuSettings.reserved,
         },
       },
       spec+: {
@@ -55,8 +56,15 @@ local base = import 'base.libsonnet';
     },
   },
 
+  reserved: {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
+
   v2_8: self.TpuSpec { version: 2, size: 8 },
   v3_8: self.TpuSpec { version: 3, size: 8 },
   v2_32: self.TpuSpec { version: 2, size: 32 },
   v3_32: self.TpuSpec { version: 3, size: 32 },
+
 }

--- a/tests/tensorflow/nightly/bert-mnli.libsonnet
+++ b/tests/tensorflow/nightly/bert-mnli.libsonnet
@@ -83,11 +83,6 @@ local tpus = import "templates/tpus.libsonnet";
       '--eval_batch_size=256',
     ],
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     bert + v2_8 + functional,
@@ -96,7 +91,7 @@ local tpus = import "templates/tpus.libsonnet";
     bert + v3_8 + convergence + timeouts.Hours(3),
     bert + v2_32 + functional,
     bert + v3_32 + functional,
-    bert + v2_32 + convergence + reserved + {schedule: "54 21 * * 1,3,5,6"},
+    bert + v2_32 + convergence + tpus.reserved + {schedule: "54 21 * * 1,3,5,6"},
     bert + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/nightly/bert-mnli.libsonnet
+++ b/tests/tensorflow/nightly/bert-mnli.libsonnet
@@ -83,6 +83,11 @@ local tpus = import "templates/tpus.libsonnet";
       '--eval_batch_size=256',
     ],
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     bert + v2_8 + functional,
@@ -91,7 +96,7 @@ local tpus = import "templates/tpus.libsonnet";
     bert + v3_8 + convergence + timeouts.Hours(3),
     bert + v2_32 + functional,
     bert + v3_32 + functional,
-    bert + v2_32 + convergence,
+    bert + v2_32 + convergence + reserved + {schedule: "54 21 * * 1,3,5,6"},
     bert + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -144,11 +144,6 @@ local gpus = import "templates/gpus.libsonnet";
   local v3_32 = tpu_common {
     accelerator: tpus.v3_32,
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     efficientnet + k80x8 + functional + timeouts.Hours(4) + mixins.Suspended,
@@ -163,7 +158,7 @@ local gpus = import "templates/gpus.libsonnet";
     efficientnet + v3_8 + convergence + timeouts.Hours(45),
     efficientnet + v2_32 + functional,
     efficientnet + v3_32 + functional,
-    efficientnet + v2_32 + convergence + timeouts.Hours(10) + reserved + {schedule: "0 7 * * 1,3,5,6"},
+    efficientnet + v2_32 + convergence + timeouts.Hours(10) + tpus.reserved + {schedule: "0 7 * * 1,3,5,6"},
     efficientnet + v3_32 + convergence + timeouts.Hours(24),
   ],
 }

--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -144,6 +144,11 @@ local gpus = import "templates/gpus.libsonnet";
   local v3_32 = tpu_common {
     accelerator: tpus.v3_32,
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     efficientnet + k80x8 + functional + timeouts.Hours(4) + mixins.Suspended,
@@ -158,7 +163,7 @@ local gpus = import "templates/gpus.libsonnet";
     efficientnet + v3_8 + convergence + timeouts.Hours(45),
     efficientnet + v2_32 + functional,
     efficientnet + v3_32 + functional,
-    efficientnet + v2_32 + convergence + timeouts.Hours(30),
+    efficientnet + v2_32 + convergence + timeouts.Hours(10) + reserved + {schedule: "0 7 * * 1,3,5,6"},
     efficientnet + v3_32 + convergence + timeouts.Hours(24),
   ],
 }

--- a/tests/tensorflow/nightly/classifier-resnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnet.libsonnet
@@ -144,11 +144,6 @@ local gpus = import "templates/gpus.libsonnet";
   local v3_32 = tpu_common {
     accelerator: tpus.v3_32,
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     resnet + k80 + functional + timeouts.Hours(5) + mixins.Suspended,
@@ -165,7 +160,7 @@ local gpus = import "templates/gpus.libsonnet";
     resnet + v3_8 + convergence,
     resnet + v2_32 + functional,
     resnet + v3_32 + functional,
-    resnet + v2_32 + convergence + reserved + {schedule: "7 11 * * 0,2,4"},
+    resnet + v2_32 + convergence + tpus.reserved + {schedule: "7 11 * * 0,2,4"},
     resnet + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/nightly/classifier-resnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnet.libsonnet
@@ -144,6 +144,11 @@ local gpus = import "templates/gpus.libsonnet";
   local v3_32 = tpu_common {
     accelerator: tpus.v3_32,
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     resnet + k80 + functional + timeouts.Hours(5) + mixins.Suspended,
@@ -160,7 +165,7 @@ local gpus = import "templates/gpus.libsonnet";
     resnet + v3_8 + convergence,
     resnet + v2_32 + functional,
     resnet + v3_32 + functional,
-    resnet + v2_32 + convergence,
+    resnet + v2_32 + convergence + reserved + {schedule: "7 11 * * 0,2,4"},
     resnet + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/nightly/maskrcnn.libsonnet
+++ b/tests/tensorflow/nightly/maskrcnn.libsonnet
@@ -174,11 +174,6 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     maskrcnn + functional + k80x8 + mixins.Suspended,
@@ -192,7 +187,7 @@ local gpus = import "templates/gpus.libsonnet";
     maskrcnn + convergence + v3_8,
     maskrcnn + functional + v2_32,
     maskrcnn + functional + v3_32,
-    maskrcnn + convergence + v2_32 + reserved + {schedule: "0 22 * * 0,2,4"},
+    maskrcnn + convergence + v2_32 + tpus.reserved + {schedule: "0 22 * * 0,2,4"},
     maskrcnn + convergence + v3_32,
   ],
 }

--- a/tests/tensorflow/nightly/maskrcnn.libsonnet
+++ b/tests/tensorflow/nightly/maskrcnn.libsonnet
@@ -174,6 +174,11 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     maskrcnn + functional + k80x8 + mixins.Suspended,
@@ -187,7 +192,7 @@ local gpus = import "templates/gpus.libsonnet";
     maskrcnn + convergence + v3_8,
     maskrcnn + functional + v2_32,
     maskrcnn + functional + v3_32,
-    maskrcnn + convergence + v2_32,
+    maskrcnn + convergence + v2_32 + reserved + {schedule: "0 22 * * 0,2,4"},
     maskrcnn + convergence + v3_32,
   ],
 }

--- a/tests/tensorflow/nightly/ncf.libsonnet
+++ b/tests/tensorflow/nightly/ncf.libsonnet
@@ -102,11 +102,6 @@ local gpus = import "templates/gpus.libsonnet";
   local v3_32 =  {
     accelerator: tpus.v3_32,
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     ncf + k80 + functional + ctl,
@@ -119,7 +114,7 @@ local gpus = import "templates/gpus.libsonnet";
     ncf + v100x4 + convergence + ctl,
     ncf + v2_8 + functional + ctl,
     ncf + v3_8 + convergence + ctl,
-    ncf + v2_32 + convergence + ctl + reserved + {schedule: "20 15 * * 1,3,5,6"},
+    ncf + v2_32 + convergence + ctl + tpus.reserved + {schedule: "20 15 * * 1,3,5,6"},
     ncf + v3_32 + functional + ctl,
   ],
 }

--- a/tests/tensorflow/nightly/ncf.libsonnet
+++ b/tests/tensorflow/nightly/ncf.libsonnet
@@ -102,6 +102,11 @@ local gpus = import "templates/gpus.libsonnet";
   local v3_32 =  {
     accelerator: tpus.v3_32,
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     ncf + k80 + functional + ctl,
@@ -114,7 +119,7 @@ local gpus = import "templates/gpus.libsonnet";
     ncf + v100x4 + convergence + ctl,
     ncf + v2_8 + functional + ctl,
     ncf + v3_8 + convergence + ctl,
-    ncf + v2_32 + convergence + ctl,
+    ncf + v2_32 + convergence + ctl + reserved + {schedule: "20 15 * * 1,3,5,6"},
     ncf + v3_32 + functional + ctl,
   ],
 }

--- a/tests/tensorflow/nightly/resnet-ctl.libsonnet
+++ b/tests/tensorflow/nightly/resnet-ctl.libsonnet
@@ -67,6 +67,11 @@ local tpus = import "templates/tpus.libsonnet";
     accelerator: tpus.v3_32,
     command+: [ "--batch_size=8192" ],
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     resnet + v2_8 + functional,
@@ -75,7 +80,7 @@ local tpus = import "templates/tpus.libsonnet";
     resnet + v3_8 + convergence,
     resnet + v2_32 + functional,
     resnet + v3_32 + functional,
-    resnet + v2_32 + convergence,
+    resnet + v2_32 + convergence + reserved + {schedule: "20 8 * * 0,2,4"},
     resnet + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/nightly/resnet-ctl.libsonnet
+++ b/tests/tensorflow/nightly/resnet-ctl.libsonnet
@@ -67,11 +67,6 @@ local tpus = import "templates/tpus.libsonnet";
     accelerator: tpus.v3_32,
     command+: [ "--batch_size=8192" ],
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     resnet + v2_8 + functional,
@@ -80,7 +75,7 @@ local tpus = import "templates/tpus.libsonnet";
     resnet + v3_8 + convergence,
     resnet + v2_32 + functional,
     resnet + v3_32 + functional,
-    resnet + v2_32 + convergence + reserved + {schedule: "20 8 * * 0,2,4"},
+    resnet + v2_32 + convergence + tpus.reserved + {schedule: "20 8 * * 0,2,4"},
     resnet + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/nightly/retinanet.libsonnet
+++ b/tests/tensorflow/nightly/retinanet.libsonnet
@@ -154,6 +154,11 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     retinanet + functional + k80x8 + mixins.Suspended,
@@ -167,7 +172,7 @@ local gpus = import "templates/gpus.libsonnet";
     retinanet + convergence + v3_8,
     retinanet + functional + v2_32,
     retinanet + functional + v3_32,
-    retinanet + convergence + v2_32,
+    retinanet + convergence + v2_32 + reserved + {schedule: "47 19 * * 1,3,5,6"},
     retinanet + convergence + v3_32,
   ],
 }

--- a/tests/tensorflow/nightly/retinanet.libsonnet
+++ b/tests/tensorflow/nightly/retinanet.libsonnet
@@ -154,11 +154,6 @@ local gpus = import "templates/gpus.libsonnet";
       },
     },
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     retinanet + functional + k80x8 + mixins.Suspended,
@@ -172,7 +167,7 @@ local gpus = import "templates/gpus.libsonnet";
     retinanet + convergence + v3_8,
     retinanet + functional + v2_32,
     retinanet + functional + v3_32,
-    retinanet + convergence + v2_32 + reserved + {schedule: "47 19 * * 1,3,5,6"},
+    retinanet + convergence + v2_32 + tpus.reserved + {schedule: "47 19 * * 1,3,5,6"},
     retinanet + convergence + v3_32,
   ],
 }

--- a/tests/tensorflow/nightly/transformer-translate.libsonnet
+++ b/tests/tensorflow/nightly/transformer-translate.libsonnet
@@ -122,6 +122,11 @@ local gpus = import "templates/gpus.libsonnet";
       "--batch_size=24576",
     ],
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     transformer + k80 + functional_short + timeouts.Hours(6) + mixins.Suspended,
@@ -138,7 +143,7 @@ local gpus = import "templates/gpus.libsonnet";
     transformer + v3_8 + convergence ,
     transformer + v2_32 + functional,
     transformer + v3_32 + functional,
-    transformer + v2_32 + convergence,
+    transformer + v2_32 + convergence + reserved + {schedule: "10 20 * * 0,2,4"},
     transformer + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/nightly/transformer-translate.libsonnet
+++ b/tests/tensorflow/nightly/transformer-translate.libsonnet
@@ -122,11 +122,6 @@ local gpus = import "templates/gpus.libsonnet";
       "--batch_size=24576",
     ],
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     transformer + k80 + functional_short + timeouts.Hours(6) + mixins.Suspended,
@@ -143,7 +138,7 @@ local gpus = import "templates/gpus.libsonnet";
     transformer + v3_8 + convergence ,
     transformer + v2_32 + functional,
     transformer + v3_32 + functional,
-    transformer + v2_32 + convergence + reserved + {schedule: "10 20 * * 0,2,4"},
+    transformer + v2_32 + convergence + tpus.reserved + {schedule: "10 20 * * 0,2,4"},
     transformer + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/nightly/xlnet-imdb.libsonnet
+++ b/tests/tensorflow/nightly/xlnet-imdb.libsonnet
@@ -85,12 +85,17 @@ local tpus = import "templates/tpus.libsonnet";
       '--test_batch_size=128',
     ],
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     xlnet + v3_8 + functional + mixins.Unsuspended,
     xlnet + v2_8 + convergence + timeouts.Hours(2),
     xlnet + v3_8 + convergence + timeouts.Hours(1),
-    xlnet + v2_32 + convergence,
+    xlnet + v2_32 + convergence + reserved + {schedule: "54 20 * * 1,3,5,6"},
     xlnet + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/nightly/xlnet-imdb.libsonnet
+++ b/tests/tensorflow/nightly/xlnet-imdb.libsonnet
@@ -85,17 +85,12 @@ local tpus = import "templates/tpus.libsonnet";
       '--test_batch_size=128',
     ],
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     xlnet + v3_8 + functional + mixins.Unsuspended,
     xlnet + v2_8 + convergence + timeouts.Hours(2),
     xlnet + v3_8 + convergence + timeouts.Hours(1),
-    xlnet + v2_32 + convergence + reserved + {schedule: "54 20 * * 1,3,5,6"},
+    xlnet + v2_32 + convergence + tpus.reserved + {schedule: "54 20 * * 1,3,5,6"},
     xlnet + v3_32 + convergence,
   ],
 }

--- a/tests/tensorflow/r1.15/bert.libsonnet
+++ b/tests/tensorflow/r1.15/bert.libsonnet
@@ -71,11 +71,16 @@ local tpus = import "templates/tpus.libsonnet";
       '--num_train_epochs=1',
     ],
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     bert + v2_8 + convergence,
     bert + v3_8 + convergence,
-    bert + v2_32 + convergence,
+    bert + v2_32 + convergence + reserved + {schedule: "12 23 * * 0,2,4"},
     bert + v3_32 + convergence,
     bert + v2_8 + functional,
     bert + v3_8 + functional,

--- a/tests/tensorflow/r1.15/bert.libsonnet
+++ b/tests/tensorflow/r1.15/bert.libsonnet
@@ -71,16 +71,11 @@ local tpus = import "templates/tpus.libsonnet";
       '--num_train_epochs=1',
     ],
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     bert + v2_8 + convergence,
     bert + v3_8 + convergence,
-    bert + v2_32 + convergence + reserved + {schedule: "12 23 * * 0,2,4"},
+    bert + v2_32 + convergence + tpus.reserved + {schedule: "12 23 * * 0,2,4"},
     bert + v3_32 + convergence,
     bert + v2_8 + functional,
     bert + v3_8 + functional,

--- a/tests/tensorflow/r1.15/mask-rcnn.libsonnet
+++ b/tests/tensorflow/r1.15/mask-rcnn.libsonnet
@@ -85,11 +85,16 @@ local tpus = import "templates/tpus.libsonnet";
       total_steps: 1000,
     },
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     mask_rcnn + v2_8 + convergence,
     mask_rcnn + v3_8 + convergence,
-    mask_rcnn + v2_32 + convergence,
+    mask_rcnn + v2_32 + convergence + reserved + {schedule: "10 4 * * 0,2,4"},
     mask_rcnn + v3_32 + convergence,
     mask_rcnn + v2_8 + functional,
     mask_rcnn + v3_8 + functional,

--- a/tests/tensorflow/r1.15/mask-rcnn.libsonnet
+++ b/tests/tensorflow/r1.15/mask-rcnn.libsonnet
@@ -85,16 +85,11 @@ local tpus = import "templates/tpus.libsonnet";
       total_steps: 1000,
     },
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     mask_rcnn + v2_8 + convergence,
     mask_rcnn + v3_8 + convergence,
-    mask_rcnn + v2_32 + convergence + reserved + {schedule: "10 4 * * 0,2,4"},
+    mask_rcnn + v2_32 + convergence + tpus.reserved + {schedule: "10 4 * * 0,2,4"},
     mask_rcnn + v3_32 + convergence,
     mask_rcnn + v2_8 + functional,
     mask_rcnn + v3_8 + functional,

--- a/tests/tensorflow/r1.15/resnet.libsonnet
+++ b/tests/tensorflow/r1.15/resnet.libsonnet
@@ -60,16 +60,11 @@ local tpus = import "templates/tpus.libsonnet";
       "--train_steps=1000",
     ],
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     resnet + v2_8 + convergence,
     resnet + v3_8 + convergence,
-    resnet + v2_32 + convergence + reserved + {schedule: "59 15 * * 0,2,4"},
+    resnet + v2_32 + convergence + tpus.reserved + {schedule: "59 15 * * 0,2,4"},
     resnet + v3_32 + convergence,
     resnet + v2_8 + functional,
     resnet + v3_8 + functional,

--- a/tests/tensorflow/r1.15/resnet.libsonnet
+++ b/tests/tensorflow/r1.15/resnet.libsonnet
@@ -60,11 +60,16 @@ local tpus = import "templates/tpus.libsonnet";
       "--train_steps=1000",
     ],
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     resnet + v2_8 + convergence,
     resnet + v3_8 + convergence,
-    resnet + v2_32 + convergence,
+    resnet + v2_32 + convergence + reserved + {schedule: "59 15 * * 0,2,4"},
     resnet + v3_32 + convergence,
     resnet + v2_8 + functional,
     resnet + v3_8 + functional,

--- a/tests/tensorflow/r1.15/retinanet.libsonnet
+++ b/tests/tensorflow/r1.15/retinanet.libsonnet
@@ -92,11 +92,16 @@ local tpus = import "templates/tpus.libsonnet";
       },
     },
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     retinanet + v2_8 + convergence,
     retinanet + v3_8 + convergence,
-    retinanet + v2_32 + convergence,
+    retinanet + v2_32 + convergence + reserved + {schedule: "37 13 * * 0,2,4"},
     retinanet + v3_32 + convergence,
     retinanet + v2_8 + functional,
     retinanet + v3_8 + functional,

--- a/tests/tensorflow/r1.15/retinanet.libsonnet
+++ b/tests/tensorflow/r1.15/retinanet.libsonnet
@@ -92,16 +92,11 @@ local tpus = import "templates/tpus.libsonnet";
       },
     },
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     retinanet + v2_8 + convergence,
     retinanet + v3_8 + convergence,
-    retinanet + v2_32 + convergence + reserved + {schedule: "37 13 * * 0,2,4"},
+    retinanet + v2_32 + convergence + tpus.reserved + {schedule: "37 13 * * 0,2,4"},
     retinanet + v3_32 + convergence,
     retinanet + v2_8 + functional,
     retinanet + v3_8 + functional,

--- a/tests/tensorflow/r1.15/shapemask.libsonnet
+++ b/tests/tensorflow/r1.15/shapemask.libsonnet
@@ -128,11 +128,16 @@ local tpus = import "templates/tpus.libsonnet";
       },
     },
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     shapemask + v2_8 + convergence,
     shapemask + v3_8 + convergence,
-    shapemask + v2_32 + convergence,
+    shapemask + v2_32 + convergence + reserved + {schedule: "0 0 * * 0,2,4"},
     shapemask + v3_32 + convergence,
     shapemask + v2_8 + functional,
     shapemask + v3_8 + functional,

--- a/tests/tensorflow/r1.15/shapemask.libsonnet
+++ b/tests/tensorflow/r1.15/shapemask.libsonnet
@@ -128,16 +128,11 @@ local tpus = import "templates/tpus.libsonnet";
       },
     },
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     shapemask + v2_8 + convergence,
     shapemask + v3_8 + convergence,
-    shapemask + v2_32 + convergence + reserved + {schedule: "0 0 * * 0,2,4"},
+    shapemask + v2_32 + convergence + tpus.reserved + {schedule: "0 0 * * 0,2,4"},
     shapemask + v3_32 + convergence,
     shapemask + v2_8 + functional,
     shapemask + v3_8 + functional,

--- a/tests/tensorflow/r1.15/transformer.libsonnet
+++ b/tests/tensorflow/r1.15/transformer.libsonnet
@@ -83,16 +83,11 @@ local utils = import "templates/utils.libsonnet";
       "--train_steps=10",
     ],
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     transformer + v2_8 + convergence + { command+: [ "--train_steps=250000" ] },
     transformer + v3_8 + convergence + { command+: [ "--train_steps=250000" ] },
-    transformer + v2_32 + convergence + { command+: [ "--train_steps=62500" ] } + reserved + {schedule: "13 18 * * 0,2,4"},
+    transformer + v2_32 + convergence + { command+: [ "--train_steps=62500" ] } + tpus.reserved + {schedule: "13 18 * * 0,2,4"},
     transformer + v3_32 + convergence + { command+: [ "--train_steps=62500" ] },
     transformer + v2_8 + functional,
     transformer + v3_8 + functional,

--- a/tests/tensorflow/r1.15/transformer.libsonnet
+++ b/tests/tensorflow/r1.15/transformer.libsonnet
@@ -83,11 +83,16 @@ local utils = import "templates/utils.libsonnet";
       "--train_steps=10",
     ],
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     transformer + v2_8 + convergence + { command+: [ "--train_steps=250000" ] },
     transformer + v3_8 + convergence + { command+: [ "--train_steps=250000" ] },
-    transformer + v2_32 + convergence + { command+: [ "--train_steps=62500" ] },
+    transformer + v2_32 + convergence + { command+: [ "--train_steps=62500" ] } + reserved + {schedule: "13 18 * * 0,2,4"},
     transformer + v3_32 + convergence + { command+: [ "--train_steps=62500" ] },
     transformer + v2_8 + functional,
     transformer + v3_8 + functional,

--- a/tests/tensorflow/r1.15/unet.libsonnet
+++ b/tests/tensorflow/r1.15/unet.libsonnet
@@ -74,10 +74,15 @@ local tpus = import "templates/tpus.libsonnet";
       train_steps: 100,
     },
   },
+  local reserved = {
+    tpuSettings+: {
+      reserved: "true",
+    },
+  },
 
   configs: [
     unet + v3_8 + convergence,
-    unet + v2_32 + convergence,
+    unet + v2_32 + convergence + reserved + {schedule: "0 1 * * 1,3,5,6"},
     unet + v3_32 + convergence,
     unet + v3_8 + functional,
     unet + v2_32 + functional,

--- a/tests/tensorflow/r1.15/unet.libsonnet
+++ b/tests/tensorflow/r1.15/unet.libsonnet
@@ -74,15 +74,10 @@ local tpus = import "templates/tpus.libsonnet";
       train_steps: 100,
     },
   },
-  local reserved = {
-    tpuSettings+: {
-      reserved: "true",
-    },
-  },
 
   configs: [
     unet + v3_8 + convergence,
-    unet + v2_32 + convergence + reserved + {schedule: "0 1 * * 1,3,5,6"},
+    unet + v2_32 + convergence + tpus.reserved + {schedule: "0 1 * * 1,3,5,6"},
     unet + v3_32 + convergence,
     unet + v3_8 + functional,
     unet + v2_32 + functional,


### PR DESCRIPTION
Split into 2 initial commits to make this more readable:
1. updates to templates and test files, 2 example yaml changes - 1 using reservation and 1 not using reservation
2. rest of the yaml updates

I chose to run TF nightly and TF 1.15 v2-32 convergence tests on our v2-32 reservation, trying to keep utilization high. I set all the `nightly` tests to run at an hour of day >= 7, since our nightly image right now gets published at ~5 in UTC time. The 1.15 tests can start at any time of day since that image is pretty static.

I generated the cron schedules with a helper python script (not checked in) but looked over them manually too. I'll save the script somewhere to make it easy for us to set up a new schedule if we want to change the tests that run reserved.

For testing: I upgraded version on oneshot cluster and ran a test there using reservation + verified that the TPU was actually from our reservation using `gcloud compute tpus describe` while the job was running

If this PR looks OK, I will:
1. upgrade real pods cluster
2. push one of these reservation yamls
3. run test job on real cluster
4. submit the PR if the real job looks OK