### PR TITLE
Longer cloudbuild timeout for pytorch.

### DIFF
--- a/images/pytorch/cloudbuild.yaml
+++ b/images/pytorch/cloudbuild.yaml
@@ -23,4 +23,4 @@ substitutions:
   _PT_XLA_VERSION: 'nightly_3.6'
 options:
     substitution_option: 'ALLOW_LOOSE'
-timeout: 1200s
+timeout: 1800s


### PR DESCRIPTION
previous timeout was 20 min but some of the new cuda triggers take ~22 min probably due to larger image size

Tested by running those triggers pointing to this branch