### PR TITLE
Yisha/refac

### DIFF
--- a/tests/pytorch/r1.10/common.libsonnet
+++ b/tests/pytorch/r1.10/common.libsonnet
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 local common = import '../common.libsonnet';
+local experimental = import '../experimental.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local volumes = import 'templates/volumes.libsonnet';
-local experimental = import '../experimental.libsonnet';
 
 {
   PyTorchTest:: common.PyTorchTest {

--- a/tests/pytorch/r1.10/common.libsonnet
+++ b/tests/pytorch/r1.10/common.libsonnet
@@ -15,6 +15,7 @@
 local common = import '../common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local volumes = import 'templates/volumes.libsonnet';
+local experimental = import '../experimental.libsonnet';
 
 {
   PyTorchTest:: common.PyTorchTest {
@@ -23,6 +24,13 @@ local volumes = import 'templates/volumes.libsonnet';
       softwareVersion: 'pytorch-1.10',
     },
     imageTag: 'r1.10',
+  },
+  // pytorch does not use a specific image for pods
+  PyTorchTpuVm:: experimental.PyTorchTpuVmMixin {
+    local config = self,
+    tpuSettings+: {
+      softwareVersion: 'tpu-vm-pt-1.10',
+    },
   },
   PyTorchXlaDistPodTest:: common.PyTorchXlaDistPodTest {
     frameworkPrefix: 'pt-r1.10',
@@ -54,11 +62,6 @@ local volumes = import 'templates/volumes.libsonnet';
   },
   tpu_vm_1_10_install: |||
     sudo bash /var/scripts/docker-login.sh
-    sudo pip3 uninstall --yes torch torch_xla torchvision
-    sudo pip3 install https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-0.1.dev20211013-py3-none-any.whl
-    sudo pip3 install torch==1.10.0 
-    sudo pip3 install torchvision==0.11.1
-    sudo pip3 install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-1.10-cp38-cp38-linux_x86_64.whl
     git clone https://github.com/pytorch/pytorch.git -b release/1.10
     cd pytorch
     git clone https://github.com/pytorch/xla.git -b r1.10

--- a/tests/pytorch/r1.10/cpp-ops.libsonnet
+++ b/tests/pytorch/r1.10/cpp-ops.libsonnet
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
@@ -52,12 +51,23 @@ local utils = import 'templates/utils.libsonnet';
       ||| % common.tpu_vm_1_10_install
     ),
   },
+  local tpu_vm = common.PyTorchTpuVm {
+    modelName: 'cpp-ops',
+
+    command: utils.scriptCommand(
+      |||
+        %(command_common)s
+        cd xla/test/cpp
+        export TPUVM_MODE=1
+        ./run_tests.sh
+      ||| % common.tpu_vm_1_10_install
+    ),
+  },
 
   configs: [
     operations + v2_8 + common.Functional + timeouts.Hours(4),
     operations + v3_8 + common.Functional + timeouts.Hours(4),
-    // TPUVM not working yet: https://b.corp.google.com/issues/183450497#comment18
-    // cpp_ops_tpu_vm + v3_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
-    // cpp_ops_tpu_vm + v2_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
+    tpu_vm + v3_8 + common.Functional + timeouts.Hours(4),
+    tpu_vm + v2_8 + common.Functional + timeouts.Hours(4),
   ],
 }

--- a/tests/pytorch/r1.10/cpp-ops.libsonnet
+++ b/tests/pytorch/r1.10/cpp-ops.libsonnet
@@ -51,23 +51,11 @@ local utils = import 'templates/utils.libsonnet';
       ||| % common.tpu_vm_1_10_install
     ),
   },
-  local tpu_vm = common.PyTorchTpuVm {
-    modelName: 'cpp-ops',
-
-    command: utils.scriptCommand(
-      |||
-        %(command_common)s
-        cd xla/test/cpp
-        export TPUVM_MODE=1
-        ./run_tests.sh
-      ||| % common.tpu_vm_1_10_install
-    ),
-  },
-
+  
   configs: [
     operations + v2_8 + common.Functional + timeouts.Hours(4),
     operations + v3_8 + common.Functional + timeouts.Hours(4),
-    tpu_vm + v3_8 + common.Functional + timeouts.Hours(4),
-    tpu_vm + v2_8 + common.Functional + timeouts.Hours(4),
+    cpp_ops_tpu_vm + v3_8 + common.Functional + timeouts.Hours(4) + common.PyTorchTpuVm,
+    cpp_ops_tpu_vm + v2_8 + common.Functional + timeouts.Hours(4) + common.PyTorchTpuVm,
   ],
 }

--- a/tests/pytorch/r1.10/cpp-ops.libsonnet
+++ b/tests/pytorch/r1.10/cpp-ops.libsonnet
@@ -51,7 +51,7 @@ local utils = import 'templates/utils.libsonnet';
       ||| % common.tpu_vm_1_10_install
     ),
   },
-  
+
   configs: [
     operations + v2_8 + common.Functional + timeouts.Hours(4),
     operations + v3_8 + common.Functional + timeouts.Hours(4),

--- a/tests/pytorch/r1.10/fs-transformer.libsonnet
+++ b/tests/pytorch/r1.10/fs-transformer.libsonnet
@@ -231,7 +231,7 @@ local utils = import 'templates/utils.libsonnet';
     common.PyTorchXlaDistPodTest + transformer + v3_32 + functional_xla_dist + timeouts.Hours(1),
     common.PyTorchTest + transformer + v3_8 + functional + timeouts.Hours(1),
     common.PyTorchTest + transformer + v3_8 + convergence + timeouts.Hours(25),
-    transformer_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(25) + experimental.PyTorchTpuVmMixin,
+    transformer_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(25) + common.PyTorchTpuVm,
     common.PyTorchTest + transformer + v3_8 + checkpoint_local + timeouts.Hours(2),
     common.PyTorchTest + transformer + v3_8 + checkpoint_gcs + timeouts.Hours(2),
   ],

--- a/tests/pytorch/r1.10/resnet50-mp.libsonnet
+++ b/tests/pytorch/r1.10/resnet50-mp.libsonnet
@@ -239,7 +239,7 @@ local utils = import 'templates/utils.libsonnet';
     resnet50_gpu_py37_cuda_102 + common.Functional + v100x4 + timeouts.Hours(1),
     resnet50_gpu_py37_cuda_112 + common.Functional + v100 + timeouts.Hours(2),
     resnet50_gpu_py37_cuda_112 + common.Functional + v100x4 + timeouts.Hours(1),
-    resnet50_tpu_vm + v3_8 + functional_tpu_vm + timeouts.Hours(2) + experimental.PyTorchTpuVmMixin,
-    resnet50_tpu_vm + v3_8 + convergence_tpu_vm + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
+    resnet50_tpu_vm + v3_8 + functional_tpu_vm + timeouts.Hours(2) + common.PyTorchTpuVm,
+    resnet50_tpu_vm + v3_8 + convergence_tpu_vm + timeouts.Hours(4) + common.PyTorchTpuVm,
   ],
 }

--- a/tests/pytorch/r1.10/roberta-pre.libsonnet
+++ b/tests/pytorch/r1.10/roberta-pre.libsonnet
@@ -155,6 +155,6 @@ local utils = import 'templates/utils.libsonnet';
     common.PyTorchGkePodTest + roberta + v3_32 + functional + timeouts.Hours(1),
     common.PyTorchTest + roberta + v3_8 + functional + timeouts.Hours(1),
     common.PyTorchTest + roberta + v3_8 + convergence + timeouts.Hours(2),
-    roberta_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + experimental.PyTorchTpuVmMixin,
+    roberta_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + common.PyTorchTpuVm,
   ],
 }


### PR DESCRIPTION
refactoring pytorch tests to enable using different software version for different releases and nightly tests.
adding 1vm tests for cpp-ops because the previous blocker has been resolved.
test run: pt-r1.10-cpp-ops-func-v2-8-1vm-rwlbf
This pr does not touch nightly tests, which is meant to use v2-nightly.
For future release tests, copy 1.10 folder will enable choice of newer released software versions.