### PR TITLE
fix flax-latest-hf-bert-mnli-func-v2-8 timeout

### DIFF
--- a/tests/jax/latest/hf-glue.libsonnet
+++ b/tests/jax/latest/hf-glue.libsonnet
@@ -106,7 +106,7 @@ local utils = import 'templates/utils.libsonnet';
     hf_bert_common + mnli + functional + v3 + v3_8,
     hf_bert_common + mrpc + functional + v3 + v3_8,
 
-    hf_bert_common + mnli + functional + v2 + v2_8,
+    hf_bert_common + mnli + functional + v2 + v2_8 + timeouts.Minutes(75),
     hf_bert_common + mrpc + functional + v2 + v2_8,
   ],
 }


### PR DESCRIPTION
This test usually takes about an hour to run, extend the time limit. TESTED=flax-latest-hf-bert-mnli-func-v2-8-1vm-85b5b