### PR TITLE
Fix date in dashboard modal

### DIFF
--- a/dashboard/javascript_utils.py
+++ b/dashboard/javascript_utils.py
@@ -68,7 +68,7 @@ BASE_MODAL_STRING = """
 
 PASS_FAIL_GRID_MODAL_STRING = """
     var test_name = source.data['test_name'][cb_data.source.selected.indices];
-    var run_date = source.data['run_date'][cb_data.source.selected.indices];
+    var run_date = new Date(source.data['run_date'][cb_data.source.selected.indices]).toJSON().split('T')[0];
     var job_status = source.data['job_status'][cb_data.source.selected.indices];
     var failed_metrics = source.data['failed_metrics'][cb_data.source.selected.indices];
     var failed_metrics_html = '';


### PR DESCRIPTION
The modal is currently showing the epoch timestamp instead of the date.

Tested:

<img width="1084" alt="Screen Shot 2021-06-09 at 10 12 29 AM" src="https://user-images.githubusercontent.com/15197278/121404136-80a6b200-c910-11eb-94ba-4bea2f6001a1.png">
