### PR TITLE
Myriad jax test improvements based on libtpu-nightly pip package.

### DIFF
--- a/tests/jax/common.libsonnet
+++ b/tests/jax/common.libsonnet
@@ -32,13 +32,13 @@ local tpus = import 'templates/tpus.libsonnet';
     accelerator: tpus.v2_8,
 
     jaxlibVersion:: error 'Add jaxlib version mixin',
-    libtpuVersion:: error 'Include libtpu version mixin',
     scriptConfig:: {
       maybeBuildJaxlib: error 'Must define `maybeBuildJaxlib`',
       installLocalJax: error 'Must define `installLocalJax`',
       installLatestJax: error 'Must define `installLatestJax`',
       testEnvWorkarounds: error 'Must define `testEnvWorkarounds`',
       printDiagnostics: |||
+        python3 -c 'import jax; print("jax version:", jax.__version__)'
         python3 -c 'import jaxlib; print("jaxlib version:", jaxlib.__version__)'
         python3 -c 'import jax; print("libtpu version:",
           jax.lib.xla_bridge.get_backend().platform_version)'
@@ -127,6 +127,9 @@ local tpus = import 'templates/tpus.libsonnet';
   jaxlibHead:: {
     jaxlibVersion:: 'head',
     scriptConfig+: {
+      // Install jax without jaxlib or libtpu deps
+      installLocalJax: 'pip install .',
+      installLatestJax: 'pip install jax',
       maybeBuildJaxlib: |||
         echo "Building jaxlib from source at TF head"
         echo "Checking out TF..."
@@ -138,42 +141,18 @@ local tpus = import 'templates/tpus.libsonnet';
         echo "Building jaxlib..."
         cd ~/jax
         python3 build/build.py --enable_tpu --bazel_options="--override_repository=org_tensorflow=$HOME/tensorflow"
-        # jaxlib should already be installed, so we can use --no-deps
-        # to avoid reinstalling all dependencies
-        pip install dist/*.whl --no-deps --force-reinstall
+        pip install dist/*.whl
         python3 -c 'import jaxlib; print("jaxlib version:", jaxlib.__version__)'
+
+        echo "Installing latest libtpu-nightly..."
+        pip install libtpu-nightly \
+          -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
       |||,
     },
   },
 
   jaxlibLatest:: {
     jaxlibVersion:: 'latest',
-    scriptConfig+: {
-      maybeBuildJaxlib: '',
-    },
-  },
-
-  libtpuNightly:: {
-    libtpuVersion: 'nightly',
-    tpuSettings+: {
-      softwareVersion: 'v2-nightly',
-    },
-    scriptConfig+: {
-      // Don't use [tpu] extra so we use system libtpu.so
-      installLocalJax: 'pip install . jaxlib',
-      installLatestJax: 'pip install jax jaxlib',
-      testEnvWorkarounds: |||
-        # b/200277707: upgrade numpy to fix torch import
-        pip install --upgrade numpy
-      |||,
-    },
-  },
-
-  libtpuAlpha:: {
-    libtpuVersion: 'alpha',
-    tpuSettings+: {
-      softwareVersion: 'v2-alpha',
-    },
     scriptConfig+: {
       installLocalJax: |||
         pip install .[tpu] \
@@ -183,6 +162,27 @@ local tpus = import 'templates/tpus.libsonnet';
         pip install jax[tpu] \
           -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
       |||,
+      maybeBuildJaxlib: '',
+    },
+  },
+
+  nightlyImage:: {
+    tpuSettings+: {
+      softwareVersion: 'v2-nightly',
+    },
+    scriptConfig+: {
+      testEnvWorkarounds: |||
+        # b/200277707: upgrade numpy to fix torch import
+        pip install --upgrade numpy
+      |||,
+    },
+  },
+
+  alphaImage:: {
+    tpuSettings+: {
+      softwareVersion: 'v2-alpha',
+    },
+    scriptConfig+: {
       testEnvWorkarounds: |||
         # b/192016388: fix host_callback_to_tf_test.py
         pip install tensorflow

--- a/tests/jax/compilation-cache.libsonnet
+++ b/tests/jax/compilation-cache.libsonnet
@@ -62,7 +62,7 @@ local mixins = import 'templates/mixins.libsonnet';
       cat >directory_size.py <<'END_SCRIPT'
       import os
       num_of_files = sum(1 for f in os.listdir("/tmp/compilation_cache_integration_test"))
-      assert num_of_files == 1, f"The number of files in the cache should be 1 but is {num_of_files}" 
+      assert num_of_files == 1, f"The number of files in the cache should be 1 but is {num_of_files}"
       END_SCRIPT
 
       python3 integration.py
@@ -74,6 +74,6 @@ local mixins = import 'templates/mixins.libsonnet';
   },
 
   configs: [
-    compilationCacheTest + common.jaxlibLatest + common.libtpuAlpha,
+    compilationCacheTest + common.jaxlibLatest + common.alphaImage,
   ],
 }

--- a/tests/jax/latest/common.libsonnet
+++ b/tests/jax/latest/common.libsonnet
@@ -16,7 +16,7 @@ local common = import '../common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
-  runFlaxLatest:: common.JaxTest + common.jaxlibLatest + common.libtpuAlpha {
+  runFlaxLatest:: common.JaxTest + common.jaxlibLatest + common.alphaImage {
     local config = self,
 
     frameworkPrefix: 'flax-latest',
@@ -60,7 +60,7 @@ local tpus = import 'templates/tpus.libsonnet';
              extraFlags: config.extraFlags,
            }),
   },
-  PodFlaxLatest:: common.JaxPodTest + common.jaxlibLatest + common.libtpuAlpha {
+  PodFlaxLatest:: common.JaxPodTest + common.jaxlibLatest + common.alphaImage {
     local config = self,
     frameworkPrefix: 'flax-latest',
     extraDeps:: '',

--- a/tests/jax/nightly/common.libsonnet
+++ b/tests/jax/nightly/common.libsonnet
@@ -16,7 +16,7 @@ local common = import '../common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
-  runFlaxNightly:: common.JaxTest + common.jaxlibHead + common.libtpuNightly {
+  runFlaxNightly:: common.JaxTest + common.jaxlibHead + common.nightlyImage {
     local config = self,
 
     frameworkPrefix: 'flax-nightly',

--- a/tests/jax/pod-test.libsonnet
+++ b/tests/jax/pod-test.libsonnet
@@ -17,7 +17,7 @@ local mixins = import 'templates/mixins.libsonnet';
 
 {
   local podTest = common.JaxPodTest + mixins.Functional {
-    modelName: 'pod-%s-libtpu-%s' % [self.jaxlibVersion, self.libtpuVersion],
+    modelName: 'pod-%s-%s' % [self.jaxlibVersion, self.tpuSettings.softwareVersion],
 
     testScript:: |||
       set -x
@@ -48,8 +48,8 @@ local mixins = import 'templates/mixins.libsonnet';
   },
 
   configs: [
-    podTest + common.jaxlibLatest + common.libtpuNightly,
-    podTest + common.jaxlibHead + common.libtpuNightly,
-    podTest + common.jaxlibLatest + common.libtpuAlpha,
+    podTest + common.jaxlibHead + common.nightlyImage,
+    podTest + common.jaxlibHead + common.alphaImage,
+    podTest + common.jaxlibLatest + common.alphaImage,
   ],
 }

--- a/tests/jax/unit-tests.libsonnet
+++ b/tests/jax/unit-tests.libsonnet
@@ -17,7 +17,7 @@ local mixins = import 'templates/mixins.libsonnet';
 
 {
   local runUnitTests = common.JaxTest + mixins.Functional {
-    modelName: '%s-libtpu-%s' % [self.jaxlibVersion, self.libtpuVersion],
+    modelName: '%s-%s' % [self.jaxlibVersion, self.tpuSettings.softwareVersion],
 
     testScript:: |||
       set -x
@@ -27,14 +27,14 @@ local mixins = import 'templates/mixins.libsonnet';
       # .bash_logout sometimes causes a spurious bad exit code, remove it.
       rm .bash_logout
 
-      pip install --upgrade pip
-      pip install --upgrade numpy==1.18.5 scipy wheel future six cython pytest \
-          absl-py opt-einsum msgpack
+      # Via https://jax.readthedocs.io/en/latest/developer.html#building-jaxlib-from-source
+      pip install numpy six wheel
 
       echo "Checking out and installing JAX..."
       git clone https://github.com/google/jax.git
       cd jax
       echo "jax git hash: $(git rev-parse HEAD)"
+      pip install -r build/test-requirements.txt
       %(installLocalJax)s
       %(maybeBuildJaxlib)s
       %(printDiagnostics)s
@@ -57,9 +57,8 @@ local mixins = import 'templates/mixins.libsonnet';
   },
 
   configs: [
-    runUnitTests + common.jaxlibHead + common.libtpuNightly,
-    runUnitTests + common.jaxlibLatest + common.libtpuNightly,
-    runUnitTests + common.jaxlibHead + common.libtpuAlpha,
-    runUnitTests + common.jaxlibLatest + common.libtpuAlpha,
+    runUnitTests + common.jaxlibHead + common.nightlyImage,
+    runUnitTests + common.jaxlibHead + common.alphaImage,
+    runUnitTests + common.jaxlibLatest + common.alphaImage,
   ],
 }


### PR DESCRIPTION
We now use the libtpu-nightly package, instead of depending on the
system libtpu. This means the VM image version is decoupled with the
libtpu version, and we don't need to test mismatched jaxlib/libtpu
versions. In light of this, this change:

1. Links the libtpu version with the jaxlib version (latest or head),
   instead of with the TPU VM image.

2. Removes unnecessary test configs (e.g. latest jaxlib + nightly image).

3. Renames some tests to refer to image instead of libtpu version. The
   new test names are:

     jax-head-v2-alpha-func-v2-8-1vm
     jax-head-v2-nightly-func-v2-8-1vm
     jax-latest-v2-alpha-func-v2-8-1vm
     jax-pod-head-v2-alpha-func-v2-32-1vm
     jax-pod-head-v2-nightly-func-v2-32-1vm
     jax-pod-latest-v2-alpha-func-v2-32-1vm

4. (Unrelated) Cleans up some of the build + test dependency installs