### PR TITLE
Verify fairseq-generate being installed

### DIFF
--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -159,9 +159,7 @@ local utils = import 'templates/utils.libsonnet';
     command: utils.scriptCommand(
       |||
         export XLA_USE_BF16=1
-        pip install --editable tpu-examples/deps/fairseq
-        which fairseq-generate
-        fairseq-generate -h
+        sudo pip install --editable tpu-examples/deps/fairseq
         %s 2>&1 | tee training_logs.txt
         bleu=`fairseq-generate \
           /datasets/wmt18_en_de_bpej32k \

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -160,6 +160,8 @@ local utils = import 'templates/utils.libsonnet';
       |||
         export XLA_USE_BF16=1
         pip install --editable tpu-examples/deps/fairseq
+        which fairseq-generate
+        fairseq-generate -h
         %s 2>&1 | tee training_logs.txt
         bleu=`fairseq-generate \
           /datasets/wmt18_en_de_bpej32k \


### PR DESCRIPTION
For some reason `fairseq-generate` is not available after `fairseq` installation. I was not able to repo locally on the xlml test docker. Adding this and manually trigger the test to help the debug.

error is `/bin/bash: line 46: fairseq-generate: command not found` after 25 epoches of training is completed.