### PR TITLE
Remove version specify from jax install command.

### DIFF
--- a/tests/jax/common.libsonnet
+++ b/tests/jax/common.libsonnet
@@ -174,7 +174,7 @@ local tpus = import 'templates/tpus.libsonnet';
           -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
       |||,
       installLatestJax: |||
-        pip install "jax[tpu]>=0.2.16" \
+        pip install jax[tpu] \
           -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
       |||,
       maybeBuildJaxlib: '',


### PR DESCRIPTION
Now that we have vanilla base images without jax preinstalled, we
don't need this version hack to make pip install the latest jax
version.

I'll update the JAX README and other documentation once we test this
actually works.