### PR TITLE
Add tests for public Colab documentation.

### DIFF
--- a/tests/pytorch/r1.9/colab.libsonnet
+++ b/tests/pytorch/r1.9/colab.libsonnet
@@ -30,7 +30,7 @@ local utils = import 'templates/utils.libsonnet';
 
         gsutil cp "${notebook_path}" "$(MODEL_DIR)/%(notebook)s"
       ||| % config.colabSettings
-    )
+    ),
   },
 
   local mnist = {

--- a/tests/pytorch/r1.9/colab.libsonnet
+++ b/tests/pytorch/r1.9/colab.libsonnet
@@ -1,0 +1,53 @@
+local common = import 'common.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+local utils = import 'templates/utils.libsonnet';
+
+{
+  local colab = common.PyTorchTest {
+    local config = self,
+
+    mode: 'colab',
+    schedule: common.Functional.schedule,
+    accelerator: tpus.v3_8,
+    cpu: 8,
+    memory: '35Gi',
+
+    colabSettings:: {
+      notebook: error 'Must set `colabSettings.notebook`',
+    },
+    command: utils.scriptCommand(
+      |||
+        cd /
+        git clone https://github.com/pytorch/xla.git
+
+        export COLAB_TPU_ADDR=${KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS#grpc://}
+        export TPU_NAME=${TPU_NAME#*/}
+
+        notebook_path='/xla/contrib/colab/%(notebook)s'
+        # HACK: Remove usage of google.colab.patches.cv2_imshow
+        sed -i '/cv2/d' $notebook_path
+        jupyter nbconvert --to notebook --inplace --execute "${notebook_path}"
+
+        gsutil cp "${notebook_path}" "$(MODEL_DIR)/%(notebook)s"
+      ||| % config.colabSettings
+    )
+  },
+
+  local mnist = {
+    modelName: 'mnist',
+    colabSettings+:: {
+      notebook: 'mnist-training.ipynb',
+    },
+  },
+  local resnet18 = {
+    modelName: 'resnet18',
+    colabSettings+:: {
+      notebook: 'resnet18-training.ipynb',
+    },
+  },
+
+  configs: [
+    colab + mnist,
+    colab + resnet18,
+  ],
+}

--- a/tests/pytorch/r1.9/targets.jsonnet
+++ b/tests/pytorch/r1.9/targets.jsonnet
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local cppOperations = import 'cpp-ops.libsonnet';
 local colab = import 'colab.libsonnet';
+local cppOperations = import 'cpp-ops.libsonnet';
 local dlrm = import 'dlrm.libsonnet';
 local fairseqTransformer = import 'fs-transformer.libsonnet';
 local hfglue = import 'hf-glue.libsonnet';

--- a/tests/pytorch/r1.9/targets.jsonnet
+++ b/tests/pytorch/r1.9/targets.jsonnet
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 local cppOperations = import 'cpp-ops.libsonnet';
+local colab = import 'colab.libsonnet';
 local dlrm = import 'dlrm.libsonnet';
 local fairseqTransformer = import 'fs-transformer.libsonnet';
 local hfglue = import 'hf-glue.libsonnet';
@@ -24,6 +25,7 @@ local fairseqRobertaPretrain = import 'roberta-pre.libsonnet';
 // Add new models here
 std.flattenArrays([
   cppOperations.configs,
+  colab.configs,
   dlrm.configs,
   fairseqTransformer.configs,
   hfglue.configs,

--- a/tests/tensorflow/r2.6/colab.libsonnet
+++ b/tests/tensorflow/r2.6/colab.libsonnet
@@ -30,7 +30,7 @@ local utils = import 'templates/utils.libsonnet';
 
         gsutil cp "${notebook_path}" "$(MODEL_DIR)/%(notebook)s"
       ||| % config.colabSettings
-    )
+    ),
   },
 
   local fashion_mnist = {

--- a/tests/tensorflow/r2.6/colab.libsonnet
+++ b/tests/tensorflow/r2.6/colab.libsonnet
@@ -1,0 +1,60 @@
+local common = import 'common.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+local utils = import 'templates/utils.libsonnet';
+
+{
+  local colab = common.ModelGardenTest {
+    local config = self,
+
+    mode: 'colab',
+    schedule: common.Functional.schedule,
+    accelerator: tpus.v3_8,
+
+    colabSettings:: {
+      notebook: error 'Must set `colabSettings.notebook`',
+    },
+    command: utils.scriptCommand(
+      |||
+        cd /
+        git clone https://github.com/tensorflow/tpu.git
+        pip install jupyter
+
+        apt-get install -y wget
+        mkdir /content
+
+        export COLAB_TPU_ADDR=${KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS#grpc://}
+        export TPU_NAME=${KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS}
+
+        notebook_path='/tpu/tools/colab/%(notebook)s'
+        jupyter nbconvert --to notebook --inplace --execute "${notebook_path}"
+
+        gsutil cp "${notebook_path}" "$(MODEL_DIR)/%(notebook)s"
+      ||| % config.colabSettings
+    )
+  },
+
+  local fashion_mnist = {
+    modelName: 'fashion-mnist',
+    colabSettings+:: {
+      notebook: 'fashion_mnist.ipynb',
+    },
+  },
+  local iris = {
+    modelName: 'iris',
+    colabSettings+:: {
+      notebook: 'classification_iris_data_with_keras.ipynb',
+    },
+  },
+  local shakespeare = {
+    modelName: 'shakespeare',
+    colabSettings+:: {
+      notebook: 'shakespeare_with_tpu_and_keras.ipynb',
+    },
+  },
+
+  configs: [
+    colab + fashion_mnist,
+    colab + iris,
+    colab + shakespeare,
+  ],
+}

--- a/tests/tensorflow/r2.6/targets.jsonnet
+++ b/tests/tensorflow/r2.6/targets.jsonnet
@@ -17,6 +17,7 @@ local bert_squad = import 'bert-squad.libsonnet';
 local classifier_efficientnet = import 'classifier-efficientnet.libsonnet';
 local classifier_resnet = import 'classifier-resnet.libsonnet';
 local classifier_resnetrs = import 'classifier-resnetrs.libsonnet';
+local colab = import 'colab.libsonnet';
 local dlrm = import 'dlrm.libsonnet';
 local inference = import 'inference.libsonnet';
 local keras_api = import 'keras-api.libsonnet';
@@ -38,6 +39,7 @@ std.flattenArrays([
   classifier_resnet.configs,
   classifier_resnetrs.configs,
   classifier_efficientnet.configs,
+  colab.configs,
   dlrm.configs,
   inference.configs,
   keras_api.configs,


### PR DESCRIPTION
Included notebooks from the public Cloud TPU docs that don't have Colab-specifc code.

We can add these to stable test suites going forward to ensure the documents stay up to date.