### PR TITLE
Run PyTorch setup steps on all TPU VM workers with `gcloud`

### DIFF
--- a/tests/experimental.libsonnet
+++ b/tests/experimental.libsonnet
@@ -118,6 +118,7 @@ local volumes = import 'templates/volumes.libsonnet';
                 exit $exit_code
               fi
 
+              echo ${zone} > /scripts/zone
               echo ${tpu_name} > /scripts/tpu_name
               gcloud compute tpus describe ${tpu_name} --project=${project} --zone=${zone} --format="value(networkEndpoints[0].ipAddress)" > /scripts/tpu_ip
               gcloud compute tpus describe ${tpu_name} --project=${project} --zone=${zone} --flatten="networkEndpoints[]" --format="csv[no-heading](networkEndpoints.ipAddress)" > /scripts/all_tpu_ips

--- a/tests/pytorch/experimental.libsonnet
+++ b/tests/pytorch/experimental.libsonnet
@@ -36,7 +36,7 @@ local utils = import 'templates/utils.libsonnet';
           monitor: null,
           train+: {
             local scriptSettings = {
-              # Distribute command with xla_dist on pods
+              // Distribute command with xla_dist on pods
               testCommand: if config.accelerator.replicas == 1 then
                 utils.toCommandString(config.command)
               else
@@ -49,7 +49,7 @@ local utils = import 'templates/utils.libsonnet';
                     '--',
                   ] + config.command,
                 ),
-              # XRT_TPU_CONFIG set up by xla_dist on pods
+              // XRT_TPU_CONFIG set up by xla_dist on pods
               xrtTpuConfig: if config.accelerator.replicas == 1 then
                 "export XRT_TPU_CONFIG='localservice;0;localhost:51011'"
               else

--- a/tests/pytorch/experimental.libsonnet
+++ b/tests/pytorch/experimental.libsonnet
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 local experimental = import '../experimental.libsonnet';
+local utils = import 'templates/utils.libsonnet';
 
 {
   PyTorchTpuVmMixin:: experimental.BaseTpuVmMixin {
@@ -35,11 +36,24 @@ local experimental = import '../experimental.libsonnet';
           monitor: null,
           train+: {
             local scriptSettings = {
-              testCommand:
-                std.join(
-                  ' ',
-                  config.command,
+              # Distribute command with xla_dist on pods
+              testCommand: if config.accelerator.replicas == 1 then
+                utils.toCommandString(config.command)
+              else
+                utils.toCommandString(
+                  [
+                    'python3',
+                    '-m',
+                    'torch_xla.distributed.xla_dist',
+                    '--tpu=tpu-$(POD_UID)',
+                    '--',
+                  ] + config.command,
                 ),
+              # XRT_TPU_CONFIG set up by xla_dist on pods
+              xrtTpuConfig: if config.accelerator.replicas == 1 then
+                "export XRT_TPU_CONFIG='localservice;0;localhost:51011'"
+              else
+                '',
               pytorchSetup: config.tpuSettings.tpuVmPytorchSetup,
               extraSetup: config.tpuSettings.tpuVmExtraSetup,
             },
@@ -52,18 +66,28 @@ local experimental = import '../experimental.libsonnet';
               |||
                 set -x
                 set -u
-                ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \
-                  'sudo apt-get -y update && sudo apt-get -y install nfs-common git google-perftools'
-                ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \
-                  'sudo mkdir /datasets && sudo mount $(PYTORCH_DATA_LOCATION) /datasets'
-                ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) << 'TEST_SCRIPT_EOF'
-                  export XRT_TPU_CONFIG='localservice;0;localhost:51011'
-                  export LD_PRELOAD='/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4'
 
+                cat > workersetup.sh << TEST_SCRIPT_EOF
+                sudo apt-get -y update
+                sudo apt-get -y install nfs-common
+                sudo mkdir /datasets && sudo mount $(PYTORCH_DATA_LOCATION) /datasets
+
+                yes '' | gcloud compute config-ssh
+
+                cd
                 %(pytorchSetup)s
+
+                cd
                 %(extraSetup)s
+                TEST_SCRIPT_EOF
+                gcloud alpha compute tpus tpu-vm ssh xl-ml-test@$(cat /scripts/tpu_name) --zone=$(cat /scripts/zone) --ssh-key-file=/scripts/id_rsa --strict-host-key-checking=no --internal-ip --worker=all --command "$(cat workersetup.sh)"
+
+                cat > testscript.sh << 'TEST_SCRIPT_EOF'
+                %(xrtTpuConfig)s
                 %(testCommand)s
                 TEST_SCRIPT_EOF
+                gcloud alpha compute tpus tpu-vm ssh xl-ml-test@$(cat /scripts/tpu_name) --zone=$(cat /scripts/zone) --ssh-key-file=/scripts/id_rsa --strict-host-key-checking=no --internal-ip --worker=0 --command "$(cat testscript.sh)"
+
                 exit_code=$?
                 bash /scripts/cleanup.sh
                 exit $exit_code
@@ -74,7 +98,6 @@ local experimental = import '../experimental.libsonnet';
       },
     },
   },
-
   PyTorchTpuVmPodTest:: experimental.BaseTpuVmMixin {
     local config = self,
     tpuSettings+: {
@@ -207,7 +230,7 @@ local experimental = import '../experimental.libsonnet';
         sudo bash /var/scripts/docker-login.sh
         sudo pip3 uninstall --yes torch torch_xla torchvision numpy
         sudo pip3 install https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/libtpu-nightly/libtpu_nightly-0.1.dev20211013-py3-none-any.whl
-        sudo pip3 install torch==1.10.0 
+        sudo pip3 install torch==1.10.0
         sudo pip3 install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-1.10-cp38-cp38-linux_x86_64.whl
         sudo pip3 install torchvision==0.11.1
         sudo pip3 install mkl mkl-include numpy

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -18,7 +18,7 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local transformer = {
+  local transformer = common.PyTorchTest {
     local config = self,
 
     modelName: 'fs-transformer',
@@ -201,11 +201,10 @@ local utils = import 'templates/utils.libsonnet';
     accelerator: tpus.v3_32,
   },
   configs: [
-    common.PyTorchXlaDistPodTest + transformer + v3_32 + functional_no_save + timeouts.Hours(1),
-    common.PyTorchTest + transformer + v3_8 + functional_no_save + timeouts.Hours(1),
-    common.PyTorchTest + transformer + v3_8 + convergence + timeouts.Hours(25),
-    common.PyTorchTest + transformer + v3_8 + convergence + timeouts.Hours(25) + tpuVm,
-    common.PyTorchTest + transformer + v3_8 + checkpoint_local + timeouts.Hours(2),
-    common.PyTorchTest + transformer + v3_8 + checkpoint_gcs + timeouts.Hours(2),
+    transformer + v3_8 + functional_no_save + timeouts.Hours(1),
+    transformer + v3_8 + convergence + timeouts.Hours(25),
+    transformer + v3_8 + convergence + timeouts.Hours(25) + tpuVm,
+    transformer + v3_8 + checkpoint_local + timeouts.Hours(2),
+    transformer + v3_8 + checkpoint_gcs + timeouts.Hours(2),
   ],
 }

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 local common = import 'common.libsonnet';
+local mixins = import 'templates/mixins.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
@@ -188,8 +189,8 @@ local utils = import 'templates/utils.libsonnet';
     tpuSettings+: {
       tpuVmExtraSetup: |||
         git clone --recursive https://github.com/pytorch-tpu/examples.git tpu-examples/
-        export PATH=~/.local/bin:$PATH
-        export XLA_USE_BF16=1
+        echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
+        sudo echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
       |||,
     },
   },
@@ -206,5 +207,6 @@ local utils = import 'templates/utils.libsonnet';
     transformer + v3_8 + convergence + timeouts.Hours(25) + tpuVm,
     transformer + v3_8 + checkpoint_local + timeouts.Hours(2),
     transformer + v3_8 + checkpoint_gcs + timeouts.Hours(2),
+    transformer + v3_32 + functional_no_save + timeouts.Hours(1) + tpuVm + mixins.Experimental,
   ],
 }

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -190,7 +190,7 @@ local utils = import 'templates/utils.libsonnet';
       tpuVmExtraSetup: |||
         git clone --recursive https://github.com/pytorch-tpu/examples.git tpu-examples/
         echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
-        sudo echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
+        echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
       |||,
     },
   },


### PR DESCRIPTION
This change makes the new `PyTorchTpuVmMixin` compatible with pod tests.

Replace fs_transformer v3-32 TPU Node `xla_dist` test with a TPU VM test. We still get coverage of the TPU Node + `xla_dist` case through ResNet:

https://github.com/GoogleCloudPlatform/ml-testing-accelerators/blob/477803e1ca54c2834e9619d893ba766f01d4ebdd/tests/pytorch/nightly/resnet50-pod.libsonnet#L41

Both TPU VM transformer tests are currently broken due to libtpu issues (bug already filed internally). I ran test runs for v3-8 and v3-32 to confirm environment is set up correctly in device and pod cases. Also ran resnet on v3-8 to confirm there is no functional impact on non-transformer tests. Disabling v3-32 test until v3-8 starts passing.

Builds on work in #550 