### PR TITLE
Prepend cronjob.batch/ to expected test names in cleanup script.

### DIFF
--- a/tests/cleanup.jsonnet
+++ b/tests/cleanup.jsonnet
@@ -24,7 +24,7 @@ local clusterTests = utils.splitByCluster(
 );
 local clusterTestNames = {
   [cluster]: [
-    test.testName
+    'cronjob.batch/' + test.testName
     for test in clusterTests[cluster]
     if test.schedule != null
   ]


### PR DESCRIPTION
#502 matches exact strings, but I forgot to prepend cronjob.batch/  to the expected test names, causing the cleanup script to delete _all_ of the tests in the cluster.