### PR TITLE
Fix jax compilation cache test

### DIFF
--- a/tests/jax/compilation-cache.libsonnet
+++ b/tests/jax/compilation-cache.libsonnet
@@ -46,11 +46,11 @@ local mixins = import 'templates/mixins.libsonnet';
       import jax
       from jax.experimental.compilation_cache import compilation_cache as cc
       from jax import pmap, lax
+      from jax._src.config import config
       from jax._src.util import prod
       import numpy as np
-      from jax._src.config import config
 
-      config.update('jax_persistent_cache_min_instruction_count', 0)
+      config.update('jax_persistent_cache_min_compile_time_secs', 0)
       cc.initialize_cache("/tmp/compilation_cache_integration_test")
       f = pmap(lambda x: x - lax.psum(x, 'i'), axis_name='i')
       print(f(np.arange(8)))


### PR DESCRIPTION
DETAILS:
Recent jax update threshold to be
jax_persistent_cache_min_compile_time_secs, set it to be zero to fix the test.

TESTED:
passed one-off test on
job_name=job.batch/jax-compilation-cache-test-func-v2-8-1vm-tkqhf