### PR TITLE
Use v2-alpha for the stable versions of PyTorch for TPUVM tests.

### DIFF
--- a/tests/pytorch/experimental.libsonnet
+++ b/tests/pytorch/experimental.libsonnet
@@ -61,7 +61,7 @@ local experimental = import '../experimental.libsonnet';
   PyTorchTpuVmPodTest:: experimental.BaseTpuVmMixin {
     local config = self,
     tpuSettings+: {
-      softwareVersion: 'v2-nightly',
+      softwareVersion: 'v2-alpha',
       tpuVmStartupScript: |||
         #! /bin/bash
         cd /usr/share
@@ -118,7 +118,7 @@ local experimental = import '../experimental.libsonnet';
   PyTorch1_9TpuVmPodTest:: experimental.BaseTpuVmMixin {
     local config = self,
     tpuSettings+: {
-      softwareVersion: 'v2-nightly',
+      softwareVersion: 'v2-alpha',
       tpuVmStartupScript: |||
         sudo bash /var/scripts/docker-login.sh
         sudo docker rm libtpu || true

--- a/tests/pytorch/r1.8.1/common.libsonnet
+++ b/tests/pytorch/r1.8.1/common.libsonnet
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 local common = import '../common.libsonnet';
+local experimental = import '../experimental.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local volumes = import 'templates/volumes.libsonnet';
 
@@ -51,6 +52,11 @@ local volumes = import 'templates/volumes.libsonnet';
   datasetsVolume: volumes.PersistentVolumeSpec {
     name: 'pytorch-datasets-claim',
     mountPath: '/datasets',
+  },
+  TpuVmMixin_1_8_1:: experimental.PyTorchTpuVmMixin {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha',
+    },
   },
   tpu_vm_1_8_1_install: |||
     sudo pip3 uninstall --yes torch torch_xla torchvision

--- a/tests/pytorch/r1.8.1/dlrm.libsonnet
+++ b/tests/pytorch/r1.8.1/dlrm.libsonnet
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
@@ -189,6 +188,6 @@ local utils = import 'templates/utils.libsonnet';
     dlrm + v3_8 + mp_fwd + timeouts.Hours(3),
     dlrm + v3_8 + mp_dp_fwd + timeouts.Hours(3),
     dlrm_convergence + v3_8 + criteo_kaggle + timeouts.Hours(6),
-    criteo_kaggle_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + experimental.PyTorchTpuVmMixin,
+    criteo_kaggle_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + common.TpuVmMixin_1_8_1,
   ],
 }

--- a/tests/pytorch/r1.8.1/fs-transformer.libsonnet
+++ b/tests/pytorch/r1.8.1/fs-transformer.libsonnet
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
@@ -246,6 +245,6 @@ local utils = import 'templates/utils.libsonnet';
     common.PyTorchTest + transformer + v3_8 + convergence + timeouts.Hours(25),
     common.PyTorchTest + transformer + v3_8 + checkpoint_local + timeouts.Hours(2),
     common.PyTorchTest + transformer + v3_8 + checkpoint_gcs + timeouts.Hours(2),
-    common.PyTorchTest + convergence_tpu_vm + v3_8 + timeouts.Hours(25) + experimental.PyTorchTpuVmMixin,
+    common.PyTorchTest + convergence_tpu_vm + v3_8 + timeouts.Hours(25) + common.TpuVmMixin_1_8_1,
   ],
 }

--- a/tests/pytorch/r1.8.1/mnist.libsonnet
+++ b/tests/pytorch/r1.8.1/mnist.libsonnet
@@ -46,7 +46,7 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local tpuVm = experimental.PyTorchTpuVmMixin {
+  local tpuVm = common.TpuVmMixin_1_8_1 {
     frameworkPrefix: 'pt-r1.8.1',
     command: utils.scriptCommand(
       |||

--- a/tests/pytorch/r1.8.1/python-ops.libsonnet
+++ b/tests/pytorch/r1.8.1/python-ops.libsonnet
@@ -51,7 +51,7 @@ local utils = import 'templates/utils.libsonnet';
   configs: [
     operations + v2_8 + common.Functional + timeouts.Hours(2),
     operations + v3_8 + common.Functional + timeouts.Hours(2),
-    py_ops_tpu_vm + v2_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
-    py_ops_tpu_vm + v3_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
+    py_ops_tpu_vm + v2_8 + common.Functional + timeouts.Hours(4) + common.TpuVmMixin_1_8_1,
+    py_ops_tpu_vm + v3_8 + common.Functional + timeouts.Hours(4) + common.TpuVmMixin_1_8_1,
   ],
 }

--- a/tests/pytorch/r1.8.1/resnet50-mp.libsonnet
+++ b/tests/pytorch/r1.8.1/resnet50-mp.libsonnet
@@ -60,9 +60,7 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local resnet50_tpu_vm = experimental.PyTorchTpuVmMixin {
-    // This test uses the default pytorch XLA version built into the TPUVM, which
-    // is 1.8.1 as of Apr 19.
+  local resnet50_tpu_vm = common.TpuVmMixin_1_8_1 {
     frameworkPrefix: 'pt-r1.8.1',
     modelName: 'resnet50-mp',
     paramsOverride: {

--- a/tests/pytorch/r1.8.1/roberta-pre.libsonnet
+++ b/tests/pytorch/r1.8.1/roberta-pre.libsonnet
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
@@ -147,6 +146,6 @@ local utils = import 'templates/utils.libsonnet';
     common.PyTorchGkePodTest + roberta + v3_32 + functional + timeouts.Hours(1),
     common.PyTorchTest + roberta + v3_8 + functional + timeouts.Hours(1),
     common.PyTorchTest + roberta + v3_8 + convergence + timeouts.Hours(2),
-    roberta_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + experimental.PyTorchTpuVmMixin,
+    roberta_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + common.TpuVmMixin_1_8_1,
   ],
 }

--- a/tests/pytorch/r1.9/common.libsonnet
+++ b/tests/pytorch/r1.9/common.libsonnet
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 local common = import '../common.libsonnet';
+local experimental = import '../experimental.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local volumes = import 'templates/volumes.libsonnet';
 
@@ -51,6 +52,11 @@ local volumes = import 'templates/volumes.libsonnet';
   datasetsVolume: volumes.PersistentVolumeSpec {
     name: 'pytorch-datasets-claim',
     mountPath: '/datasets',
+  },
+  TpuVmMixin_1_9:: experimental.PyTorchTpuVmMixin {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha',
+    },
   },
   tpu_vm_1_9_install: |||
     sudo bash /var/scripts/docker-login.sh

--- a/tests/pytorch/r1.9/dlrm.libsonnet
+++ b/tests/pytorch/r1.9/dlrm.libsonnet
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
@@ -185,6 +184,6 @@ local utils = import 'templates/utils.libsonnet';
     dlrm + v3_8 + mp_fwd + timeouts.Hours(3),
     dlrm + v3_8 + mp_dp_fwd + timeouts.Hours(3),
     dlrm_convergence + v3_8 + criteo_kaggle + timeouts.Hours(6),
-    criteo_kaggle_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + experimental.PyTorchTpuVmMixin,
+    criteo_kaggle_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + common.TpuVmMixin_1_9,
   ],
 }

--- a/tests/pytorch/r1.9/fs-transformer.libsonnet
+++ b/tests/pytorch/r1.9/fs-transformer.libsonnet
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
@@ -243,6 +242,6 @@ local utils = import 'templates/utils.libsonnet';
     common.PyTorchTest + transformer + v3_8 + convergence + timeouts.Hours(25),
     common.PyTorchTest + transformer + v3_8 + checkpoint_local + timeouts.Hours(2),
     common.PyTorchTest + transformer + v3_8 + checkpoint_gcs + timeouts.Hours(2),
-    common.PyTorchTest + convergence_tpu_vm + v3_8 + timeouts.Hours(25) + experimental.PyTorchTpuVmMixin,
+    common.PyTorchTest + convergence_tpu_vm + v3_8 + timeouts.Hours(25) + common.TpuVmMixin_1_9,
   ],
 }

--- a/tests/pytorch/r1.9/mnist.libsonnet
+++ b/tests/pytorch/r1.9/mnist.libsonnet
@@ -45,7 +45,7 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpuVm = experimental.PyTorchTpuVmMixin {
+  local tpuVm = common.TpuVmMixin_1_9 {
     frameworkPrefix: 'pt-r1.9',
     command: utils.scriptCommand(
       |||

--- a/tests/pytorch/r1.9/python-ops.libsonnet
+++ b/tests/pytorch/r1.9/python-ops.libsonnet
@@ -49,7 +49,7 @@ local utils = import 'templates/utils.libsonnet';
   configs: [
     operations + v2_8 + common.Functional + timeouts.Hours(2),
     operations + v3_8 + common.Functional + timeouts.Hours(2),
-    py_ops_tpu_vm + v3_8 + common.Functional + timeouts.Hours(2) + experimental.PyTorchTpuVmMixin,
-    py_ops_tpu_vm + v2_8 + common.Functional + timeouts.Hours(2) + experimental.PyTorchTpuVmMixin,
+    py_ops_tpu_vm + v3_8 + common.Functional + timeouts.Hours(2) + common.TpuVmMixin_1_9,
+    py_ops_tpu_vm + v2_8 + common.Functional + timeouts.Hours(2) + common.TpuVmMixin_1_9,
   ],
 }

--- a/tests/pytorch/r1.9/resnet50-mp.libsonnet
+++ b/tests/pytorch/r1.9/resnet50-mp.libsonnet
@@ -37,7 +37,7 @@ local utils = import 'templates/utils.libsonnet';
     cpu: '90.0',
     memory: '400Gi',
   },
-  local resnet50_tpu_vm = experimental.PyTorchTpuVmMixin {
+  local resnet50_tpu_vm = common.TpuVmMixin_1_9 {
     frameworkPrefix: 'pt-r1.9',
     modelName: 'resnet50-mp',
     paramsOverride: {

--- a/tests/pytorch/r1.9/roberta-pre.libsonnet
+++ b/tests/pytorch/r1.9/roberta-pre.libsonnet
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
@@ -149,6 +148,6 @@ local utils = import 'templates/utils.libsonnet';
     common.PyTorchGkePodTest + roberta + v3_32 + functional + timeouts.Hours(1),
     common.PyTorchTest + roberta + v3_8 + functional + timeouts.Hours(1),
     common.PyTorchTest + roberta + v3_8 + convergence + timeouts.Hours(2),
-    roberta_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + experimental.PyTorchTpuVmMixin,
+    roberta_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + common.TpuVmMixin_1_9,
   ],
 }


### PR DESCRIPTION
all our TPUVM tests were using v2-nightly, but it makes more sense for the stable versions to run on v2-alpha. Nightly wheels will keep using v2-nightly for TPUVM version