### PR TITLE
Extend jax test to 90 mins

### DIFF
--- a/tests/jax/unit-tests.libsonnet
+++ b/tests/jax/unit-tests.libsonnet
@@ -14,6 +14,7 @@
 
 local common = import 'common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
+local timeouts = import 'templates/timeouts.libsonnet';
 
 {
   local runUnitTests = common.JaxTest + mixins.Functional {
@@ -52,9 +53,9 @@ local mixins = import 'templates/mixins.libsonnet';
   },
 
   configs: [
-    runUnitTests + common.jaxlibHead + common.tpuVmBaseImage,
-    runUnitTests + common.jaxlibLatest + common.tpuVmBaseImage,
-    runUnitTests + common.jaxlibHead + common.tpuVmV4Base,
-    runUnitTests + common.jaxlibLatest + common.tpuVmV4Base,
+    runUnitTests + common.jaxlibHead + timeouts.Minutes(90) + common.tpuVmBaseImage,
+    runUnitTests + common.jaxlibLatest + timeouts.Minutes(90) + common.tpuVmBaseImage,
+    runUnitTests + common.jaxlibHead + timeouts.Minutes(90) + common.tpuVmV4Base,
+    runUnitTests + common.jaxlibLatest + timeouts.Minutes(90) + common.tpuVmV4Base,
   ],
 }


### PR DESCRIPTION
DETAILS:
- both two v4 jax tests are timeout within 1 hour, extend them to 90 mins
- v2 jax tests finishes at 1 hour boundary, also extend them to 90 mins 

TESTED:
ran jax-head-tpu-vm-v4-base-func-v4-8-1vm-xmsvk
ran jax-head-tpu-vm-base-func-v2-8-1vm-btxh