### PR TITLE
Add missing `python3` to fs-transformer conv test

### DIFF
--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -170,6 +170,7 @@ local utils = import 'templates/utils.libsonnet';
         '--max-epoch=25',
       ],
       generateCommand: [
+        'python3',
         std.strReplace(self.scriptPath, 'train.py', 'generate.py'),
         '/datasets/wmt18_en_de_bpej32k',
         '--remove-bpe',


### PR DESCRIPTION
Currently fails with this error: `/bin/bash: line 42: fairseq-pjrt/generate.py: Permission denied`