### PR TITLE
Update DLRM TPU v4 tests

### DIFF
--- a/tests/tensorflow/nightly/dlrm.libsonnet
+++ b/tests/tensorflow/nightly/dlrm.libsonnet
@@ -219,7 +219,7 @@ local tpus = import 'templates/tpus.libsonnet';
     paramsOverride+:: {
       task+: {
         model+: {
-          bottom_mlp: [512, 256, 32],
+          bottom_mlp: [512, 256, 64],
           embedding_dim: 64,
         },
       },

--- a/tests/tensorflow/r2.9/dlrm.libsonnet
+++ b/tests/tensorflow/r2.9/dlrm.libsonnet
@@ -218,7 +218,7 @@ local tpus = import 'templates/tpus.libsonnet';
     paramsOverride+:: {
       task+: {
         model+: {
-          bottom_mlp: [512, 256, 32],
+          bottom_mlp: [512, 256, 64],
           embedding_dim: 64,
         },
       },
@@ -255,5 +255,7 @@ local tpus = import 'templates/tpus.libsonnet';
     dlrm + convergence + v3_8 + common.tpuVm,
     dlrm + convergence + v2_32 + common.tpuVm,
     dlrm + functional + v3_32 + common.tpuVm,
+    dlrm + functional + v4_8 + common.tpuVm,
+    dlrm + functional + cross_interaction + v4_32 + common.tpuVm,
   ],
 }


### PR DESCRIPTION
Update DLRM TPU v4 tests making sure that the output dimension of the bottom_mlp layer matches the embedding_dim.