### PR TITLE
Bump python runtime for dashboard app from 3.6 to 3.7

### DIFF
--- a/dashboard/app.yaml
+++ b/dashboard/app.yaml
@@ -17,7 +17,7 @@ env: flex
 entrypoint: bokeh serve --disable-index-redirect --num-procs=1 --port=$PORT --allow-websocket-origin=xl-ml-test.appspot.com dashboard.py metrics.py compare.py
 
 runtime_config:
-  python_version: 3
+  python_version: 3.7
 
 automatic_scaling:
   min_num_instances: 2


### PR DESCRIPTION
Python 3.6 is deprecated and causing PyTorch build to fail during deployment. Upgrading to PyThon 3.7, [test run](Yeounoh Chung, 9:53 AM
https://console.cloud.google.com/cloud-build/builds/2a273101-85f8-469e-bd9d-7a592ed51631?project=1030754782689
).