### PR TITLE
Enable xla_dist pod testing for transformer and resnet

### DIFF
--- a/tests/pytorch/r1.8/fs-transformer.libsonnet
+++ b/tests/pytorch/r1.8/fs-transformer.libsonnet
@@ -113,6 +113,7 @@ local utils = import "templates/utils.libsonnet";
     },
   },
   local functional_xla_dist = common.Functional {
+    condaEnv: "torch-xla-1.8",
     command: [
       "python",
       "/usr/share/torch-xla-1.8/tpu-examples/deps/fairseq/train.py",
@@ -204,8 +205,7 @@ local utils = import "templates/utils.libsonnet";
     accelerator: tpus.v3_32,
   },
   configs: [
-    # TODO: Enable once new GCE conda env exists.
-    # common.PyTorchXlaDistPodTest + transformer + v3_32 + functional_xla_dist + timeouts.Hours(1),
+    common.PyTorchXlaDistPodTest + transformer + v3_32 + functional_xla_dist + timeouts.Hours(1),
     common.PyTorchTest + transformer + v3_8 + functional + timeouts.Hours(1),
     common.PyTorchTest + transformer + v3_8 + convergence + timeouts.Hours(25),
     common.PyTorchTest + transformer + v3_8 + checkpoint_local + timeouts.Hours(2),

--- a/tests/pytorch/r1.8/resnet50-pod.libsonnet
+++ b/tests/pytorch/r1.8/resnet50-pod.libsonnet
@@ -27,6 +27,7 @@ local mixins = import "templates/mixins.libsonnet";
   },
   local resnet50_pod_func = common.PyTorchXlaDistPodTest {
     modelName: "resnet50-pod",
+    condaEnv: "torch-xla-1.8",
     command: [
       "python3",
       "/usr/share/torch-xla-1.8/pytorch/xla/test/test_train_mp_imagenet.py",
@@ -73,8 +74,7 @@ local mixins = import "templates/mixins.libsonnet";
     accelerator: tpus.v3_32,
   },
   configs: [
-    # TODO: Enable once new GCE conda env exists.
-    # resnet50_pod_func + v3_32 + functional,
+    resnet50_pod_func + v3_32 + functional,
     resnet50_pod + v3_32 + convergence,
   ],
 }


### PR DESCRIPTION
[resnet oneshot](https://pantheon.corp.google.com/logs/viewer?interval=NO_LIMIT&project=xl-ml-test&minLogLevel=0&expandAll=false&timestamp=2021-02-25T23:37:26.419000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22xl-ml-test%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22oneshots-europe-west4%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name%3D%22pt-r1.8-resnet50-pod-func-v3-32-wtb8t-zzlwk%22%0Aresource.labels.container_name%3D%22train%22)

[transformer oneshot](https://pantheon.corp.google.com/logs/viewer?interval=NO_LIMIT&project=xl-ml-test&minLogLevel=0&expandAll=false&timestamp=2021-02-25T23:36:52.145000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22xl-ml-test%22%0Aresource.labels.location%3D%22europe-west4%22%0Aresource.labels.cluster_name%3D%22oneshots-europe-west4%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name%3D%22pt-r1.8-fs-transformer-func-v3-32-9826k-tdz25%22%0Aresource.labels.container_name%3D%22train%22)