### PR TITLE
Use memory-map for DLRM 2VM convergence test.

### DIFF
--- a/tests/pytorch/nightly/dlrm.libsonnet
+++ b/tests/pytorch/nightly/dlrm.libsonnet
@@ -134,14 +134,14 @@ local utils = import "templates/utils.libsonnet";
         pip install onnx
         git clone --recursive https://github.com/pytorch-tpu/examples.git
         python examples/deps/dlrm/dlrm_tpu_runner.py \
-            --num-workers=7 \
+            --memory-map \
             --arch-sparse-feature-size=16 \
             --arch-mlp-bot="13-512-256-64-16" \
             --arch-mlp-top="512-256-1" \
             --data-generation=dataset \
             --data-set=kaggle \
-            --raw-data-file=/datasets/criteo-kaggle/train.txt \
-            --processed-data-file=/datasets/criteo-kaggle/kaggleAdDisplayChallenge_processed.npz \
+            --raw-data-file=/datasets/criteo-kaggle-mm/train.txt \
+            --processed-data-file=/datasets/criteo-kaggle-mm/kaggleAdDisplayChallenge_processed.npz \
             --loss-function=bce \
             --round-targets=True \
             --learning-rate=0.1 \

--- a/tests/pytorch/nightly/dlrm.libsonnet
+++ b/tests/pytorch/nightly/dlrm.libsonnet
@@ -134,6 +134,7 @@ local utils = import "templates/utils.libsonnet";
         pip install onnx
         git clone --recursive https://github.com/pytorch-tpu/examples.git
         python examples/deps/dlrm/dlrm_tpu_runner.py \
+            --num-workers=7 \
             --arch-sparse-feature-size=16 \
             --arch-mlp-bot="13-512-256-64-16" \
             --arch-mlp-top="512-256-1" \


### PR DESCRIPTION
Trying to run this version now as `pt-nightly-dlrm-convergence-conv-v3-8-manual-m8ckj`

I'll make sure the job starts up and looks reasonable before submitting