### PR TITLE
Enable cross-account publish on event-publisher

### DIFF
--- a/metrics/publisher/event_publisher.py
+++ b/metrics/publisher/event_publisher.py
@@ -160,7 +160,10 @@ def main(argv):
   cluster_name = FLAGS.cluster_name or _get_metadata('cluster-name')
   cluster_location = FLAGS.cluster_location or _get_metadata('cluster-location')
 
-  topic = f'projects/{project}/topics/{FLAGS.pubsub_topic}'
+  if re.match('^projects/[^/]+/topics/[^/]+$', FLAGS.pubsub_topic):
+    topic = FLAGS.pubsub_topic
+  else:
+    topic = f'projects/{project}/topics/{FLAGS.pubsub_topic}'
   publisher = pubsub_v1.PublisherClient()
 
   while True:


### PR DESCRIPTION
1VM tests provisioned using QueuedResources are hosted in a separate project, so to minimize infrastructure duplication the event publisher should be able to publish cross-account directly to the main project's metrics topic. This requires that `--topic` accepts a full topic resource name.

For backwards compatibility, the `--topic` flag will continue to accept the shorthand topic name for topics within the same project as the publisher.