### PR TITLE
Freezing first 10 layers of Resnet in Mask-RCNN training.

### DIFF
--- a/tests/tensorflow/nightly/maskrcnn.libsonnet
+++ b/tests/tensorflow/nightly/maskrcnn.libsonnet
@@ -32,6 +32,7 @@ local gpus = import "templates/gpus.libsonnet";
           path: "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07",
           prefix: "resnet50/",
         },
+        frozen_variable_prefix: "(conv2d(|_([1-9]|10))|batch_normalization(|_([1-9]|10)))\\/",
         total_steps: error "Must set `train.total_steps`",
         batch_size: error "Must set `train.batch_size`",
         train_file_pattern: "$(COCO_DIR)/train*",

--- a/tests/tensorflow/r2.5/maskrcnn.libsonnet
+++ b/tests/tensorflow/r2.5/maskrcnn.libsonnet
@@ -32,6 +32,7 @@ local gpus = import "templates/gpus.libsonnet";
           path: "$(RESNET_PRETRAIN_DIR)/resnet50-checkpoint-2018-02-07",
           prefix: "resnet50/",
         },
+        frozen_variable_prefix: "(conv2d(|_([1-9]|10))|batch_normalization(|_([1-9]|10)))\\/",
         total_steps: error "Must set `train.total_steps`",
         batch_size: error "Must set `train.batch_size`",
         train_file_pattern: "$(COCO_DIR)/train*",


### PR DESCRIPTION
Adding frozen_variable_prefix for Mask-RCNN training with Resnet50 backbone.
It helps to speed up the training and also not OOM on v2-8