### PR TITLE
Install cloud-tpu-client for PyTorch TPU VM tests

### DIFF
--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -44,7 +44,7 @@ local volumes = import 'templates/volumes.libsonnet';
         sudo pip3 install https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch-nightly-cp38-cp38-linux_x86_64.whl https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torchvision-nightly-cp38-cp38-linux_x86_64.whl https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-nightly-cp38-cp38-linux_x86_64.whl numpy
         # Install corresponding libtpu-nightly
         sudo pip3 install torch_xla[tpuvm]
-        sudo pip3 install mkl mkl-include
+        sudo pip3 install mkl mkl-include cloud-tpu-client
         sudo apt-get -y update
         sudo apt-get install -y libomp5
         # No need to check out the PyTorch repository, but check out PT/XLA at


### PR DESCRIPTION
Pod tests are failing with this message:

`Traceback (most recent call last): File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main return _run_code(code, main_globals, None, File "/usr/lib/python3.8/runpy.py", line 87, in _run_code exec(code, run_globals) File "/usr/local/lib/python3.8/dist-packages/torch_xla/distributed/xla_dist.py", line 7, in <module> import cloud_tpu_client ModuleNotFoundError: No module named 'cloud_tpu_client'`