### PR TITLE
Add actions to diff and build generated files.

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,0 +1,40 @@
+# Build generated files with JSonnet and show diff output.
+name: Diff Generated Files
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, edited]
+  
+  workflow_dispatch: {}
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Go environment
+      uses: actions/setup-go@v2.1.3
+
+    - name: Install JSonnet
+      run: |
+        go get github.com/google/go-jsonnet/cmd/jsonnet
+        echo "$HOME/go/bin" >> $GITHUB_PATH
+
+    - name: Build repository
+      run: |
+        scripts/gen-tests.sh
+
+    # New files need to be added before git diff will recognize them.
+    - name: Show git diff
+      run: |
+        git add -N k8s/
+        git fetch origin gen
+        git diff origin/gen -- k8s/ | tee generated.diff
+
+    - name: Upload a diff file
+      uses: actions/upload-artifact@v2.2.0
+      with:
+        name: diff
+        path: generated.diff

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,37 @@
+# Build generated files and push them to the gen branch.
+name: Build Generated Files
+
+on:
+  push:
+    branches: [master]
+  
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Branch to gen
+      run: |
+        git branch -f gen
+  
+    - name: Setup Go environment
+      uses: actions/setup-go@v2.1.3
+      
+    - name: Install JSonnet
+      run: |
+        go get github.com/google/go-jsonnet/cmd/jsonnet
+        echo "$HOME/go/bin" >> $GITHUB_PATH
+
+    - name: Build JSonnet templates
+      run: |
+        scripts/gen-tests.sh
+    
+    - name: Git Commit/Push Changes
+      uses: actions-x/commit@v2
+      with:
+        branch: gen
+        files: k8s/
+        force: true


### PR DESCRIPTION
This change will remove the need for contributors to rebuild generated files. Each PR will have a check showing the diff that contributors can use as a sanity-check. Generated files will be built for each push to master and kept on the gen branch. After this PR is submitted, I can update Cloud Build to use the generated files from gen instead.