### PR TITLE
Fix jax compilatioin cache test

### DIFF
--- a/tests/jax/compilation-cache.libsonnet
+++ b/tests/jax/compilation-cache.libsonnet
@@ -48,10 +48,13 @@ local mixins = import 'templates/mixins.libsonnet';
       from jax import pmap, lax
       from jax._src.util import prod
       import numpy as np
-
+      from jax._src.config import config
+      original_jax_persistent_cache_min_instruction_count = config.jax_persistent_cache_min_instruction_count
+      config.update('jax_persistent_cache_min_instruction_count', 0)
       cc.initialize_cache("/tmp/compilation_cache_integration_test")
       f = pmap(lambda x: x - lax.psum(x, 'i'), axis_name='i')
       print(f(np.arange(8)))
+      config.update('jax_persistent_cache_min_instruction_count', original_jax_persistent_cache_min_instruction_count)
       END_SCRIPT
 
       cat >directory_size.py <<'END_SCRIPT'

--- a/tests/jax/unit-tests.libsonnet
+++ b/tests/jax/unit-tests.libsonnet
@@ -14,6 +14,7 @@
 
 local common = import 'common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
+local timeouts = import 'templates/timeouts.libsonnet';
 
 {
   local runUnitTests = common.JaxTest + mixins.Functional {
@@ -52,9 +53,9 @@ local mixins = import 'templates/mixins.libsonnet';
   },
 
   configs: [
-    runUnitTests + common.jaxlibHead + common.tpuVmBaseImage,
-    runUnitTests + common.jaxlibLatest + common.tpuVmBaseImage,
-    runUnitTests + common.jaxlibHead + common.tpuVmV4Base,
-    runUnitTests + common.jaxlibLatest + common.tpuVmV4Base,
+    runUnitTests + common.jaxlibHead + timeouts.Minutes(90) + common.tpuVmBaseImage,
+    runUnitTests + common.jaxlibLatest + timeouts.Minutes(90) + common.tpuVmBaseImage,
+    runUnitTests + common.jaxlibHead + timeouts.Minutes(90) + common.tpuVmV4Base,
+    runUnitTests + common.jaxlibLatest + timeouts.Minutes(90) + common.tpuVmV4Base,
   ],
 }


### PR DESCRIPTION
DETAILS:
Current computation has num of instruction = 5 which is below threshold=6, set threshold=0 to fix the test.

TESTED:
passed one-off test on
job.batch/jax-compilation-cache-test-func-v2-8-1vm-wmfq7