### PR TITLE
Add UNet3D convergence test on TPU v3-8

### DIFF
--- a/tests/pytorch/nightly/targets.jsonnet
+++ b/tests/pytorch/nightly/targets.jsonnet
@@ -22,6 +22,7 @@ local pythonOperations = import 'python-ops.libsonnet';
 local resnet50_mp = import 'resnet50-mp.libsonnet';
 local resnet50_pod = import 'resnet50-pod.libsonnet';
 local fairseqRobertaPretrain = import 'roberta-pre.libsonnet';
+local unet3d = import 'unet3d.libsonnet';
 local wav2vec2 = import 'wav2vec2.libsonnet';
 
 // Add new models here
@@ -37,4 +38,5 @@ std.flattenArrays([
   resnet50_mp.configs,
   resnet50_pod.configs,
   wav2vec2.configs,
+  unet3d.configs,
 ])

--- a/tests/pytorch/nightly/unet3d.libsonnet
+++ b/tests/pytorch/nightly/unet3d.libsonnet
@@ -24,10 +24,10 @@ local utils = import 'templates/utils.libsonnet';
     pip3 install tqdm
 
     python3 unet3d_test/image_segmentation/pytorch/main.py --data_dir /datasets/kits19 \
-    --epochs 4000 \
-    --evaluate_every 300 \
-    --start_eval_at 300 \
-    --quality_threshold 0.5 \
+    --epochs 501 \
+    --evaluate_every 250 \
+    --start_eval_at 250 \
+    --quality_threshold 0.2 \
     --batch_size 1 \
     --optimizer sgd \
     --ga_steps 1 \
@@ -57,7 +57,7 @@ local utils = import 'templates/utils.libsonnet';
           tail -1 | grep -oP '"value": \K[+-]?([0-9]*[.])?[0-9]+'
         )
         echo 'Final UNet3D model accuracy is' $acc
-        test $(echo $acc'>'0.5 | bc -l) -eq 1  # assert model accuracy is higher than 0.5
+        test $(echo $acc'>'0.2 | bc -l) -eq 1  # assert model accuracy is higher than 0.2
       ||| % command_common
     ),
   },

--- a/tests/pytorch/nightly/unet3d.libsonnet
+++ b/tests/pytorch/nightly/unet3d.libsonnet
@@ -1,0 +1,83 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local common = import 'common.libsonnet';
+local timeouts = import 'templates/timeouts.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+local utils = import 'templates/utils.libsonnet';
+
+{
+  local command_common = |||
+    git clone https://github.com/thisisalbertliang/training.git -b test-grid-integration unet3d_test
+    pip3 install -r unet3d_test/image_segmentation/pytorch/requirements.txt
+    pip3 install tqdm
+
+    python3 unet3d_test/image_segmentation/pytorch/main.py --data_dir /datasets/kits19 \
+    --epochs 4000 \
+    --evaluate_every 300 \
+    --start_eval_at 300 \
+    --quality_threshold 0.5 \
+    --batch_size 1 \
+    --optimizer sgd \
+    --ga_steps 1 \
+    --learning_rate 0.8 \
+    --seed 0 \
+    --lr_warmup_epochs 0 \
+    --input_shape 128 128 128 \
+    --debug \
+    --device xla
+  |||,
+  local unet3d = common.PyTorchTest {
+    modelName: 'unet3d',
+
+    volumeMap+: {
+      datasets: common.datasetsVolume,
+    },
+    cpu: '40.0',
+    memory: '300Gi',
+  },
+  local conv = common.Convergence {
+    command: utils.scriptCommand(
+      |||
+        %(command_common)s \
+          2>&1 | tee training_logs.txt
+        acc=$(
+          cat training_logs.txt | grep 'eval_accuracy' | \
+          tail -1 | grep -oP '"value": \K[+-]?([0-9]*[.])?[0-9]+'
+        )
+        echo 'Final UNet3D model accuracy is' $acc
+        test $(echo $acc'>'0.5 | bc -l) -eq 1  # assert model accuracy is higher than 0.5
+      ||| % command_common
+    ),
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+  local tpuVm = common.PyTorchTpuVmMixin {
+
+    tpuSettings+: {
+
+      tpuVmExtraSetup: |||
+
+        echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
+
+      |||,
+
+    },
+
+  },
+  configs: [
+    unet3d + v3_8 + conv + timeouts.Hours(25) + tpuVm,
+  ],
+}


### PR DESCRIPTION
Resolves #616 

## Pull Request Summary
@thisisalbertliang developed [a UNet3D PyTorch/XLA codebase](https://github.com/thisisalbertliang/training/tree/master/image_segmentation/pytorch) that can train [MLPerf's UNet3D](https://github.com/mlcommons/training/tree/master/image_segmentation/pytorch) on both TPU and GPU.
This PR adds a convergence test for this UNet3D model on TPU v3-8

## Notes
- Currently, this convergence test still has trouble starting up on TPU v3-8 in GKE due to some configuration errors. In particular, the UNet3D training currently crashes upon start-up from an error: `tensorflow/core/framework/op_kernel.cc:1745] OP_REQUIRES failed at tpu_execute_op.cc:266 : INVALID_ARGUMENT: Run-time shape mismatch for XRTExecute argument[0] (2289320477493819). Expected element_type: F32`. The source of this error is likely unrelated to @thisisalbertliang's UNet3D PyTorch/XLA codebase.
    - For Googlers, see [b/229152397](https://b.corp.google.com/229152397) for more details on this. 
- To clarify, the code used by this convergence test is actually not the `master` branch of the UNet3D PyTorch/XLA codebase. Instead, it uses the `test-grid-integration` branch. This is because the `master` branch currently runs the model evaluation on TPU/GPU, which runs into OOM issues (described in detail in [b/220350444](https://b.corp.google.com/issues/220350444)). The `test-grid-integration` branch refactors the model evaluation to run on CPU, which has proved to successfully train the UNet3D model to convergence to `90.8%` accuracy in the past (see [b/228597462](https://b.corp.google.com/issues/228597462) for a successful convergence run on TPU v4-8)

## For Googlers
See b/229152397 for more details.