### PR TITLE
Remove BaseTest.jobSpec

### DIFF
--- a/templates/base.libsonnet
+++ b/templates/base.libsonnet
@@ -249,9 +249,9 @@ local volumes = import 'volumes.libsonnet';
       metadata: {
         annotations+: if config.metricConfig != null then {
           'ml-testing-accelerators/metric-config':
-              std.manifestJsonEx(config.metricConfig, '  ') + '\n',
+            std.manifestJsonEx(config.metricConfig, '  ') + '\n',
           'ml-testing-accelerators/gcs-subdir': gcsSubdir,
-        } else { },
+        } else {},
         labels: config.labels,
       },
       spec: {

--- a/tests/common.libsonnet
+++ b/tests/common.libsonnet
@@ -26,41 +26,38 @@ local metrics = import 'templates/metrics.libsonnet';
     },
 
     // Add experimental TPU health monitor to Job.
-    // TODO: move this to base template if it's working well.
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: if config.accelerator.type == 'tpu' then
-            {
-              monitor: {
-                name: 'monitor',
-                image: 'gcr.io/xl-ml-test/health-monitor:stable',
-                imagePullPolicy: 'Always',
-                env: [
-                  {
-                    name: 'POD_NAME',
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: 'metadata.name',
-                      },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: if config.accelerator.type == 'tpu' then
+          {
+            monitor: {
+              name: 'monitor',
+              image: 'gcr.io/xl-ml-test/health-monitor:stable',
+              imagePullPolicy: 'Always',
+              env: [
+                {
+                  name: 'POD_NAME',
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: 'metadata.name',
                     },
                   },
-                  {
-                    name: 'POD_NAMESPACE',
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: 'metadata.namespace',
-                      },
+                },
+                {
+                  name: 'POD_NAMESPACE',
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: 'metadata.namespace',
                     },
                   },
-                ],
-              },
-            }
-          else {},
-        } + if config.accelerator.type == 'gpu' then {
-          priorityClassName: 'gpu-%(version)s' % config.accelerator,
-        } else {},
-      },
+                },
+              ],
+            },
+          }
+        else {},
+      } + if config.accelerator.type == 'gpu' then {
+        priorityClassName: 'gpu-%(version)s' % config.accelerator,
+      } else {},
     },
 
     cronJob+:: {

--- a/tests/common.libsonnet
+++ b/tests/common.libsonnet
@@ -25,6 +25,9 @@ local metrics = import 'templates/metrics.libsonnet';
       requireTpuAvailableLabel: true,
     },
 
+    metricConfig:
+      metrics.CompatMetrics(config.metricCollectionConfig, config.regressionTestConfig),
+
     // Add experimental TPU health monitor to Job.
     podTemplate+:: {
       spec+: {
@@ -63,17 +66,6 @@ local metrics = import 'templates/metrics.libsonnet';
     cronJob+:: {
       metadata+: {
         namespace: 'automated',
-      },
-      spec+: {
-        jobTemplate+: {
-          metadata+: {
-            annotations+: {
-              'ml-testing-accelerators/metric-config':
-                std.manifestJsonEx(metrics.CompatMetrics(config.metricCollectionConfig, config.regressionTestConfig), '  ') + '\n',
-              'ml-testing-accelerators/gcs-subdir': '%(frameworkPrefix)s/%(modelName)s/%(mode)s/%(acceleratorName)s' % config,
-            },
-          },
-        },
       },
     },
   },

--- a/tests/pytorch/nightly/dlrm.libsonnet
+++ b/tests/pytorch/nightly/dlrm.libsonnet
@@ -43,16 +43,14 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '9.0',
-                  memory: '30Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '9.0',
+                memory: '30Gi',
               },
             },
           },
@@ -66,16 +64,14 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '40.0',
-                  memory: '500Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '40.0',
+                memory: '500Gi',
               },
             },
           },

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -98,14 +98,12 @@ local utils = import 'templates/utils.libsonnet';
         gsutil rm -r %(savedir)s
       ||| % { common: chpt_command_common, savedir: '$MODEL_DIR/checkpoints' }
     ),
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              envMap+: {
-                XLA_USE_BF16: '1',
-              },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            envMap+: {
+              XLA_USE_BF16: '1',
             },
           },
         },
@@ -183,14 +181,12 @@ local utils = import 'templates/utils.libsonnet';
         test $bleu -gt 27 -a $wps -gt 10000
       ||| % command_common
     ),
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              envMap+: {
-                XLA_USE_BF16: '1',
-              },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            envMap+: {
+              XLA_USE_BF16: '1',
             },
           },
         },

--- a/tests/pytorch/nightly/hf-glue.libsonnet
+++ b/tests/pytorch/nightly/hf-glue.libsonnet
@@ -134,16 +134,14 @@ local utils = import 'templates/utils.libsonnet';
   },
   local hf_glue = common.PyTorchTest {
     modelName: 'hf-glue',
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '12.0',
-                  memory: '80Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '12.0',
+                memory: '80Gi',
               },
             },
           },

--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -140,16 +140,14 @@ local utils = import 'templates/utils.libsonnet';
   },
   local hf_lm = common.PyTorchTest {
     modelName: 'hf-lm',
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '12.0',
-                  memory: '80Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '12.0',
+                memory: '80Gi',
               },
             },
           },

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -55,16 +55,14 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '90.0',
-                  memory: '400Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '90.0',
+                memory: '400Gi',
               },
             },
           },

--- a/tests/pytorch/nightly/roberta-pre.libsonnet
+++ b/tests/pytorch/nightly/roberta-pre.libsonnet
@@ -64,17 +64,15 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '9.0',
-                  memory: '30Gi',
-                  'ephemeral-storage': '10Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '9.0',
+                memory: '30Gi',
+                'ephemeral-storage': '10Gi',
               },
             },
           },

--- a/tests/pytorch/r1.7/fs-transformer.libsonnet
+++ b/tests/pytorch/r1.7/fs-transformer.libsonnet
@@ -84,14 +84,12 @@ local utils = import 'templates/utils.libsonnet';
         gsutil rm -r %(savedir)s
       ||| % { common: chpt_command_common, savedir: '$MODEL_DIR/checkpoints' }
     ),
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              envMap+: {
-                XLA_USE_BF16: '1',
-              },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            envMap+: {
+              XLA_USE_BF16: '1',
             },
           },
         },
@@ -131,14 +129,12 @@ local utils = import 'templates/utils.libsonnet';
         test $bleu -gt 27
       ||| % command_common
     ),
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              envMap+: {
-                XLA_USE_BF16: '1',
-              },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            envMap+: {
+              XLA_USE_BF16: '1',
             },
           },
         },

--- a/tests/pytorch/r1.7/roberta-pre.libsonnet
+++ b/tests/pytorch/r1.7/roberta-pre.libsonnet
@@ -59,17 +59,15 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '9.0',
-                  memory: '30Gi',
-                  'ephemeral-storage': '10Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '9.0',
+                memory: '30Gi',
+                'ephemeral-storage': '10Gi',
               },
             },
           },

--- a/tests/pytorch/r1.8.1/dlrm.libsonnet
+++ b/tests/pytorch/r1.8.1/dlrm.libsonnet
@@ -43,16 +43,14 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '9.0',
-                  memory: '30Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '9.0',
+                memory: '30Gi',
               },
             },
           },
@@ -66,16 +64,14 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '40.0',
-                  memory: '500Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '40.0',
+                memory: '500Gi',
               },
             },
           },

--- a/tests/pytorch/r1.8.1/fs-transformer.libsonnet
+++ b/tests/pytorch/r1.8.1/fs-transformer.libsonnet
@@ -98,14 +98,12 @@ local utils = import 'templates/utils.libsonnet';
         gsutil rm -r %(savedir)s
       ||| % { common: chpt_command_common, savedir: '$MODEL_DIR/checkpoints' }
     ),
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              envMap+: {
-                XLA_USE_BF16: '1',
-              },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            envMap+: {
+              XLA_USE_BF16: '1',
             },
           },
         },
@@ -184,14 +182,12 @@ local utils = import 'templates/utils.libsonnet';
         test $bleu -gt 27 -a $wps -gt 10000
       ||| % command_common
     ),
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              envMap+: {
-                XLA_USE_BF16: '1',
-              },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            envMap+: {
+              XLA_USE_BF16: '1',
             },
           },
         },

--- a/tests/pytorch/r1.8.1/hf-glue.libsonnet
+++ b/tests/pytorch/r1.8.1/hf-glue.libsonnet
@@ -134,16 +134,14 @@ local utils = import 'templates/utils.libsonnet';
   },
   local hf_glue = common.PyTorchTest {
     modelName: 'hf-glue',
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '12.0',
-                  memory: '80Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '12.0',
+                memory: '80Gi',
               },
             },
           },

--- a/tests/pytorch/r1.8.1/roberta-pre.libsonnet
+++ b/tests/pytorch/r1.8.1/roberta-pre.libsonnet
@@ -64,17 +64,15 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '9.0',
-                  memory: '30Gi',
-                  'ephemeral-storage': '10Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '9.0',
+                memory: '30Gi',
+                'ephemeral-storage': '10Gi',
               },
             },
           },

--- a/tests/pytorch/r1.8/dlrm.libsonnet
+++ b/tests/pytorch/r1.8/dlrm.libsonnet
@@ -43,16 +43,14 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '9.0',
-                  memory: '30Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '9.0',
+                memory: '30Gi',
               },
             },
           },
@@ -66,16 +64,14 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '40.0',
-                  memory: '500Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '40.0',
+                memory: '500Gi',
               },
             },
           },

--- a/tests/pytorch/r1.8/fs-transformer.libsonnet
+++ b/tests/pytorch/r1.8/fs-transformer.libsonnet
@@ -98,14 +98,12 @@ local utils = import 'templates/utils.libsonnet';
         gsutil rm -r %(savedir)s
       ||| % { common: chpt_command_common, savedir: '$MODEL_DIR/checkpoints' }
     ),
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              envMap+: {
-                XLA_USE_BF16: '1',
-              },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            envMap+: {
+              XLA_USE_BF16: '1',
             },
           },
         },
@@ -184,14 +182,12 @@ local utils = import 'templates/utils.libsonnet';
         test $bleu -gt 27 -a $wps -gt 10000
       ||| % command_common
     ),
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              envMap+: {
-                XLA_USE_BF16: '1',
-              },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            envMap+: {
+              XLA_USE_BF16: '1',
             },
           },
         },

--- a/tests/pytorch/r1.8/hf-glue.libsonnet
+++ b/tests/pytorch/r1.8/hf-glue.libsonnet
@@ -134,16 +134,14 @@ local utils = import 'templates/utils.libsonnet';
   },
   local hf_glue = common.PyTorchTest {
     modelName: 'hf-glue',
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '12.0',
-                  memory: '80Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '12.0',
+                memory: '80Gi',
               },
             },
           },

--- a/tests/pytorch/r1.8/roberta-pre.libsonnet
+++ b/tests/pytorch/r1.8/roberta-pre.libsonnet
@@ -64,17 +64,15 @@ local utils = import 'templates/utils.libsonnet';
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              resources+: {
-                requests: {
-                  cpu: '9.0',
-                  memory: '30Gi',
-                  'ephemeral-storage': '10Gi',
-                },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '9.0',
+                memory: '30Gi',
+                'ephemeral-storage': '10Gi',
               },
             },
           },

--- a/tests/runnable.jsonnet
+++ b/tests/runnable.jsonnet
@@ -1,0 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local all_tests = import 'all_tests.jsonnet';
+
+function(test) std.manifestYamlDoc(all_tests[test].runnablePod)

--- a/tests/tensorflow/common.libsonnet
+++ b/tests/tensorflow/common.libsonnet
@@ -28,14 +28,12 @@ local volumes = import 'templates/volumes.libsonnet';
         mountPath: '/dev/shm',
       },
     },
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              envMap+: {
-                TF_ENABLE_LEGACY_FILESYSTEM: '1',
-              },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            envMap+: {
+              TF_ENABLE_LEGACY_FILESYSTEM: '1',
             },
           },
         },

--- a/tests/tensorflow/r1.15/shapemask.libsonnet
+++ b/tests/tensorflow/r1.15/shapemask.libsonnet
@@ -55,18 +55,16 @@ local tpus = import 'templates/tpus.libsonnet';
       '--model_dir=$(MODEL_DIR)',
     ],
 
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+: {
-            train+: {
-              env+: [
-                {
-                  name: 'PYTHONPATH',
-                  value: '/shapemask/models/',
-                },
-              ],
-            },
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            env+: [
+              {
+                name: 'PYTHONPATH',
+                value: '/shapemask/models/',
+              },
+            ],
           },
         },
       },

--- a/tests/tensorflow/r1.15/transformer.libsonnet
+++ b/tests/tensorflow/r1.15/transformer.libsonnet
@@ -32,19 +32,17 @@ local utils = import 'templates/utils.libsonnet';
       '--output_dir=$(MODEL_DIR)',
     ],
 
-    jobSpec+:: {
-      template+: {
-        spec+: {
-          containerMap+:: {
-            train+: {
-              args: utils.scriptCommand(
-                // HACK: Trim TPU name from `zone/name` to `name`.
-                |||
-                  unset KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS
-                  %s --cloud_tpu_name="${TPU_NAME##*/}"
-                ||| % std.join(' ', config.command)
-              ),
-            },
+    podTemplate+:: {
+      spec+: {
+        containerMap+:: {
+          train+: {
+            args: utils.scriptCommand(
+              // HACK: Trim TPU name from `zone/name` to `name`.
+              |||
+                unset KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS
+                %s --cloud_tpu_name="${TPU_NAME##*/}"
+              ||| % std.join(' ', config.command)
+            ),
           },
         },
       },


### PR DESCRIPTION
- Move the logic in jobSpec to `podTemplate` and `jobTemplate`. "Templates" include metadata, which is where the new metric information is stored.
- Add `metricConfig` field to BaseTest. Mark old metric fields deprecated.

This refactor is a no-op for generated files.