### PR TITLE
Add r1.9 python TPUVM op tests. Still using manual install becaause T…

### DIFF
--- a/tests/pytorch/r1.9/python-ops.libsonnet
+++ b/tests/pytorch/r1.9/python-ops.libsonnet
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local common = import 'common.libsonnet';
 local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';


### PR DESCRIPTION
…PUVMs still come with 1.8.1

Pushed workloads to k8s and confirmed they start up successfully and begin testing. If any tests fail we'll modify the underlying test, not this yaml 