### PR TITLE
Add HuggingFace Bart Tests

### DIFF
--- a/tests/jax/latest/hf-bart.libsonnet
+++ b/tests/jax/latest/hf-bart.libsonnet
@@ -1,0 +1,115 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local common = import '../common.libsonnet';
+local mixins = import 'templates/mixins.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+
+{
+  local hf_bart_common = common.JaxTest + common.huggingFace {
+    local config = self,
+    frameworkPrefix: 'flax-latest',
+    modelName:: 'hf-bart',
+    extraFlags:: '',
+    testScript:: |||
+      %(installPackages)s
+      pip install -r examples/flax/summarization/requirements.txt
+      %(verifySetup)s
+
+      export GCS_BUCKET=$(MODEL_DIR)
+      python3 examples/flax/summarization/run_summarization_flax.py \
+        --output_dir './bart-base-wiki' \
+        --model_name_or_path facebook/bart-base \
+        --tokenizer_name facebook/bart-base \
+        --dataset_name 'wiki_summary' \
+        --do_train \
+        --do_eval \
+        --do_predict \
+        --predict_with_generate \
+        --learning_rate 5e-5 \
+        --warmup_steps 0 \
+        --per_device_train_batch_size 32 \
+        --per_device_eval_batch_size 32 \
+        --max_source_length 512 \
+        --max_target_length 64 \
+        %(extraFlags)s
+
+      # Ignore CommandException for the rest workers in TPU pod
+      gsutil -m cp -r ./bart-base-wiki $(MODEL_DIR) || exit 0
+    ||| % (self.scriptConfig { extraFlags: config.extraFlags }),
+  },
+
+  local func = mixins.Functional {
+    extraFlags+:: '--num_train_epochs 3 \\',
+  },
+  local conv = mixins.Convergence {
+    extraFlags+:: '--num_train_epochs 30 \\',
+
+    metricConfig+: {
+      sourceMap+:: {
+        tensorboard+: {
+          aggregateAssertionsMap+:: {
+            train_loss: {
+              FINAL: {
+                fixed_value: {
+                  comparison: 'LESS',
+                  value: 1.0,
+                },
+                inclusive_bounds: false,
+                wait_for_n_data_points: 0,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  local tpuVm = common.tpuVmBaseImage,
+  local tpuVmV4 = common.tpuVmV4Base,
+
+  local v2_8 = {
+    accelerator: tpus.v2_8,
+  },
+  local v2_32 = {
+    accelerator: tpus.v2_32,
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+  local v3_32 = {
+    accelerator: tpus.v3_32,
+  },
+  local v4_8 = {
+    accelerator: tpus.v4_8,
+  },
+  local v4_32 = {
+    accelerator: tpus.v4_32,
+  },
+
+  local func_tests = [
+    hf_bart_common + func + tpuVm + v2_8,
+    hf_bart_common + func + tpuVm + v2_32,
+    hf_bart_common + func + tpuVm + v3_8,
+    hf_bart_common + func + tpuVm + v3_32,
+    hf_bart_common + func + tpuVmV4 + v4_8,
+    hf_bart_common + func + tpuVmV4 + v4_32,
+  ],
+
+  local conv_tests = [
+    hf_bart_common + conv + tpuVmV4 + v4_32,
+  ],
+
+  configs: func_tests + conv_tests,
+}

--- a/tests/jax/latest/hf-bart.libsonnet
+++ b/tests/jax/latest/hf-bart.libsonnet
@@ -76,39 +76,36 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local tpuVm = common.tpuVmBaseImage,
-  local tpuVmV4 = common.tpuVmV4Base,
-
-  local v2_8 = {
+  local v2_8 = common.tpuVmBaseImage {
     accelerator: tpus.v2_8,
   },
-  local v2_32 = {
+  local v2_32 = common.tpuVmBaseImage {
     accelerator: tpus.v2_32,
   },
-  local v3_8 = {
+  local v3_8 = common.tpuVmBaseImage {
     accelerator: tpus.v3_8,
   },
-  local v3_32 = {
+  local v3_32 = common.tpuVmBaseImage {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = {
+  local v4_8 = common.tpuVmV4Base {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = {
+  local v4_32 = common.tpuVmV4Base {
     accelerator: tpus.v4_32,
   },
 
   local func_tests = [
-    hf_bart_common + func + tpuVm + v2_8,
-    hf_bart_common + func + tpuVm + v2_32,
-    hf_bart_common + func + tpuVm + v3_8,
-    hf_bart_common + func + tpuVm + v3_32,
-    hf_bart_common + func + tpuVmV4 + v4_8,
-    hf_bart_common + func + tpuVmV4 + v4_32,
+    hf_bart_common + func + v2_8,
+    hf_bart_common + func + v2_32,
+    hf_bart_common + func + v3_8,
+    hf_bart_common + func + v3_32,
+    hf_bart_common + func + v4_8,
+    hf_bart_common + func + v4_32,
   ],
 
   local conv_tests = [
-    hf_bart_common + conv + tpuVmV4 + v4_32,
+    hf_bart_common + conv + v4_32,
   ],
 
   configs: func_tests + conv_tests,

--- a/tests/jax/latest/targets.jsonnet
+++ b/tests/jax/latest/targets.jsonnet
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License,
 
+local hf_bart = import 'hf-bart.libsonnet';
 local hf_glue = import 'hf-glue.libsonnet';
 local hf_vit = import 'hf-vit.libsonnet';
 local imagenet = import 'imagenet.libsonnet';
@@ -20,6 +21,7 @@ local wmt = import 'wmt.libsonnet';
 
 // Add new models here
 std.flattenArrays([
+  hf_bart.configs,
   hf_vit.configs,
   hf_glue.configs,
   imagenet.configs,


### PR DESCRIPTION
* Context: 
  * Bart uses a standard seq2seq/machine translation architecture with a bidirectional encoder (like BERT) and a left-to-right decoder (like GPT).
  * Bart is particularly effective when fine tuned for text generation but also works well for comprehension tasks.
  * Bart model is popular in HuggingFace with millions of downloads last month
* Integrate with HuggingFace to add Bart with summarization tasks in JAX
* Add functional tests for v2, v3, v4 and convergence test for v4
* Tests below have passed:
  * v2-8 func: flax-latest-hf-bart-func-v2-8-1vm-qs8hj
  * v4-8 func: flax-latest-hf-bart-func-v4-8-1vm-f29kh
  * v4-32 func: flax-latest-hf-bart-func-v4-32-1vm-mqtrl
  * v4-32 conv: flax-latest-hf-bart-conv-v4-32-1vm-wfvn7