### PR TITLE
Fix metric minimum time calculation and add tests.

### DIFF
--- a/metrics_v2/handler/bigquery_client.py
+++ b/metrics_v2/handler/bigquery_client.py
@@ -18,6 +18,7 @@ import math
 import typing
 
 from absl import logging
+import google.auth
 from google.cloud import bigquery
 
 from handler import utils

--- a/metrics_v2/handler/collectors/base.py
+++ b/metrics_v2/handler/collectors/base.py
@@ -66,14 +66,20 @@ class BaseCollector:
     if not self._metric_store:
       raise ValueError('Metric history requested for {}, but no metric store '
                        'was provided to Collector.'.format(metric_key))
+
+    if time_window.ToTimedelta():
+      min_time = max(
+          min_timestamp.ToDatetime(),
+          self._event.start_time.ToDatetime() - time_window.ToTimedelta())
+    else:
+      min_time = min_timestamp.ToDatetime()
+
     history_rows = self._metric_store.get_metric_history(
       benchmark_id=(
           self._event.metric_collection_config.compare_to_benchmark_id or
           self._event.benchmark_id),
       metric_key=metric_key,
-      min_time=max(
-          min_timestamp.ToDatetime(),
-          self._event.start_time.ToDatetime() - time_window.ToTimedelta())
+      min_time=min_time,
     )
     
     return [row.metric_value for row in history_rows]

--- a/metrics_v2/handler/collectors/base_test.py
+++ b/metrics_v2/handler/collectors/base_test.py
@@ -15,9 +15,12 @@
 import dataclasses
 import datetime
 import math
+from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
+from google.protobuf import duration_pb2
+from google.protobuf import timestamp_pb2
 
 import base
 from handler import bigquery_client
@@ -170,6 +173,53 @@ class BaseCollectorTest(parameterized.TestCase):
         dataclasses.astuple(utils.Bounds(*expected_bounds,
             inclusive or comparison == 'EQUAL')),
         places=3)
+
+  @parameterized.named_parameters(
+    ('none', None, None, datetime.datetime.fromtimestamp(0)),
+    ('window', datetime.timedelta(days=2), None, datetime.datetime(2021, 2, 14, 0, 0, 0)),
+    ('timestamp', None, datetime.datetime(2021, 2, 14, 0, 0, 0), datetime.datetime(2021, 2, 14, 0, 0, 0)),
+    ('both_1', datetime.timedelta(days=3), datetime.datetime(2021, 2, 14, 0, 0, 0), datetime.datetime(2021, 2, 14, 0, 0, 0)),
+    ('both_2', datetime.timedelta(days=2), datetime.datetime(2021, 2, 13, 0, 0, 0), datetime.datetime(2021, 2, 14, 0, 0, 0)),
+  )
+  def test_min_time(self, window, timestamp, expected_min):
+    start_time = timestamp_pb2.Timestamp()
+    start_time.FromDatetime(datetime.datetime(2021, 2, 16, 0, 0, 0))
+
+    min_timestamp = timestamp_pb2.Timestamp()
+    if timestamp:
+      min_timestamp.FromDatetime(timestamp)
+
+    time_window = duration_pb2.Duration()
+    if window:
+      time_window.FromTimedelta(window)
+
+    assertion = metrics_pb2.Assertion(
+      std_devs_from_mean=metrics_pb2.Assertion.StdDevsFromMean(
+        comparison=metrics_pb2.Assertion.Comparison.WITHIN,
+        std_devs=1,
+      ),
+      time_window=time_window,
+      min_timestamp=min_timestamp,
+    )
+
+    metric_store = bigquery_client.BigQueryMetricStore('fake_dataset', 'fake_project')
+    metric_store.get_metric_history = mock.Mock(return_value=[])
+
+    collector = base.BaseCollector(
+      metrics_pb2.TestCompletedEvent(
+        benchmark_id="test_benchmark",
+        start_time=start_time,
+      ),
+      None,
+      metric_store)
+
+    collector.compute_bounds("metric_key", assertion)
+
+    metric_store.get_metric_history.assert_called_with(
+      benchmark_id="test_benchmark",
+      metric_key="metric_key",
+      min_time=expected_min)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
When the time window was unset, the duration defaulted to 0 seconds, so the minimum metric timestamp was just the tests' start time. Any metrics recorded before the start time of a test would be ignored, which is not a reasonable default behavior.