### PR TITLE
Fix libtpu version prefix in PT TPU Node tests

### DIFF
--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -67,7 +67,7 @@ local volumes = import 'templates/volumes.libsonnet';
 
                 ctc = cloud_tpu_client.Client(tpu=os.path.basename('$(TPU_NAME)'), zone=os.path.dirname('$(TPU_NAME)'))
                 ctc.wait_for_healthy()
-                ctc.configure_tpu_version(f'pytorch-0.5-dev{libtpu_date}', restart_type='always')
+                ctc.configure_tpu_version(f'pytorch-nightly-dev{libtpu_date}', restart_type='always')
                 ctc.wait_for_healthy()
               |||,
             ],


### PR DESCRIPTION
`pytorch-0.5` is deprecated. Tested that this prefix works with a manual run.