### PR TITLE
Adjust threshold for eval loss to match historic value.

### DIFF
--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -83,7 +83,7 @@ local utils = import 'templates/utils.libsonnet';
       metric_success_conditions+: {
         'eval/loss_final': {
           success_threshold: {
-            fixed_value: 1.5,
+            fixed_value: 2.8,
           },
           comparison: 'less',
         },


### PR DESCRIPTION
Loss has been stable around 2.8 for this test since q4 2020