### PR TITLE
Update actions-x/commit in `generate.yml` workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -33,7 +33,7 @@ jobs:
         scripts/gen-tests.sh
     
     - name: Git Commit/Push Changes
-      uses: actions-x/commit@v2
+      uses: actions-x/commit@v5
       with:
         branch: gen
         files: k8s/


### PR DESCRIPTION
Upgrading actions-x/commit to v5 per their [README](https://github.com/actions-x/commit/blob/1929419481a5b78d564c9f71e99309e7fccacf8b/README.md?plain=1#L3)

Fixes broken CI workflow