### PR TITLE
Modify one shot runner script to show when an option is invalid.

### DIFF
--- a/scripts/run-oneshot.sh
+++ b/scripts/run-oneshot.sh
@@ -136,13 +136,14 @@ while [ "$1" != "" ]; do
     -h | --help )           help
                             exit
                             ;;
-    -t | --testtype)        shift
+    -t | --type)            shift
                             testtype="$1"
                             ;;
     -p | --patch)           shift
                             patch="$1"
                             ;;
-    * )                     usage
+    * )                     echo "Invalid option: $1"
+                            help 
                             exit 1
   esac
   shift


### PR DESCRIPTION
Currently it shows the help page rather than what's wrong with the command. This makes it clearer and fixes a misnamed flag :)