### PR TITLE
Remove redundant PT/XLA tests.

### DIFF
--- a/tests/pytorch/nightly/cpp-ops.libsonnet
+++ b/tests/pytorch/nightly/cpp-ops.libsonnet
@@ -55,7 +55,6 @@ local utils = import 'templates/utils.libsonnet';
 
   configs: [
     operations + v2_8 + common.Functional + timeouts.Hours(4),
-    operations + v3_8 + common.Functional + timeouts.Hours(4),
     // TPUVM not working yet: https://b.corp.google.com/issues/183450497#comment18
     // cpp_ops_tpu_vm + v3_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,
     // cpp_ops_tpu_vm + v2_8 + common.Functional + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -203,10 +203,9 @@ local utils = import 'templates/utils.libsonnet';
   },
   configs: [
     transformer + v3_8 + functional_no_save + timeouts.Hours(1),
-    transformer + v3_8 + convergence + timeouts.Hours(25),
     transformer + v3_8 + convergence + timeouts.Hours(25) + tpuVm,
-    transformer + v3_8 + checkpoint_local + timeouts.Hours(2),
-    transformer + v3_8 + checkpoint_gcs + timeouts.Hours(2),
+    transformer + v2_8 + checkpoint_local + timeouts.Hours(2),
+    transformer + v2_8 + checkpoint_gcs + timeouts.Hours(2),
     transformer + v3_32 + functional_no_save + timeouts.Hours(1) + tpuVm,
   ],
 }

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -195,9 +195,6 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local v2_8 = {
-    accelerator: tpus.v2_8,
-  },
   local v3_8 = {
     accelerator: tpus.v3_8,
   },
@@ -207,8 +204,8 @@ local utils = import 'templates/utils.libsonnet';
   configs: [
     transformer + v3_8 + functional_no_save + timeouts.Hours(1),
     transformer + v3_8 + convergence + timeouts.Hours(25) + tpuVm,
-    transformer + v2_8 + checkpoint_local + timeouts.Hours(2),
-    transformer + v2_8 + checkpoint_gcs + timeouts.Hours(2),
+    transformer + v3_8 + checkpoint_local + timeouts.Hours(2),
+    transformer + v3_8 + checkpoint_gcs + timeouts.Hours(2),
     transformer + v3_32 + functional_no_save + timeouts.Hours(1) + tpuVm,
   ],
 }

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -195,6 +195,9 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
+  local v2_8 = {
+    accelerator: tpus.v2_8,
+  },
   local v3_8 = {
     accelerator: tpus.v3_8,
   },

--- a/tests/pytorch/nightly/hf-glue.libsonnet
+++ b/tests/pytorch/nightly/hf-glue.libsonnet
@@ -184,7 +184,6 @@ local utils = import 'templates/utils.libsonnet';
     accelerator: tpus.v3_8,
   },
   configs: [
-    hf_glue + v3_8 + bert_base_cased + timeouts.Hours(2),
     hf_glue + v2_8 + bert_base_cased + timeouts.Hours(2),
     hf_glue + v3_8 + xlnet_large_cased + timeouts.Hours(5),
     hf_glue + v3_8 + roberta_large + timeouts.Hours(4),

--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -190,7 +190,6 @@ local utils = import 'templates/utils.libsonnet';
     accelerator: tpus.v3_8,
   },
   configs: [
-    hf_lm + v3_8 + roberta_base_pre + timeouts.Hours(4),
     hf_lm + v2_8 + roberta_base_pre + timeouts.Hours(5),
     hf_lm + v3_8 + roberta_base_fine + timeouts.Hours(3),
     hf_lm + v3_8 + bert_base_pre + timeouts.Hours(6),

--- a/tests/pytorch/nightly/mnist.libsonnet
+++ b/tests/pytorch/nightly/mnist.libsonnet
@@ -60,11 +60,6 @@ local utils = import 'templates/utils.libsonnet';
 
   local v2_8 = {
     accelerator: tpus.v2_8,
-
-  },
-  local v3_8 = {
-    accelerator: tpus.v3_8,
-
   },
   local v3_32 = {
     accelerator: tpus.v3_32,
@@ -86,16 +81,11 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v100 = gpu {
-    accelerator: gpus.teslaV100,
-  },
   local v100x4 = gpu {
     accelerator: gpus.teslaV100 { count: 4 },
   },
   configs: [
     mnist + convergence + v2_8 + timeouts.Hours(1),
-    mnist + convergence + v3_8 + timeouts.Hours(1),
-    mnist + convergence + v100 + timeouts.Hours(6),
     mnist + convergence + v100x4 + timeouts.Hours(6),
   ],
 }

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -209,9 +209,6 @@ local utils = import 'templates/utils.libsonnet';
     ),
   },
   configs: [
-    resnet50_MP + v3_8 + convergence + timeouts.Hours(26) + mixins.PreemptibleTpu,
-    resnet50_MP + v3_8 + functional + timeouts.Hours(2),
-    resnet50_gpu_py37_cuda_112 + common.Functional + v100 + timeouts.Hours(2),
     resnet50_gpu_py37_cuda_112 + common.Functional + v100x4 + timeouts.Hours(1),
     resnet50_tpu_vm + v3_8 + functional_tpu_vm + timeouts.Hours(2) + experimental.PyTorchTpuVmMixin,
     resnet50_tpu_vm + v3_8 + convergence_tpu_vm + timeouts.Hours(4) + experimental.PyTorchTpuVmMixin,

--- a/tests/pytorch/nightly/resnet50-pod.libsonnet
+++ b/tests/pytorch/nightly/resnet50-pod.libsonnet
@@ -87,14 +87,11 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v3_8 = {
-    accelerator: tpus.v3_8,
-  },
   local v3_32 = {
     accelerator: tpus.v3_32,
   },
   configs: [
-    resnet50_pod_func + v3_32 + functional,
+    resnet50_pod_func + v3_32 + functional + mixins.Experimental,
     resnet50_pod + v3_32 + common.Convergence + common.PyTorchTpuVmMixin,
   ],
 }

--- a/tests/pytorch/nightly/roberta-pre.libsonnet
+++ b/tests/pytorch/nightly/roberta-pre.libsonnet
@@ -152,9 +152,7 @@ local utils = import 'templates/utils.libsonnet';
     accelerator: tpus.v3_32,
   },
   configs: [
-    common.PyTorchGkePodTest + roberta + v3_32 + functional + timeouts.Hours(1),
     common.PyTorchTest + roberta + v3_8 + functional + timeouts.Hours(1),
-    common.PyTorchTest + roberta + v3_8 + convergence + timeouts.Hours(2),
     roberta_tpu_vm + v3_8 + common.Convergence + timeouts.Hours(6) + experimental.PyTorchTpuVmMixin,
   ],
 }

--- a/tests/pytorch/r1.10/common.libsonnet
+++ b/tests/pytorch/r1.10/common.libsonnet
@@ -47,14 +47,13 @@ local volumes = import 'templates/volumes.libsonnet';
     imageTag: 'r1.10',
   },
   Functional:: mixins.Functional {
-    schedule: '0 7 * * *',
+    schedule: null,
     tpuSettings+: {
       preemptible: false,
     },
   },
   Convergence:: mixins.Convergence {
-    // Run 3 times/week.
-    schedule: '0 7 * * 1,3,5',
+    schedule: null,
   },
   datasetsVolume: volumes.PersistentVolumeSpec {
     name: 'pytorch-datasets-claim',

--- a/tests/pytorch/r1.11/common.libsonnet
+++ b/tests/pytorch/r1.11/common.libsonnet
@@ -41,12 +41,14 @@ local volumes = import 'templates/volumes.libsonnet';
     imageTag: 'r1.11',
   },
   Functional:: mixins.Functional {
-    schedule: '0 7 * * *',
+    schedule: '0 7 * * 6',
     tpuSettings+: {
       preemptible: false,
     },
   },
-  Convergence:: mixins.Convergence,
+  Convergence:: mixins.Convergence {
+    schedule: null,
+  },
   PyTorchTpuVmMixin:: experimental.PyTorchTpuVmMixin {
     tpuSettings+: {
       softwareVersion: 'tpu-vm-pt-1.11',


### PR DESCRIPTION
Delete r1.10 tests and r1.11 convergence tests since both releases are stable. Run r1.11 functional tests once per week (consistent with TF).