### PR TITLE
Update timeout for python-op tests again

### DIFF
--- a/tests/pytorch/nightly/python-ops.libsonnet
+++ b/tests/pytorch/nightly/python-ops.libsonnet
@@ -41,7 +41,7 @@ local utils = import 'templates/utils.libsonnet';
   },
 
   configs: [
-    operations + v2_8 + common.Functional + timeouts.Hours(6),
-    operations + v3_8 + common.Functional + timeouts.Hours(6),
+    operations + v2_8 + common.Functional + timeouts.Hours(12),
+    operations + v3_8 + common.Functional + timeouts.Hours(12),
   ],
 }


### PR DESCRIPTION
The previous timeout increase PR https://github.com/GoogleCloudPlatform/ml-testing-accelerators/pull/596 was not enough, as tests are still timing out. 

cc @miladm @will-cromar 