### PR TITLE
Fix jax compilatioin cache test

### DIFF
--- a/tests/jax/compilation-cache.libsonnet
+++ b/tests/jax/compilation-cache.libsonnet
@@ -48,7 +48,9 @@ local mixins = import 'templates/mixins.libsonnet';
       from jax import pmap, lax
       from jax._src.util import prod
       import numpy as np
+      from jax._src.config import config
 
+      config.update('jax_persistent_cache_min_instruction_count', 0)
       cc.initialize_cache("/tmp/compilation_cache_integration_test")
       f = pmap(lambda x: x - lax.psum(x, 'i'), axis_name='i')
       print(f(np.arange(8)))


### PR DESCRIPTION
DETAILS:
Current computation has num of instruction = 5 which is below threshold=6, set threshold=0 to fix the test.

TESTED:
passed one-off test on
job.batch/jax-compilation-cache-test-func-v2-8-1vm-wmfq7