### PR TITLE
Update base template to make writing simple tests more simple.

### DIFF
--- a/templates/base.libsonnet
+++ b/templates/base.libsonnet
@@ -25,6 +25,10 @@ local volumes = import 'volumes.libsonnet';
     // HACK: for format strings
     acceleratorName:: config.accelerator.name,
     mode: error 'Must set `mode`',
+
+    // `entrypoint` in Docker sense. Corresponds to container `command`.
+    entrypoint: null,
+    // `command` in Docker sense. Corresponds to container `args`.
     command: error 'Must specify model `command`',
 
     // Image in main `train` container.
@@ -56,10 +60,14 @@ local volumes = import 'volumes.libsonnet';
     // If null, defer to namespace default.
     cpu: null,
     memory: null,
+
     // Map of names to VolumeSpecs.
     volumeMap: {},
     // List of ConfigMaps to pull environment variables from.
-    configMaps: ['gcs-buckets'],
+    configMaps: [],
+    // GCS location to store test output. Can be a Kubernetes env var if set in
+    // a config map.
+    outputBucket: error 'Must set `outputBucket`',
 
     // Settings for metric collection and assertions. Should evaluate to
     // MetricCollectionConfig from metrics/metrics.proto. See
@@ -123,7 +131,7 @@ local volumes = import 'volumes.libsonnet';
           },
           {
             name: 'MODEL_DIR',
-            value: '$(OUTPUT_BUCKET)/%s/$(JOB_NAME)' % gcsSubdir,
+            value: '%s/%s/$(JOB_NAME)' % [config.outputBucket, gcsSubdir],
           },
         ],
 
@@ -140,7 +148,7 @@ local volumes = import 'volumes.libsonnet';
 
             image: '%(image)s:%(imageTag)s' % config,
             imagePullPolicy: 'Always',
-            // Use Docker image's entrypoint wrapper
+            // Use Docker image's entrypoint wrapper unless `entrypoint` is set.
             args: config.command,
 
             envFrom: [
@@ -168,7 +176,9 @@ local volumes = import 'volumes.libsonnet';
                 memory: config.memory,
               },
             }),
-          },
+          } + if config.entrypoint != null then
+            { command: config.entrypoint }
+          else { },
         },
         containers: [
           { name: name } + pod.containerMap[name]

--- a/tests/common.libsonnet
+++ b/tests/common.libsonnet
@@ -23,6 +23,9 @@ local metrics = import 'templates/metrics.libsonnet';
       requireTpuAvailableLabel: true,
     },
 
+    configMaps+: ['gcs-buckets'],
+    outputBucket: '$(OUTPUT_BUCKET)', // Comes from `gcs-buckets` config map.
+
     metricConfig: metrics.MetricCollectionConfigHelper {
       sourceMap:: {
         tensorboard: metrics.TensorBoardSourceHelper {


### PR DESCRIPTION
Fix some usability issues I saw when rewriting our tutorials.

- Remove hard-coded requirement for a `gcs-buckets` `ConfigMap`.
- Add `entrypoint` override option.
- Update `tests/common.libsonnet` so our generated files stay the same.