### PR TITLE
Fix hf-bert-mrpc-func tests failure

### DIFF
--- a/tests/jax/latest/hf-glue.libsonnet
+++ b/tests/jax/latest/hf-glue.libsonnet
@@ -74,7 +74,7 @@ local utils = import 'templates/utils.libsonnet';
   },
   local mrpc = {
     modelName+: '-mrpc',
-    extraFlags+: '--task_name mrpc --max_seq_length 128 ',
+    extraFlags+: '--task_name mrpc --max_seq_length 128 --eval_steps 100 ',
   },
 
   local v2 = common.tpuVmBaseImage {


### PR DESCRIPTION
* Add evaluation step in command
* Test in v2-8, v3-8, and v4-8
  * flax-latest-hf-bert-mrpc-func-v2-8-1vm-v5v2g
  * flax-latest-hf-bert-mrpc-func-v3-8-1vm-vj6zj
  * flax-latest-hf-bert-mrpc-func-v4-8-1vm-z5ppw