### PR TITLE
[Keras API] Adding full name of save and load feature test.

### DIFF
--- a/tests/tensorflow/nightly/keras-api.libsonnet
+++ b/tests/tensorflow/nightly/keras-api.libsonnet
@@ -86,7 +86,7 @@ local utils = import 'templates/utils.libsonnet';
 
   local save_and_load = API {
     mode: 'save-and-load',
-    testFeature:: 'save_and_load',
+    testFeature:: 'save_and_load.feature',
     // Run at 2:30AM PST daily
     schedule: '30 10 * * *',
   },

--- a/tests/tensorflow/r2.4/keras-api.libsonnet
+++ b/tests/tensorflow/r2.4/keras-api.libsonnet
@@ -86,7 +86,7 @@ local utils = import 'templates/utils.libsonnet';
 
   local save_and_load = API {
     mode: 'save-and-load',
-    testFeature:: 'save_and_load',
+    testFeature:: 'save_and_load.feature',
     // Run at 2:30AM PST daily
     schedule: '30 10 * * *',
   },

--- a/tests/tensorflow/r2.5/keras-api.libsonnet
+++ b/tests/tensorflow/r2.5/keras-api.libsonnet
@@ -86,7 +86,7 @@ local utils = import 'templates/utils.libsonnet';
 
   local save_and_load = API {
     mode: 'save-and-load',
-    testFeature:: 'save_and_load',
+    testFeature:: 'save_and_load.feature',
     // Run at 2:30AM PST daily
     schedule: '30 10 * * *',
   },

--- a/tests/tensorflow/r2.6/keras-api.libsonnet
+++ b/tests/tensorflow/r2.6/keras-api.libsonnet
@@ -86,7 +86,7 @@ local utils = import 'templates/utils.libsonnet';
 
   local save_and_load = API {
     mode: 'save-and-load',
-    testFeature:: 'save_and_load',
+    testFeature:: 'save_and_load.feature',
     // Run at 2:30AM PST daily
     schedule: '30 10 * * *',
   },


### PR DESCRIPTION
[Keras API] Adding full name of save and load feature test as it used to run `save_and_load_io_device_local_drive` test which has the same prefix.