### PR TITLE
Make `run-oneshot.sh` less flaky

### DIFF
--- a/scripts/run-oneshot.sh
+++ b/scripts/run-oneshot.sh
@@ -84,11 +84,10 @@ run()
     jsonnet tests/oneshot.jsonnet -J . -S --tla-str test=$test_name > $temp_file
 
     job_name=$(kubectl create -f $temp_file -o name)
-    pod_name=$(kubectl get pod -l job-name=${job_name#job.batch/} -o name)
 
-    echo "GKE pod name: ${pod_name#pod/}"
-    kubectl wait --for=condition=ready --timeout=10m $pod_name
-    kubectl logs -f $pod_name --container=train
+    echo "GKE job name: ${job_name#job.batch/}"
+    kubectl wait --for=condition=ready --timeout=10m pod -l job-name=${job_name#job.batch/}
+    kubectl logs -f $job_name
   else
     echo "gcloud container clusters get-credentials $CLUSTER --region $region --project xl-ml-test"
     jsonnet tests/oneshot.jsonnet -J . -S --tla-str test=$test_name


### PR DESCRIPTION
`kubectl` will occasionally not get a pod name in time and the script will exit without getting any logs. Wait for any pod with the correct `job-name` label to become ready before streaming logs instead.