### PR TITLE
Install torch audio when running w2v2

### DIFF
--- a/tests/pytorch/nightly/wav2vec2.libsonnet
+++ b/tests/pytorch/nightly/wav2vec2.libsonnet
@@ -19,6 +19,7 @@ local utils = import 'templates/utils.libsonnet';
 
 {
   local command_common = |||
+    pip install https://storage.googleapis.com/tpu-pytorch/wheels/torchaudio-nightly-cp37-cp37m-linux_x86_64.whl
     pip install omegaconf hydra-core soundfile
     sudo apt-get install -y libsndfile-dev
     git clone --recursive https://github.com/pytorch/fairseq.git


### PR DESCRIPTION
Verified by pulling xlml test docker and verified that by installing this wheel it will not try to overwrite pytorch when installing fairseq.