### PR TITLE
Match full test name in cleanup job

### DIFF
--- a/tests/cleanup.jsonnet
+++ b/tests/cleanup.jsonnet
@@ -59,7 +59,7 @@ local cleaners = {
                       %s
                       EOF
 
-                      delete_list=$(kubectl get cronjob --namespace=automated -l benchmarkId -o name | grep -v -f tests.txt)
+                      delete_list=$(kubectl get cronjob --namespace=automated -l benchmarkId -o name | grep -vx -f tests.txt)
                       if [[ "$delete_list" ]]; then
                         kubectl delete $delete_list;
                       fi


### PR DESCRIPTION
The cleanup job is currently matching test names that are prefixed by another test name. E.g., it is keeping `pt-nightly-python-ops-func-v2-8-1vm` (removed) because it is prefixed by  `pt-nightly-python-ops-func-v2-8` (still exists). Adding `grep`'s `-x` to match full strings.

Example: we want to print `pt-nightly-python-ops-func-v2-8-1vm` but not `pt-nightly-python-ops-func-v2-8`

```bash
$ cat > tests.txt
pt-nightly-python-ops-func-v2-8

# Without `-x` (current)
$ echo pt-nightly-python-ops-func-v2-8 | grep -v -f tests.txt
$ echo pt-nightly-python-ops-func-v2-8-1vm | grep -v -f tests.txt

# With `-x` (proposed change)
$ echo pt-nightly-python-ops-func-v2-8 | grep -vx -f tests.txt
$ echo pt-nightly-python-ops-func-v2-8-1vm | grep -vx -f tests.txt
pt-nightly-python-ops-func-v2-8-1vm
```