### PR TITLE
Use the TF version that ships with the VM (2.6.0) on nightly jobs.

### DIFF
--- a/tests/jax/common.libsonnet
+++ b/tests/jax/common.libsonnet
@@ -37,6 +37,7 @@ local tpus = import 'templates/tpus.libsonnet';
       maybeBuildJaxlib: error 'Must define `maybeBuildJaxlib`',
       installLocalJax: error 'Must define `installLocalJax`',
       installLatestJax: error 'Must define `installLatestJax`',
+      maybeInstallTF: error 'Must define `maybeInstallTF`',
       printDiagnostics: |||
         python3 -c 'import jaxlib; print("jaxlib version:", jaxlib.__version__)'
         python3 -c 'import jax; print("libtpu version:",
@@ -161,6 +162,7 @@ local tpus = import 'templates/tpus.libsonnet';
       // Don't use [tpu] extra so we use system libtpu.so
       installLocalJax: 'pip install . jaxlib',
       installLatestJax: 'pip install jax jaxlib',
+      maybeInstallTF: '',
     },
   },
 
@@ -178,6 +180,8 @@ local tpus = import 'templates/tpus.libsonnet';
         pip install jax[tpu] \
           -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
       |||,
+      // b/192016388
+      maybeInstallTF: 'pip install tensorflow',
     },
   },
   Functional:: mixins.Functional {

--- a/tests/jax/unit-tests.libsonnet
+++ b/tests/jax/unit-tests.libsonnet
@@ -46,7 +46,7 @@ local mixins = import 'templates/mixins.libsonnet';
       fi
 
       # b/192016388
-      pip install tensorflow
+      %(maybeInstallTF)s
 
       export JAX_NUM_GENERATED_CASES=5
       export COLUMNS=160


### PR DESCRIPTION
Tests currently pip install TF 2.5.0 to avoid a bunch of segfaults and other errors when using JAX + TF. This seems to be resolved in the nightly image, but using TF 2.5.0 causes errors like:

```
/usr/local/lib/python3.8/dist-packages/tensorflow/core/kernels/libtfkernel_sobol_op.so: undefined symbol: _ZNK10tensorflow8OpKernel11TraceStringB5cxx11ERKNS_15OpKernelContextEb"
```