### PR TITLE
Add '-W default' to pytest to fix test failure due to warning message

### DIFF
--- a/tests/jax/unit-tests.libsonnet
+++ b/tests/jax/unit-tests.libsonnet
@@ -46,7 +46,7 @@ local mixins = import 'templates/mixins.libsonnet';
       export COLUMNS=160
       # Remove 'Captured stdout call' due to b/181896778
       python3 -u -m pytest --tb=short --continue-on-collection-errors \
-          tests examples | sed 's/Captured stdout call/output/'
+         -W default tests examples | sed 's/Captured stdout call/output/'
       exit ${PIPESTATUS[0]}
     ||| % self.scriptConfig,
   },


### PR DESCRIPTION
…ssage

DETAILS:

without the flag '-W default', tests/compilation_cache_test.py appears to be failed due to warning messages.

TESTED:
ran one-off jax-head-tpu-vm-base-func-v2-8-1vm-kv865 and passed tests/compilation_cache_test