### PR TITLE
Remove TPUVM nightly wheel python ops test and add r1.8.1 python ops …

### DIFF
--- a/tests/pytorch/nightly/python-ops.libsonnet
+++ b/tests/pytorch/nightly/python-ops.libsonnet
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
@@ -33,25 +32,9 @@ local utils = import 'templates/utils.libsonnet';
   local v3_8 = {
     accelerator: tpus.v3_8,
   },
-  local py_ops_tpu_vm = common.PyTorchTest {
-    modelName: 'python-ops',
-    schedule: '0 1 * * *',
-    command: utils.scriptCommand(
-      |||
-        %(command_common)s
-        sudo pip3 install hypothesis
-        cd xla/test
-        export TPUVM_MODE=1
-        ./run_tests.sh
-      ||| % common.tpu_vm_nightly_install
-    ),
-  },
-
 
   configs: [
     operations + v2_8 + common.Functional + timeouts.Hours(4),
     operations + v3_8 + common.Functional + timeouts.Hours(4),
-    py_ops_tpu_vm + v3_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
-    py_ops_tpu_vm + v2_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
   ],
 }

--- a/tests/pytorch/r1.8.1/python-ops.libsonnet
+++ b/tests/pytorch/r1.8.1/python-ops.libsonnet
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local common = import 'common.libsonnet';
 local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';

--- a/tests/pytorch/r1.8.1/python-ops.libsonnet
+++ b/tests/pytorch/r1.8.1/python-ops.libsonnet
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 local common = import 'common.libsonnet';
+local experimental = import '../experimental.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
+local utils = import 'templates/utils.libsonnet';
 
 {
   local operations = common.PyTorchTest {
@@ -31,9 +33,25 @@ local tpus = import 'templates/tpus.libsonnet';
   local v3_8 = {
     accelerator: tpus.v3_8,
   },
-
+  local py_ops_tpu_vm = common.PyTorchTest {
+    modelName: 'python-ops',
+    schedule: '0 1 * * *',
+    command: utils.scriptCommand(
+      |||
+        sudo pip3 install hypothesis
+        git clone https://github.com/pytorch/pytorch.git -b release/1.8
+        cd pytorch
+        git clone https://github.com/pytorch/xla.git -b r1.8.1
+        cd xla/test
+        export TPUVM_MODE=1
+        ./run_tests.sh
+      |||
+    ),
+  },
   configs: [
     operations + v2_8 + common.Functional + timeouts.Hours(2),
     operations + v3_8 + common.Functional + timeouts.Hours(2),
+    py_ops_tpu_vm + v2_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
+    py_ops_tpu_vm + v3_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
   ],
 }


### PR DESCRIPTION
…test.

The 1.8.1 python ops tests have been running for a while in k8s but I forgot to submit the change