### PR TITLE
Migrating JAX tests to tpu-vm-base image.

### DIFF
--- a/tests/jax/compilation-cache.libsonnet
+++ b/tests/jax/compilation-cache.libsonnet
@@ -31,11 +31,6 @@ local mixins = import 'templates/mixins.libsonnet';
       pip install --upgrade numpy==1.18.5 scipy wheel future six cython pytest \
           absl-py opt-einsum msgpack
 
-      echo "Checking out and installing JAX..."
-      git clone https://github.com/google/jax.git
-      cd jax
-      git fetch
-      echo "jax git hash: $(git rev-parse HEAD)"
       %(installLocalJax)s
       %(maybeBuildJaxlib)s
       %(printDiagnostics)s
@@ -74,6 +69,6 @@ local mixins = import 'templates/mixins.libsonnet';
   },
 
   configs: [
-    compilationCacheTest + common.jaxlibLatest + common.alphaImage,
+    compilationCacheTest + common.jaxlibLatest + common.tpuVmBaseImage,
   ],
 }

--- a/tests/jax/latest/common.libsonnet
+++ b/tests/jax/latest/common.libsonnet
@@ -16,7 +16,7 @@ local common = import '../common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
-  runFlaxLatest:: common.JaxTest + common.jaxlibLatest + common.alphaImage {
+  runFlaxLatest:: common.JaxTest + common.jaxlibLatest + common.tpuVmBaseImage {
     local config = self,
 
     frameworkPrefix: 'flax-latest',
@@ -32,11 +32,12 @@ local tpus = import 'templates/tpus.libsonnet';
       rm .bash_logout
 
       pip install --upgrade pip
+      pip install --upgrade clu %(extraDeps)s
+
       %(installLatestJax)s
       %(maybeBuildJaxlib)s
       %(printDiagnostics)s
 
-      pip install --upgrade clu %(extraDeps)s
 
       num_devices=`python3 -c "import jax; print(jax.device_count())"`
       if [ "$num_devices" = "1" ]; then
@@ -60,7 +61,7 @@ local tpus = import 'templates/tpus.libsonnet';
              extraFlags: config.extraFlags,
            }),
   },
-  PodFlaxLatest:: common.JaxPodTest + common.jaxlibLatest + common.alphaImage {
+  PodFlaxLatest:: common.JaxPodTest + common.jaxlibLatest + common.tpuVmBaseImage {
     local config = self,
     frameworkPrefix: 'flax-latest',
     extraDeps:: '',
@@ -73,10 +74,12 @@ local tpus = import 'templates/tpus.libsonnet';
       # .bash_logout sometimes causes a spurious bad exit code, remove it.
       rm .bash_logout
       pip install --upgrade pip
+      pip install --upgrade clu %(extraDeps)s
+
       %(installLatestJax)s
       %(maybeBuildJaxlib)s
       %(printDiagnostics)s
-      pip install --upgrade clu %(extraDeps)s
+
       git clone https://github.com/google/flax
       cd flax
       pip install -e .

--- a/tests/jax/latest/vit.libsonnet
+++ b/tests/jax/latest/vit.libsonnet
@@ -41,11 +41,12 @@ local tpus = import 'templates/tpus.libsonnet';
     rm .bash_logout
 
     pip install --upgrade pip
+    pip install --upgrade clu %(extraDeps)s
+
     %(installLatestJax)s
     %(maybeBuildJaxlib)s
     %(printDiagnostics)s
 
-    pip install --upgrade clu %(extraDeps)s
 
     num_devices=`python3 -c "import jax; print(jax.device_count())"`
     if [ "$num_devices" = "1" ]; then
@@ -65,7 +66,7 @@ local tpus = import 'templates/tpus.libsonnet';
       %(extraFlags)s
   |||,
 
-  local vit = common.JaxTest + common.jaxlibLatest + common.alphaImage {
+  local vit = common.JaxTest + common.jaxlibLatest + common.tpuVmBaseImage {
     local config = self,
     frameworkPrefix: 'flax-latest',
     modelName:: 'vit',

--- a/tests/jax/nightly/common.libsonnet
+++ b/tests/jax/nightly/common.libsonnet
@@ -16,7 +16,7 @@ local common = import '../common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
-  runFlaxNightly:: common.JaxTest + common.jaxlibHead + common.nightlyImage {
+  runFlaxNightly:: common.JaxTest + common.jaxlibHead + common.tpuVmBaseImage {
     local config = self,
 
     frameworkPrefix: 'flax-nightly',
@@ -34,10 +34,6 @@ local tpus = import 'templates/tpus.libsonnet';
       pip install --upgrade pip
       pip install --upgrade clu %(extraDeps)s
 
-      echo "Checking out and installing JAX..."
-      git clone https://github.com/google/jax.git
-      cd jax
-      echo "jax git hash: $(git rev-parse HEAD)"
       %(installLocalJax)s
       %(maybeBuildJaxlib)s
       %(printDiagnostics)s

--- a/tests/jax/nightly/vit.libsonnet
+++ b/tests/jax/nightly/vit.libsonnet
@@ -30,7 +30,7 @@ local tpus = import 'templates/tpus.libsonnet';
   },
 
   // TODO: move shared code into a common file
-  local vit = common.JaxTest + common.jaxlibHead + common.nightlyImage {
+  local vit = common.JaxTest + common.jaxlibHead + common.tpuVmBaseImage {
     local config = self,
     frameworkPrefix: 'flax-nightly',
     modelName:: 'vit',

--- a/tests/jax/pod-test.libsonnet
+++ b/tests/jax/pod-test.libsonnet
@@ -24,10 +24,6 @@ local mixins = import 'templates/mixins.libsonnet';
       set -u
       set -e
 
-      echo "Checking out and installing JAX..."
-      git clone https://github.com/google/jax.git
-      cd jax
-      echo "jax git hash: $(git rev-parse HEAD)"
       %(installLocalJax)s
       %(maybeBuildJaxlib)s
       %(printDiagnostics)s
@@ -48,8 +44,7 @@ local mixins = import 'templates/mixins.libsonnet';
   },
 
   configs: [
-    podTest + common.jaxlibHead + common.nightlyImage,
-    podTest + common.jaxlibHead + common.alphaImage,
-    podTest + common.jaxlibLatest + common.alphaImage,
+    podTest + common.jaxlibHead + common.tpuVmBaseImage,
+    podTest + common.jaxlibLatest + common.tpuVmBaseImage,
   ],
 }

--- a/tests/jax/unit-tests.libsonnet
+++ b/tests/jax/unit-tests.libsonnet
@@ -57,8 +57,7 @@ local mixins = import 'templates/mixins.libsonnet';
   },
 
   configs: [
-    runUnitTests + common.jaxlibHead + common.nightlyImage,
-    runUnitTests + common.jaxlibHead + common.alphaImage,
-    runUnitTests + common.jaxlibLatest + common.alphaImage,
+    runUnitTests + common.jaxlibHead + common.tpuVmBaseImage,
+    runUnitTests + common.jaxlibLatest + common.tpuVmBaseImage,
   ],
 }


### PR DESCRIPTION
- Migrated all the JAX tests to use `tpu-vm-base` image instead of `v2-alpha` and `v2-nightly`.
- Moved code to sync github jax up in the mixin, ie into 'installLocalJax' which only requires this repository.
- Refactored tests. 