### PR TITLE
Pull in pytorch data configMap to pytorch tests. Use the new env var …

### DIFF
--- a/tests/pytorch/common.libsonnet
+++ b/tests/pytorch/common.libsonnet
@@ -17,6 +17,7 @@ local volumes = import 'templates/volumes.libsonnet';
 
 {
   local PyTorchBaseTest = common.CloudAcceleratorTest {
+    configMaps+: ['pytorch-nfs-ip'],
     regressionTestConfig+: {
       metric_subset_to_alert: [
         'ExecuteTime__Percentile_99_sec_final',

--- a/tests/pytorch/experimental.libsonnet
+++ b/tests/pytorch/experimental.libsonnet
@@ -41,7 +41,7 @@ local experimental = import '../experimental.libsonnet';
                 ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \
                   'sudo apt-get -y update && sudo apt-get -y install nfs-common git google-perftools'
                 ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \
-                  'sudo mkdir /datasets && sudo mount 10.182.107.26:/pytorch_datasets /datasets'
+                  'sudo mkdir /datasets && sudo mount $(PYTORCH_DATA_LOCATION) /datasets'
                 ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) << 'TEST_SCRIPT_EOF'
                   export XRT_TPU_CONFIG='localservice;0;localhost:51011'
                   export LD_PRELOAD='/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4'


### PR DESCRIPTION
…to mount NFS in TPUVM tests.

Manual run: [logs](https://pantheon.corp.google.com/logs/viewer?interval=NO_LIMIT&project=xl-ml-test&minLogLevel=0&expandAll=false&timestamp=2021-06-02T21:23:59.068000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22xl-ml-test%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22xl-ml-test-us-central1%22%0Aresource.labels.namespace_name%3D%22automated%22%0Aresource.labels.pod_name%3D%22pt-r1.8.1-resnet50-mp-conv-v3-8-1vm-manual-9dbmf-jsvxw%22%0Aresource.labels.container_name%3D%22train%22&scrollTimestamp=2021-06-02T20:56:29.909719434Z)

in the manual run - NFS IP looks correct and training no longer hangs

