### PR TITLE
Some ResNet RS changes

### DIFF
--- a/tests/tensorflow/nightly/classifier-resnetrs.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnetrs.libsonnet
@@ -150,7 +150,7 @@ local tpus = import 'templates/tpus.libsonnet';
     resnetrs + v3_8 + functional,
     resnetrs + v2_8 + convergence + timeouts.Hours(24),
     resnetrs + v3_8 + convergence + timeouts.Hours(24),
-    resnetrs + v2_32 + functional + mixins.Unsuspended,
+    resnetrs + v2_32 + functional,
     resnetrs + v3_32 + functional,
     resnetrs + v2_32 + convergence + tpus.reserved + { schedule: '7 11 * * 0,2,4' } + timeouts.Hours(15),
     resnetrs + v3_32 + convergence + timeouts.Hours(15),

--- a/tests/tensorflow/nightly/classifier-resnetrs.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnetrs.libsonnet
@@ -24,6 +24,7 @@ local tpus = import 'templates/tpus.libsonnet';
     paramsOverride:: {
       trainer: {
         train_steps: error 'Must set `trainer.train_steps`',
+        validation_interval: error 'Must set `trainer.validation_interval`',
       },
       task: {
         train_data: {
@@ -48,6 +49,7 @@ local tpus = import 'templates/tpus.libsonnet';
     paramsOverride+: {
       trainer+: {
         train_steps: 320,
+        validation_interval: 320,
       },
     },
   },
@@ -55,6 +57,10 @@ local tpus = import 'templates/tpus.libsonnet';
     paramsOverride+: {
       trainer+: {
         train_steps: 109200,
+        validation_interval: 3120,
+      },
+    },
+    regressionTestConfig+: {
       },
     },
     regressionTestConfig+: {
@@ -140,11 +146,11 @@ local tpus = import 'templates/tpus.libsonnet';
     resnetrs + v100x4 + convergence + mixins.Experimental + mixins.Suspended,
     resnetrs + v100x8 + functional + mixins.Unsuspended + mixins.Suspended,
     resnetrs + v100x8 + convergence + timeouts.Hours(14) + mixins.Suspended,
-    resnetrs + v2_8 + functional,
+    resnetrs + v2_8 + functional + mixins.Unsuspended,
     resnetrs + v3_8 + functional,
     resnetrs + v2_8 + convergence + timeouts.Hours(24),
     resnetrs + v3_8 + convergence + timeouts.Hours(24),
-    resnetrs + v2_32 + functional,
+    resnetrs + v2_32 + functional + mixins.Unsuspended,
     resnetrs + v3_32 + functional,
     resnetrs + v2_32 + convergence + tpus.reserved + { schedule: '7 11 * * 0,2,4' } + timeouts.Hours(15),
     resnetrs + v3_32 + convergence + timeouts.Hours(15),

--- a/tests/tensorflow/nightly/classifier-resnetrs.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnetrs.libsonnet
@@ -61,9 +61,6 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
     regressionTestConfig+: {
-      },
-    },
-    regressionTestConfig+: {
       metric_success_conditions+: {
         'validation/accuracy_final': {
           success_threshold: {


### PR DESCRIPTION
- Enable a v2-8 functional test so we can at least get a signal of TF-Vision success
- Increase `validation_interval` to help deal with how long convergence takes to run. Increases it from validation for every epoch to every 10 epochs.