### PR TITLE
Add TPUVM tests for v3-8 and v2-8 accelerators for PyTorch XLA 1.9

### DIFF
--- a/tests/pytorch/r1.9/common.libsonnet
+++ b/tests/pytorch/r1.9/common.libsonnet
@@ -52,4 +52,23 @@ local volumes = import 'templates/volumes.libsonnet';
     name: 'pytorch-datasets-claim',
     mountPath: '/datasets',
   },
+  tpu_vm_1_9_install: |||
+    sudo bash /var/scripts/docker-login.sh
+    sudo docker rm libtpu || true
+    sudo docker create --name libtpu gcr.io/cloud-tpu-v2-images/libtpu:pytorch-1.9 "/bin/bash"
+    sudo docker cp libtpu:libtpu.so /lib
+    sudo pip3 uninstall --yes torch torch_xla torchvision numpy
+    sudo pip3 install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch-1.9-cp38-cp38-linux_x86_64.whl https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-1.9-cp38-cp38-linux_x86_64.whl https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torchvision-1.9-cp38-cp38-linux_x86_64.whl numpy
+    sudo pip3 install mkl mkl-include numpy
+    sudo ln -s /usr/local/lib/libmkl_intel_lp64.so.1 /usr/local/lib/libmkl_intel_lp64.so
+    sudo ln -s /usr/local/lib/libmkl_intel_thread.so.1 /usr/local/lib/libmkl_intel_thread.so
+    sudo ln -s /usr/local/lib/libmkl_core.so.1 /usr/local/lib/libmkl_core.so
+    sudo apt-get -y update
+    sudo apt-get install -y libomp5
+    git clone https://github.com/pytorch/pytorch.git -b release/1.9
+    cd pytorch
+    git clone https://github.com/pytorch/xla.git -b r1.9
+    export XRT_TPU_CONFIG='localservice;0;localhost:51011'
+    export LD_PRELOAD='/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4'
+  |||,
 }

--- a/tests/pytorch/r1.9/dlrm.libsonnet
+++ b/tests/pytorch/r1.9/dlrm.libsonnet
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local common = import 'common.libsonnet';
 local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';

--- a/tests/pytorch/r1.9/fs-transformer.libsonnet
+++ b/tests/pytorch/r1.9/fs-transformer.libsonnet
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local common = import 'common.libsonnet';
 local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';

--- a/tests/pytorch/r1.9/mnist.libsonnet
+++ b/tests/pytorch/r1.9/mnist.libsonnet
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local common = import 'common.libsonnet';
 local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';

--- a/tests/pytorch/r1.9/resnet50-mp.libsonnet
+++ b/tests/pytorch/r1.9/resnet50-mp.libsonnet
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local common = import 'common.libsonnet';
 local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';

--- a/tests/pytorch/r1.9/roberta-pre.libsonnet
+++ b/tests/pytorch/r1.9/roberta-pre.libsonnet
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local common = import 'common.libsonnet';
 local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';

--- a/tests/pytorch/r1.9/roberta-pre.libsonnet
+++ b/tests/pytorch/r1.9/roberta-pre.libsonnet
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 local common = import 'common.libsonnet';
+local experimental = import '../experimental.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
@@ -93,6 +94,50 @@ local utils = import 'templates/utils.libsonnet';
       wpsTarget: 17000,
     },
   },
+  local roberta_tpu_vm = common.PyTorchTest {
+    frameworkPrefix: 'pt-r1.9',
+    modelName: 'roberta-convergence',
+    schedule: '30 18 * * *',
+    command: utils.scriptCommand(
+      |||
+        git clone --recursive https://github.com/pytorch-tpu/examples.git -b r1.9
+        pip3 install --editable examples/deps/fairseq
+        python3 \
+          examples/deps/fairseq/train.py \
+          /datasets/wikitext-103 \
+          --task=masked_lm --criterion=masked_lm \
+          --arch=roberta_base --sample-break-mode=complete \
+          --tokens-per-sample=512 \
+          --optimizer=adam \
+          --adam-betas='(0.9,0.98)' \
+          --adam-eps=1e-6 \
+          --clip-norm=0.0 \
+          --lr-scheduler=polynomial_decay \
+          --lr=0.0005 \
+          --warmup-updates=10000 \
+          --dropout=0.1 \
+          --attention-dropout=0.1 \
+          --weight-decay=0.01 \
+          --update-freq=16 \
+          --log-format=simple \
+          --train-subset=train \
+          --valid-subset=valid \
+          --num_cores=8 \
+          --metrics_debug \
+          --save-dir=checkpoints \
+          --log_steps=30 \
+          --skip-invalid-size-inputs-valid-test \
+          --suppress_loss_report \
+          --input_shapes 16x512 18x480 21x384 \
+          --max-epoch=5 \
+          2>&1 | tee training_logs.txt
+        wps=$(cat training_logs.txt | grep '| wps ' | tail -1 | grep -o -E ' wps [0-9]+' | sed 's/[^0-9]*//g')
+        echo 'final words per second (wps) is' $wps
+        test $wps -gt 19000
+      |||
+    ),
+  },
+
   local v3_8 = {
     accelerator: tpus.v3_8,
   },
@@ -103,5 +148,6 @@ local utils = import 'templates/utils.libsonnet';
     common.PyTorchGkePodTest + roberta + v3_32 + functional + timeouts.Hours(1),
     common.PyTorchTest + roberta + v3_8 + functional + timeouts.Hours(1),
     common.PyTorchTest + roberta + v3_8 + convergence + timeouts.Hours(2),
+    roberta_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + experimental.PyTorchTpuVmMixin,
   ],
 }


### PR DESCRIPTION
Tried out the mnist v2-8 TPUVM test manually and it succeeded: [logs](https://pantheon.corp.google.com/logs/viewer?interval=PT1H&project=xl-ml-test&rif_reserved&minLogLevel=0&expandAll=false&timestamp=2021-06-03T22:38:37.176000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22xl-ml-test%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22xl-ml-test-us-central1%22%0Aresource.labels.namespace_name%3D%22automated%22%0Aresource.labels.pod_name%3D%22pt-r1.9-mnist-conv-v2-8-1vm-manual-c9gpc-4s9fv%22%0Aresource.labels.container_name%3D%22train%22&scrollTimestamp=2021-06-03T22:07:57.283604324Z&dateRangeUnbound=forwardInTime&dateRangeStart=2021-06-03T21:38:37.175Z&dateRangeEnd=2021-06-03T22:38:37.175Z)