### PR TITLE
Update tensorflow test nlp-wmt.libsonnet to fix timeout issue

### DIFF
--- a/tests/tensorflow/nightly/nlp-wmt.libsonnet
+++ b/tests/tensorflow/nightly/nlp-wmt.libsonnet
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
-local mixins = import 'templates/mixins.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
-local utils = import 'templates/utils.libsonnet';
 
 {
   local transformer = common.TfNlpTest {

--- a/tests/tensorflow/nightly/nlp-wmt.libsonnet
+++ b/tests/tensorflow/nightly/nlp-wmt.libsonnet
@@ -41,18 +41,65 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = common.Convergence {
+    local config = self,
+    scriptConfig+: {
+      paramsOverride+: {
+        trainer+: {
+          train_steps: 200000 / config.accelerator.replicas,
+        },
+      },
+    },
+  },
+
   local v2_8 = {
     accelerator: tpus.v2_8,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 6144,
+          },
+        },
+      },
+    },
   },
+
   local v3_8 = {
     accelerator: tpus.v3_8,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 6144,
+          },
+        },
+      },
+    },
   },
   local v2_32 = {
     accelerator: tpus.v2_32,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 24576,
+          },
+        },
+      },
+    },
   },
   local v3_32 = {
     accelerator: tpus.v3_32,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 24576,
+          },
+        },
+      },
+    },
   },
   configs: [
     transformer + accelerator + functional

--- a/tests/tensorflow/r2.9/nlp-wmt.libsonnet
+++ b/tests/tensorflow/r2.9/nlp-wmt.libsonnet
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
-local mixins = import 'templates/mixins.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
-local utils = import 'templates/utils.libsonnet';
 
 {
   local transformer = common.TfNlpTest {

--- a/tests/tensorflow/r2.9/nlp-wmt.libsonnet
+++ b/tests/tensorflow/r2.9/nlp-wmt.libsonnet
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local experimental = import '../experimental.libsonnet';
 local common = import 'common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
@@ -40,18 +41,64 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = common.Convergence {
+    local config = self,
+    scriptConfig+: {
+      paramsOverride+: {
+        trainer+: {
+          train_steps: 200000 / config.accelerator.replicas,
+        },
+      },
+    },
+  },
+
   local v2_8 = {
     accelerator: tpus.v2_8,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 6144,
+          },
+        },
+      },
+    },
   },
   local v3_8 = {
     accelerator: tpus.v3_8,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 6144,
+          },
+        },
+      },
+    },
   },
   local v2_32 = {
     accelerator: tpus.v2_32,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 24576,
+          },
+        },
+      },
+    },
   },
   local v3_32 = {
     accelerator: tpus.v3_32,
+    scriptConfig+: {
+      paramsOverride+: {
+        task+: {
+          train_data+: {
+            global_batch_size: 24576,
+          },
+        },
+      },
+    },
   },
   configs: [
     transformer + accelerator + functional


### PR DESCRIPTION
The same test is timeout for both tf-nightly and tf-2.9.1
Compared with the test in tf2.8, I updated train steps and batch size.
Test pass on tf-nightly-nlp-wmt-transformer-conv-v2-8