### PR TITLE
Rename batch/v1beta1 CronJob -> batch/v1 CronJob

### DIFF
--- a/k8s/europe-west4/profile-cleanup.yaml
+++ b/k8s/europe-west4/profile-cleanup.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: profile-cleanup

--- a/k8s/europe-west4/tpu-vm-quota.yaml
+++ b/k8s/europe-west4/tpu-vm-quota.yaml
@@ -71,7 +71,7 @@ subjects:
   name: tpu-vm-quota-patcher
   namespace: automated
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tpu-daytime-limits
@@ -109,7 +109,7 @@ spec:
                 }
               }'
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tpu-off-hours-limits

--- a/k8s/us-central1/tpu-vm-quota.yaml
+++ b/k8s/us-central1/tpu-vm-quota.yaml
@@ -71,7 +71,7 @@ subjects:
   name: tpu-vm-quota-patcher
   namespace: automated
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tpu-daytime-limits
@@ -101,7 +101,7 @@ spec:
                 }
               }'
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tpu-off-hours-limits

--- a/k8s/us-central2/tpu-vm-quota.yaml
+++ b/k8s/us-central2/tpu-vm-quota.yaml
@@ -73,7 +73,7 @@ subjects:
   name: tpu-vm-quota-patcher
   namespace: automated
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tpu-daytime-limits
@@ -102,7 +102,7 @@ spec:
                 }
               }'
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tpu-off-hours-limits

--- a/templates/base.libsonnet
+++ b/templates/base.libsonnet
@@ -237,7 +237,7 @@ local volumes = import 'volumes.libsonnet';
     },
 
     cronJob:: {
-      apiVersion: 'batch/v1beta1',
+      apiVersion: 'batch/v1',
       kind: 'CronJob',
       metadata: {
         name: config.testName,

--- a/tests/cleanup.jsonnet
+++ b/tests/cleanup.jsonnet
@@ -33,7 +33,7 @@ local clusterTestNames = {
 
 local cleaners = {
   [cluster]: {
-    apiVersion: 'batch/v1beta1',
+    apiVersion: 'batch/v1',
     kind: 'CronJob',
     metadata: {
       name: 'cronjob-cleanup',


### PR DESCRIPTION
The old name is deprecated: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125