### PR TITLE
Move TPU priority classes to k8s/common

### DIFF
--- a/k8s/common/tpu-priority-classes.yaml
+++ b/k8s/common/tpu-priority-classes.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: tpu-device
+value: 1000000
+globalDefault: false
+description: "PriorityClass for pods using TPU devices."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: tpu-pod
+value: 1000000
+globalDefault: false
+description: "PriorityClass for pods using TPU pods."

--- a/k8s/europe-west4/tpu-vm-quota.yaml
+++ b/k8s/europe-west4/tpu-vm-quota.yaml
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: tpu-device
-value: 1000000
-globalDefault: false
-description: "PriorityClass for pods using TPU devices."
----
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -33,14 +25,6 @@ spec:
     - scopeName: PriorityClass
       operator: In
       values: [ tpu-device ]
----
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: tpu-pod
-value: 1000000
-globalDefault: false
-description: "PriorityClass for pods using TPU pods."
 ---
 apiVersion: v1
 kind: ResourceQuota

--- a/k8s/us-central1/tpu-vm-quota.yaml
+++ b/k8s/us-central1/tpu-vm-quota.yaml
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: tpu-device
-value: 1000000
-globalDefault: false
-description: "PriorityClass for pods using TPU devices."
----
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -33,14 +25,6 @@ spec:
     - scopeName: PriorityClass
       operator: In
       values: [ tpu-device ]
----
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: tpu-pod
-value: 1000000
-globalDefault: false
-description: "PriorityClass for pods using TPU pods."
 ---
 apiVersion: v1
 kind: ResourceQuota


### PR DESCRIPTION
It's useful to deploy this separately from the specific resource quotas.