### PR TITLE
adding TPU_NAME to fix 'no accelerator found' error

### DIFF
--- a/tests/tensorflow/nightly/keras-api.libsonnet
+++ b/tests/tensorflow/nightly/keras-api.libsonnet
@@ -29,6 +29,7 @@ local utils = import 'templates/utils.libsonnet';
         cd ~
         export PATH=$PATH:/root/google-cloud-sdk/bin
         export PATH=$PATH:/home/xl-ml-test/.local/bin
+        export TPU_NAME=local
         gcloud source repos clone tf2-api-tests --project=xl-ml-test
         cd tf2-api-tests
         pip3 install behave


### PR DESCRIPTION
Works on donuts only