### PR TITLE
Fix TPU VM settings for PyTorch resnet50

### DIFF
--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -99,9 +99,11 @@ local tpus = import 'templates/tpus.libsonnet';
   },
 
   local tpuVm = common.PyTorchTpuVmMixin {
-    tpuVmExtraSetup+: |||
-      pip install tensorboardX google-cloud-storage
-    |||,
+    tpuSettings+: {
+      tpuVmExtraSetup+: |||
+        pip install tensorboardX google-cloud-storage
+      |||,
+    },
   },
 
   configs: [


### PR DESCRIPTION
This test is currently failing with `ModuleNotFoundError: No module named 'tensorboardX'`. I doubled checked that this install makes it into the generated workload now.