### PR TITLE
Increase timeout for nightly python-ops tests

### DIFF
--- a/tests/pytorch/nightly/python-ops.libsonnet
+++ b/tests/pytorch/nightly/python-ops.libsonnet
@@ -41,7 +41,7 @@ local utils = import 'templates/utils.libsonnet';
   },
 
   configs: [
-    operations + v2_8 + common.Functional + timeouts.Hours(4),
-    operations + v3_8 + common.Functional + timeouts.Hours(4),
+    operations + v2_8 + common.Functional + timeouts.Hours(6),
+    operations + v3_8 + common.Functional + timeouts.Hours(6),
   ],
 }


### PR DESCRIPTION
Increasing timeout for `python-ops` tests as they have been failing for a while due to timeouts. 