### PR TITLE
JAX test updates:

### DIFF
--- a/tests/jax/latest/common.libsonnet
+++ b/tests/jax/latest/common.libsonnet
@@ -32,7 +32,9 @@ local tpus = import 'templates/tpus.libsonnet';
       rm .bash_logout
 
       pip install --upgrade pip
-      %(installJaxlib)s
+      %(installLatestJax)s
+      %(maybeBuildJaxlib)s
+      %(printDiagnostics)s
 
       pip install --upgrade clu %(extraDeps)s
 

--- a/tests/jax/nightly/common.libsonnet
+++ b/tests/jax/nightly/common.libsonnet
@@ -27,26 +27,34 @@ local tpus = import 'templates/tpus.libsonnet';
       set -x
       set -u
       set -e
+
       # .bash_logout sometimes causes a spurious bad exit code, remove it.
       rm .bash_logout
+
       pip install --upgrade pip
       pip install --upgrade clu %(extraDeps)s
+
       echo "Checking out and installing JAX..."
       git clone https://github.com/google/jax.git
       cd jax
       echo "jax git hash: $(git rev-parse HEAD)"
-      pip install -e .
-      %(installJaxlib)s
+      %(installLocalJax)s
+      %(maybeBuildJaxlib)s
+      %(printDiagnostics)s
+
       sudo rm /usr/local/lib/python3.8/dist-packages/tensorflow/core/kernels/libtfkernel_sobol_op.so
+
       num_devices=`python3 -c "import jax; print(jax.device_count())"`
       if [ "$num_devices" = "1" ]; then
         echo "No TPU devices detected"
         exit 1
       fi
+
       cd ~/
       git clone https://github.com/google/flax
       cd flax
       pip install -e .
+
       cd examples/%(modelName)s
       export GCS_BUCKET=$(MODEL_DIR)
       export TFDS_DATA_DIR=$(TFDS_DIR)

--- a/tests/jax/pod-test.libsonnet
+++ b/tests/jax/pod-test.libsonnet
@@ -28,9 +28,9 @@ local mixins = import 'templates/mixins.libsonnet';
       git clone https://github.com/google/jax.git
       cd jax
       echo "jax git hash: $(git rev-parse HEAD)"
-      pip install -e .
-
-      %(installJaxlib)s
+      %(installLocalJax)s
+      %(maybeBuildJaxlib)s
+      %(printDiagnostics)s
 
       # Very basic smoke test
       python3 -c "import jax; assert jax.device_count() == 32, jax.device_count()"

--- a/tests/jax/unit-tests.libsonnet
+++ b/tests/jax/unit-tests.libsonnet
@@ -35,15 +35,18 @@ local mixins = import 'templates/mixins.libsonnet';
       git clone https://github.com/google/jax.git
       cd jax
       echo "jax git hash: $(git rev-parse HEAD)"
-      pip install -e .
-
-      %(installJaxlib)s
+      %(installLocalJax)s
+      %(maybeBuildJaxlib)s
+      %(printDiagnostics)s
 
       num_devices=`python3 -c "import jax; print(jax.device_count())"`
       if [ "$num_devices" = "1" ]; then
         echo "No TPU devices detected"
         exit 1
       fi
+
+      # b/192016388
+      pip install tensorflow
 
       export JAX_NUM_GENERATED_CASES=5
       export COLUMNS=160


### PR DESCRIPTION
* Use new `pip install jax[tpu]` install command
* Always print jaxlib and libtpu versions
* Refactor tests to reflect that `pip install jax[tpu]` installs jax, jaxlib, and libtpu