### PR TITLE
Fix nightly TF GCS filesystem registration errors

### DIFF
--- a/tests/tensorflow/common.libsonnet
+++ b/tests/tensorflow/common.libsonnet
@@ -28,6 +28,19 @@ local volumes = import "templates/volumes.libsonnet";
         mountPath: "/dev/shm",
       },
     },
+    jobSpec+:: {
+      template+: {
+        spec+: {
+          containerMap+: {
+            train+: {
+              envMap+: {
+                TF_ENABLE_LEGACY_FILESYSTEM: "1",
+              },
+            },
+          },
+        },
+      },
+    },
   },
   LegacyTpuTest:: common.CloudAcceleratorTest {
     local config = self,


### PR DESCRIPTION
Cloud filesystems will be built separately out of TF core into TF IO and
we'll have to use those instead. This is a temporary fix and we should
move to using GCSFS from TF IO. For more context: b/183753662.

Failing stack trace:
```
tensorflow.python.framework.errors_impl.UnimplementedError: File system scheme 'gs' not implemented (file: 'gs://**REDACTED**')
```

Failing current nightly run: http://shortn/_ol0GDZwRDz
Passing run with fix: http://shortn/_qRc99qLNYu