### PR TITLE
Use the updated HF path.

### DIFF
--- a/tests/pytorch/nightly/hf-glue.libsonnet
+++ b/tests/pytorch/nightly/hf-glue.libsonnet
@@ -23,9 +23,9 @@ local utils = import "templates/utils.libsonnet";
     cd transformers && pip install .
     git log -1
     pip install datasets
-    python examples/xla_spawn.py \
+    python examples/pytorch/xla_spawn.py \
       --num_cores 8 \
-      examples/text-classification/run_glue.py \
+      examples/pytorch/text-classification/run_glue.py \
       --logging_dir=./tensorboard-metrics \
       --task_name MNLI \
       --cache_dir ./cache_dir \

--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -23,9 +23,9 @@ local utils = import "templates/utils.libsonnet";
     cd transformers && pip install .
     git log -1
     pip install datasets
-    python examples/xla_spawn.py \
+    python examples/pytorch/xla_spawn.py \
       --num_cores 8 \
-      examples/language-modeling/run_mlm.py \
+      examples/pytorch/language-modeling/run_mlm.py \
       --logging_dir ./tensorboard-metrics \
       --cache_dir ./cache_dir \
       --dataset_name wikitext \

--- a/tests/pytorch/r1.8.1/hf-glue.libsonnet
+++ b/tests/pytorch/r1.8.1/hf-glue.libsonnet
@@ -23,9 +23,9 @@ local utils = import "templates/utils.libsonnet";
     cd transformers && pip install .
     git log -1
     pip install datasets
-    python examples/xla_spawn.py \
+    python examples/pytorch/xla_spawn.py \
       --num_cores 8 \
-      examples/text-classification/run_glue.py \
+      examples/pytorch/text-classification/run_glue.py \
       --logging_dir=./tensorboard-metrics \
       --task_name MNLI \
       --cache_dir ./cache_dir \

--- a/tests/pytorch/r1.8/hf-glue.libsonnet
+++ b/tests/pytorch/r1.8/hf-glue.libsonnet
@@ -23,9 +23,9 @@ local utils = import "templates/utils.libsonnet";
     cd transformers && pip install .
     git log -1
     pip install datasets
-    python examples/xla_spawn.py \
+    python examples/pytorch/xla_spawn.py \
       --num_cores 8 \
-      examples/text-classification/run_glue.py \
+      examples/pytorch/text-classification/run_glue.py \
       --logging_dir=./tensorboard-metrics \
       --task_name MNLI \
       --cache_dir ./cache_dir \


### PR DESCRIPTION
Huggingface changed the path in https://github.com/huggingface/transformers/pull/11350

Use the updated path for all tests that clone the huggingface repo (the 1.7 test does not clone it)
