### PR TITLE
Updates the path of the legacy tf-vision.

### DIFF
--- a/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-efficientnet.libsonnet
@@ -43,7 +43,7 @@ local tpus = import 'templates/tpus.libsonnet';
     },
     command: [
       'python3',
-      'official/vision/image_classification/classifier_trainer.py',
+      'official/legacy/image_classification/classifier_trainer.py',
       '--data_dir=$(IMAGENET_DIR)',
       '--model_type=efficientnet',
       '--dataset=imagenet',
@@ -117,7 +117,7 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
     command+: [
-      '--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-gpu.yaml',
+      '--config_file=official/legacy/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-gpu.yaml',
     ],
   },
   local k80x8 = gpu_common {
@@ -137,7 +137,7 @@ local tpus = import 'templates/tpus.libsonnet';
   local tpu_common = {
     command+: [
       '--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)',
-      '--config_file=official/vision/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml',
+      '--config_file=official/legacy/image_classification/configs/examples/efficientnet/imagenet/efficientnet-b0-tpu.yaml',
     ],
   },
   local v2_8 = tpu_common {

--- a/tests/tensorflow/nightly/classifier-resnet.libsonnet
+++ b/tests/tensorflow/nightly/classifier-resnet.libsonnet
@@ -38,7 +38,7 @@ local tpus = import 'templates/tpus.libsonnet';
     },
     command: [
       'python3',
-      'official/vision/image_classification/classifier_trainer.py',
+      'official/legacy/image_classification/classifier_trainer.py',
       '--data_dir=$(IMAGENET_DIR)',
       '--model_type=resnet',
       '--dataset=imagenet',
@@ -106,7 +106,7 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
     command+: [
-      '--config_file=official/vision/image_classification/configs/examples/resnet/imagenet/gpu.yaml',
+      '--config_file=official/legacy/image_classification/configs/examples/resnet/imagenet/gpu.yaml',
     ],
   },
   local k80 = gpu_common {
@@ -155,7 +155,7 @@ local tpus = import 'templates/tpus.libsonnet';
   local tpu_common = {
     command+: [
       '--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)',
-      '--config_file=official/vision/image_classification/configs/examples/resnet/imagenet/tpu.yaml',
+      '--config_file=official/legacy/image_classification/configs/examples/resnet/imagenet/tpu.yaml',
     ],
   },
   local v2_8 = tpu_common {

--- a/tests/tensorflow/nightly/maskrcnn.libsonnet
+++ b/tests/tensorflow/nightly/maskrcnn.libsonnet
@@ -44,7 +44,7 @@ local tpus = import 'templates/tpus.libsonnet';
     },
     command: [
       'python3',
-      'official/vision/detection/main.py',
+      'official/legacy/detection/main.py',
       '--model=mask_rcnn',
       '--params_override=%s' % (std.manifestYamlDoc(self.paramsOverride) + '\n'),
       '--model_dir=$(MODEL_DIR)',

--- a/tests/tensorflow/nightly/mnist.libsonnet
+++ b/tests/tensorflow/nightly/mnist.libsonnet
@@ -23,7 +23,7 @@ local tpus = import 'templates/tpus.libsonnet';
     modelName: 'mnist',
     command: [
       'python3',
-      'official/vision/image_classification/mnist_main.py',
+      'official/legacy/image_classification/mnist_main.py',
       '--data_dir=%s' % self.flags.dataDir,
       '--model_dir=%s' % self.flags.modelDir,
     ],

--- a/tests/tensorflow/nightly/resnet-ctl.libsonnet
+++ b/tests/tensorflow/nightly/resnet-ctl.libsonnet
@@ -23,7 +23,7 @@ local tpus = import 'templates/tpus.libsonnet';
     modelName: 'resnet-ctl',
     command: [
       'python3',
-      'official/vision/image_classification/resnet/resnet_ctl_imagenet_main.py',
+      'official/legacy/image_classification/resnet/resnet_ctl_imagenet_main.py',
       '--tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS)',
       '--distribution_strategy=tpu',
       '--use_synthetic_data=false',

--- a/tests/tensorflow/nightly/retinanet.libsonnet
+++ b/tests/tensorflow/nightly/retinanet.libsonnet
@@ -45,7 +45,7 @@ local tpus = import 'templates/tpus.libsonnet';
     },
     command: [
       'python3',
-      'official/vision/detection/main.py',
+      'official/legacy/detection/main.py',
       '--params_override=%s' % (std.manifestYamlDoc(self.paramsOverride) + '\n'),
       '--model_dir=$(MODEL_DIR)',
     ],

--- a/tests/tensorflow/nightly/shapemask.libsonnet
+++ b/tests/tensorflow/nightly/shapemask.libsonnet
@@ -21,7 +21,7 @@ local utils = import 'templates/utils.libsonnet';
 
 {
   local command_common = |||
-    python3 official/vision/detection/main.py \
+    python3 official/legacy/detection/main.py \
       --tpu=$(KUBE_GOOGLE_CLOUD_TPU_ENDPOINTS) \
       --strategy_type=tpu \
       --model=shapemask \


### PR DESCRIPTION
The following test has been run on locally machine successfully after change.

```
	modified:   tests/tensorflow/nightly/classifier-efficientnet.libsonnet
	modified:   tests/tensorflow/nightly/classifier-resnet.libsonnet
	modified:   tests/tensorflow/nightly/maskrcnn.libsonnet
	modified:   tests/tensorflow/nightly/mnist.libsonnet
	modified:   tests/tensorflow/nightly/resnet-ctl.libsonnet
	modified:   tests/tensorflow/nightly/retinanet.libsonnet
	modified:   tests/tensorflow/nightly/shapemask.libsonnet
```