### PR TITLE
Reduce batch size for pods in Bart tests

### DIFF
--- a/tests/jax/latest/hf-bart.libsonnet
+++ b/tests/jax/latest/hf-bart.libsonnet
@@ -39,8 +39,6 @@ local tpus = import 'templates/tpus.libsonnet';
         --predict_with_generate \
         --learning_rate 5e-5 \
         --warmup_steps 0 \
-        --per_device_train_batch_size 32 \
-        --per_device_eval_batch_size 32 \
         --max_source_length 512 \
         --max_target_length 64 \
         %(extraFlags)s
@@ -78,21 +76,27 @@ local tpus = import 'templates/tpus.libsonnet';
 
   local v2_8 = common.tpuVmBaseImage {
     accelerator: tpus.v2_8,
+    extraFlags+:: '--per_device_train_batch_size 32 --per_device_eval_batch_size 32',
   },
   local v2_32 = common.tpuVmBaseImage {
     accelerator: tpus.v2_32,
+    extraFlags+:: '--per_device_train_batch_size 8 --per_device_eval_batch_size 8',
   },
   local v3_8 = common.tpuVmBaseImage {
     accelerator: tpus.v3_8,
+    extraFlags+:: '--per_device_train_batch_size 32 --per_device_eval_batch_size 32',
   },
   local v3_32 = common.tpuVmBaseImage {
     accelerator: tpus.v3_32,
+    extraFlags+:: '--per_device_train_batch_size 16 --per_device_eval_batch_size 16',
   },
   local v4_8 = common.tpuVmV4Base {
     accelerator: tpus.v4_8,
+    extraFlags+:: '--per_device_train_batch_size 64 --per_device_eval_batch_size 64',
   },
   local v4_32 = common.tpuVmV4Base {
     accelerator: tpus.v4_32,
+    extraFlags+:: '--per_device_train_batch_size 32 --per_device_eval_batch_size 32',
   },
 
   local func_tests = [


### PR DESCRIPTION
* Noticed v2-32 and v3-32 failures due to HLO operation-level constraints
  * https://screenshot.googleplex.com/3qtLq8NBMm3wtfF
  * https://screenshot.googleplex.com/BcC9MhN6S3zp7cB 
* Reduce batch size for v2-32 from 32 to 8, and v3-32 from 32 to 16
* Increase batch size for v4-8 from 32 to 64
* Tests:
  * flax-latest-hf-bart-func-v2-32-1vm-g8xqq  
  * flax-latest-hf-bart-func-v3-32-1vm-bjf7x
  * flax-latest-hf-bart-func-v4-8-1vm-6w9sj