### PR TITLE
Fix OOM for vision-resnet-conv-v2-8 tests

### DIFF
--- a/tests/tensorflow/nightly/vision-imagenet.libsonnet
+++ b/tests/tensorflow/nightly/vision-imagenet.libsonnet
@@ -52,6 +52,18 @@ local utils = import 'templates/utils.libsonnet';
   local convergence = common.Convergence,
   local v2_8 = {
     accelerator: tpus.v2_8,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 1024,
+          },
+          validation_data+: {
+            global_batch_size: 1024,
+          },
+        },
+      },
+    },
   },
   local v3_8 = {
     accelerator: tpus.v3_8,

--- a/tests/tensorflow/r2.9/vision-imagenet.libsonnet
+++ b/tests/tensorflow/r2.9/vision-imagenet.libsonnet
@@ -52,6 +52,18 @@ local utils = import 'templates/utils.libsonnet';
   local convergence = common.Convergence,
   local v2_8 = {
     accelerator: tpus.v2_8,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 1024,
+          },
+          validation_data+: {
+            global_batch_size: 1024,
+          },
+        },
+      },
+    },
   },
   local v3_8 = {
     accelerator: tpus.v3_8,


### PR DESCRIPTION
vision-resnet-conv-v2-8 tests for tf-nightly and tf-r2.9.1 used the default
batch size of 4096, which caused OOM during training. Overriding the
global_batch_size parameter to 1024 allows the tests to run successfully.

Other tests (such as v3-8 and v2-32) are succeeding with the default
batch size, so this change does not override their configuration.