### PR TITLE
Replace invalid character in TPU VM label

### DIFF
--- a/tests/experimental.libsonnet
+++ b/tests/experimental.libsonnet
@@ -95,7 +95,7 @@ local volumes = import 'templates/volumes.libsonnet';
               softwareVersion: std.escapeStringBash(config.tpuSettings.softwareVersion),
               startupScript: std.escapeStringBash(config.tpuSettings.tpuVmStartupScript),
               sleepTime: config.tpuSettings.tpuVmCreateSleepSeconds,
-              testName: config.testName,
+              testName: std.strReplace(config.testName, '.', '-'),
             },
             command: utils.scriptCommand(|||
               project=$(curl -sS "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")


### PR DESCRIPTION
Fixes errors like this:

```
2021-06-29 22:30:23.943 PDT' --labels=test-name=pt-r1.9-resnet50-mp-func-v3-32-1vm --zone=europe-west4-a
Error
2021-06-29 22:30:24.843 PDTERROR: (gcloud.alpha.compute.tpus.tpu-vm.create) INVALID_ARGUMENT: resource labels are invalid: value "pt-r1.9-resnet50-mp-func-v3-32-1vm" contains invalid character '.' at index 5 for key "test-name"
```