### PR TITLE
Add cuda 10.1, 10.2, and 11.2 tests for pytorch.

### DIFF
--- a/tests/pytorch/nightly/mnist.libsonnet
+++ b/tests/pytorch/nightly/mnist.libsonnet
@@ -44,12 +44,29 @@ local utils = import 'templates/utils.libsonnet';
       --datadir=/datasets/mnist-data
   |||,
 
-  local mnist_gpu = common.PyTorchTest {
-    imageTag: 'nightly_3.6_cuda',
-    modelName: 'mnist',
+  local mnist_gpu_py37_cuda_101 = common.PyTorchTest {
+    imageTag: 'nightly_3.7_cuda_10.1',
+    modelName: 'mnist-cuda-10-1',
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
+    schedule: '0 19 * * *',
+  },
+  local mnist_gpu_py37_cuda_102 = common.PyTorchTest {
+    imageTag: 'nightly_3.7_cuda_10.2',
+    modelName: 'mnist-cuda-10-2',
+    volumeMap+: {
+      datasets: common.datasetsVolume,
+    },
+    schedule: '0 21 * * *',
+  },
+  local mnist_gpu_py37_cuda_112 = common.PyTorchTest {
+    imageTag: 'nightly_3.7_cuda_11.2',
+    modelName: 'mnist-cuda-11-2',
+    volumeMap+: {
+      datasets: common.datasetsVolume,
+    },
+    schedule: '0 23 * * *',
   },
 
   local convergence = common.Convergence {
@@ -82,19 +99,21 @@ local utils = import 'templates/utils.libsonnet';
     command: utils.scriptCommand(
       gpu_command_base % 1
     ),
-    schedule: '0 19 * * *',
   },
   local v100x4 = v100 {
     accelerator: gpus.teslaV100 { count: 4 },
     command: utils.scriptCommand(
       gpu_command_base % 4
     ),
-    schedule: '2 19 * * *',
   },
   configs: [
     mnist + convergence + v2_8 + timeouts.Hours(1),
     mnist + convergence + v3_8 + timeouts.Hours(1),
-    mnist_gpu + convergence + v100 + timeouts.Hours(1),
-    mnist_gpu + convergence + v100x4 + timeouts.Hours(1),
+    mnist_gpu_py37_cuda_101 + convergence + v100 + timeouts.Hours(1),
+    mnist_gpu_py37_cuda_101 + convergence + v100x4 + timeouts.Hours(1),
+    mnist_gpu_py37_cuda_102 + convergence + v100 + timeouts.Hours(1),
+    mnist_gpu_py37_cuda_102 + convergence + v100x4 + timeouts.Hours(1),
+    mnist_gpu_py37_cuda_112 + convergence + v100 + timeouts.Hours(1),
+    mnist_gpu_py37_cuda_112 + convergence + v100x4 + timeouts.Hours(1),
   ],
 }

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -27,20 +27,40 @@ local utils = import 'templates/utils.libsonnet';
     --model=resnet50 \
     --batch_size=128 \
     --log_steps=100 \
-    --num_workers=4 \
+    --num_workers=2 \
     --num_epochs=2 \
     --datadir=/datasets/imagenet-mini \
   |||,
-  local resnet50_gpu = common.PyTorchTest {
-    imageTag: 'nightly_3.6_cuda',
-    modelName: 'resnet50-mp',
+  local resnet50_gpu_py37_cuda_101 = common.PyTorchTest {
+    imageTag: 'nightly_3.7_cuda_10.1',
+    modelName: 'resnet50-mp-cuda-10-1',
     volumeMap+: {
       datasets: common.datasetsVolume,
     },
-    cpu: '13.0',
+    cpu: '7.0',
     memory: '40Gi',
+    schedule: '0 20 * * *',
   },
-
+  local resnet50_gpu_py37_cuda_102 = common.PyTorchTest {
+    imageTag: 'nightly_3.7_cuda_10.2',
+    modelName: 'resnet50-mp-cuda-10-2',
+    volumeMap+: {
+      datasets: common.datasetsVolume,
+    },
+    cpu: '7.0',
+    memory: '40Gi',
+    schedule: '0 18 * * *',
+  },
+  local resnet50_gpu_py37_cuda_112 = common.PyTorchTest {
+    imageTag: 'nightly_3.7_cuda_11.2',
+    modelName: 'resnet50-mp-cuda-11-2',
+    volumeMap+: {
+      datasets: common.datasetsVolume,
+    },
+    cpu: '7.0',
+    memory: '40Gi',
+    schedule: '0 16 * * *',
+  },
   local resnet50_MP = common.PyTorchTest {
     modelName: 'resnet50-mp',
     command: [
@@ -104,19 +124,21 @@ local utils = import 'templates/utils.libsonnet';
     command: utils.scriptCommand(
       gpu_command_base % 1
     ),
-    schedule: '0 20 * * *',
   },
   local v100x4 = v100 {
     accelerator: gpus.teslaV100 { count: 4 },
     command: utils.scriptCommand(
       gpu_command_base % 4
     ),
-    schedule: '2 20 * * *',
   },
   configs: [
     resnet50_MP + v3_8 + convergence + timeouts.Hours(26) + mixins.PreemptibleTpu,
     resnet50_MP + v3_8 + functional + timeouts.Hours(2),
-    resnet50_gpu + common.Functional + v100 + timeouts.Hours(2),
-    resnet50_gpu + common.Functional + v100x4 + timeouts.Hours(1),
+    resnet50_gpu_py37_cuda_101 + common.Functional + v100 + timeouts.Hours(2),
+    resnet50_gpu_py37_cuda_101 + common.Functional + v100x4 + timeouts.Hours(1),
+    resnet50_gpu_py37_cuda_102 + common.Functional + v100 + timeouts.Hours(2),
+    resnet50_gpu_py37_cuda_102 + common.Functional + v100x4 + timeouts.Hours(1),
+    resnet50_gpu_py37_cuda_112 + common.Functional + v100 + timeouts.Hours(2),
+    resnet50_gpu_py37_cuda_112 + common.Functional + v100x4 + timeouts.Hours(1),
   ],
 }


### PR DESCRIPTION
sample runs:
* [resnet cuda 11.2](https://pantheon.corp.google.com/logs/viewer?project=xl-ml-test&minLogLevel=0&expandAll=false&timestamp=2021-06-22T00:30:59.697000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.cluster_name%3Dxl-ml-test-us-central1%0Aresource.labels.namespace_name%3Dautomated%0Aresource.labels.pod_name:pt-nightly-resnet50-mp-cuda-11-2-func-v100-x1-manual-d9f8x%0Aresource.labels.location:us-central1%0A&dateRangeEnd=2021-06-22T00:30:38.121Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2021-06-21T22:39:50.761747081Z)
* [resnet cuda 10.1](https://pantheon.corp.google.com/logs/viewer?project=xl-ml-test&minLogLevel=0&expandAll=false&timestamp=2021-06-22T00:30:57.887000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.cluster_name%3Dxl-ml-test-us-central1%0Aresource.labels.namespace_name%3Dautomated%0Aresource.labels.pod_name:pt-nightly-resnet50-mp-cuda-10-1-func-v100-x1-manual-tnclt%0Aresource.labels.location:us-central1%0A&dateRangeEnd=2021-06-22T00:30:46.144Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2021-06-21T22:35:44.570145760Z)
* [mnist cuda 10.1](https://pantheon.corp.google.com/logs/viewer?project=xl-ml-test&minLogLevel=0&expandAll=false&timestamp=2021-06-22T00:31:02.432000000Z&customFacets=&limitCustomFacetWidth=true&advancedFilter=resource.type%3Dk8s_container%0Aresource.labels.project_id%3Dxl-ml-test%0Aresource.labels.cluster_name%3Dxl-ml-test-us-central1%0Aresource.labels.namespace_name%3Dautomated%0Aresource.labels.pod_name:pt-nightly-mnist-cuda-10-1-conv-v100-x1-manual-cfzrk%0Aresource.labels.location:us-central1%0A&dateRangeEnd=2021-06-22T00:31:00.552Z&interval=PT1H&dateRangeUnbound=backwardInTime&scrollTimestamp=2021-06-21T21:28:17.781380977Z)