### PR TITLE
Convert extraFlags in Flax tests to a list

### DIFF
--- a/tests/jax/latest/common.libsonnet
+++ b/tests/jax/latest/common.libsonnet
@@ -20,8 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
     local config = self,
 
     frameworkPrefix: 'flax-latest',
-    extraDeps:: '',
-    extraFlags:: '',
+    extraDeps:: [],
+    extraFlags:: [],
 
     testScript:: |||
       set -x
@@ -55,9 +55,9 @@ local tpus = import 'templates/tpus.libsonnet';
       python3 main.py --workdir=$(MODEL_DIR)  --config=configs/%(extraConfig)s %(extraFlags)s
     ||| % (self.scriptConfig {
              modelName: config.modelName,
-             extraDeps: config.extraDeps,
+             extraDeps: std.join(' ', config.extraDeps),
              extraConfig: config.extraConfig,
-             extraFlags: config.extraFlags,
+             extraFlags: std.join(' ', config.extraFlags),
            }),
   },
 }

--- a/tests/jax/latest/hf-bart.libsonnet
+++ b/tests/jax/latest/hf-bart.libsonnet
@@ -21,7 +21,7 @@ local tpus = import 'templates/tpus.libsonnet';
     local config = self,
     frameworkPrefix: 'flax-latest',
     modelName:: 'hf-bart',
-    extraFlags:: '',
+    extraFlags:: [],
     testScript:: |||
       %(installPackages)s
       pip install -r examples/flax/summarization/requirements.txt
@@ -45,14 +45,14 @@ local tpus = import 'templates/tpus.libsonnet';
 
       # Ignore CommandException for the rest workers in TPU pod
       gsutil -m cp -r ./bart-base-wiki $(MODEL_DIR) || exit 0
-    ||| % (self.scriptConfig { extraFlags: config.extraFlags }),
+    ||| % (self.scriptConfig { extraFlags: std.join(' ', config.extraFlags) }),
   },
 
   local func = mixins.Functional {
-    extraFlags+:: '--num_train_epochs 3 \\',
+    extraFlags+:: ['--num_train_epochs 3'],
   },
   local conv = mixins.Convergence {
-    extraFlags+:: '--num_train_epochs 30 \\',
+    extraFlags+:: ['--num_train_epochs 30'],
 
     metricConfig+: {
       sourceMap+:: {
@@ -76,27 +76,27 @@ local tpus = import 'templates/tpus.libsonnet';
 
   local v2_8 = common.tpuVmBaseImage {
     accelerator: tpus.v2_8,
-    extraFlags+:: '--per_device_train_batch_size 32 --per_device_eval_batch_size 32',
+    extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
   local v2_32 = common.tpuVmBaseImage {
     accelerator: tpus.v2_32,
-    extraFlags+:: '--per_device_train_batch_size 8 --per_device_eval_batch_size 8',
+    extraFlags+:: ['--per_device_train_batch_size 8', '--per_device_eval_batch_size 8'],
   },
   local v3_8 = common.tpuVmBaseImage {
     accelerator: tpus.v3_8,
-    extraFlags+:: '--per_device_train_batch_size 32 --per_device_eval_batch_size 32',
+    extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
   local v3_32 = common.tpuVmBaseImage {
     accelerator: tpus.v3_32,
-    extraFlags+:: '--per_device_train_batch_size 16 --per_device_eval_batch_size 16',
+    extraFlags+:: ['--per_device_train_batch_size 16', '--per_device_eval_batch_size 16'],
   },
   local v4_8 = common.tpuVmV4Base {
     accelerator: tpus.v4_8,
-    extraFlags+:: '--per_device_train_batch_size 64 --per_device_eval_batch_size 64',
+    extraFlags+:: ['--per_device_train_batch_size 64', '--per_device_eval_batch_size 64'],
   },
   local v4_32 = common.tpuVmV4Base {
     accelerator: tpus.v4_32,
-    extraFlags+:: '--per_device_train_batch_size 32 --per_device_eval_batch_size 32',
+    extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
 
   local func_tests = [

--- a/tests/jax/latest/hf-glue.libsonnet
+++ b/tests/jax/latest/hf-glue.libsonnet
@@ -22,7 +22,7 @@ local utils = import 'templates/utils.libsonnet';
     local config = self,
     frameworkPrefix: 'flax-latest',
     modelName:: 'hf-bert',
-    extraFlags:: '',
+    extraFlags:: [],
     testScript:: |||
       %(installPackages)s
       pip install -r examples/flax/text-classification/requirements.txt
@@ -37,17 +37,17 @@ local utils = import 'templates/utils.libsonnet';
         --per_device_train_batch_size 4 \
         %(extraFlags)s
       gsutil -m cp -r ${OUTPUT_DIR} $(MODEL_DIR)
-    ||| % (self.scriptConfig { extraFlags: config.extraFlags }),
+    ||| % (self.scriptConfig { extraFlags: std.join(' ', config.extraFlags) }),
   },
 
   local functional = mixins.Functional {
-    extraFlags+: '--num_train_epochs 1 ',
+    extraFlags+: ['--num_train_epochs 1'],
     extraConfig:: 'default.py',
   },
 
   local convergence = mixins.Convergence {
     extraConfig:: 'default.py',
-    extraFlags+: '--num_train_epochs 3 --learning_rate 2e-5 --eval_steps 500 ',
+    extraFlags+: ['--num_train_epochs 3', '--learning_rate 2e-5', '--eval_steps 500'],
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -70,21 +70,21 @@ local utils = import 'templates/utils.libsonnet';
 
   local mnli = {
     modelName+: '-mnli',
-    extraFlags+: '--task_name mnli --max_seq_length 512 --eval_steps 1000 ',
+    extraFlags+: ['--task_name mnli', '--max_seq_length 512', '--eval_steps 1000'],
   },
   local mrpc = {
     modelName+: '-mrpc',
-    extraFlags+: '--task_name mrpc --max_seq_length 128 --eval_steps 100 ',
+    extraFlags+: ['--task_name mrpc', '--max_seq_length 128', '--eval_steps 100'],
   },
 
   local v2 = common.tpuVmBaseImage {
-    extraFlags+:: '--per_device_train_batch_size 4 --per_device_eval_batch_size 4',
+    extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
   },
   local v3 = common.tpuVmBaseImage {
-    extraFlags+:: '--per_device_train_batch_size 4 --per_device_eval_batch_size 4',
+    extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
   },
   local v4 = common.tpuVmV4Base {
-    extraFlags+:: '--per_device_train_batch_size 8 --per_device_eval_batch_size 8',
+    extraFlags+:: ['--per_device_train_batch_size 8', '--per_device_eval_batch_size 8'],
   },
 
   local v2_8 = {

--- a/tests/jax/latest/hf-vit.libsonnet
+++ b/tests/jax/latest/hf-vit.libsonnet
@@ -21,7 +21,7 @@ local tpus = import 'templates/tpus.libsonnet';
     local config = self,
     frameworkPrefix: 'flax-latest',
     modelName:: 'hf-vit',
-    extraFlags:: '',
+    extraFlags:: [],
     testScript:: |||
       %(installPackages)s
       pip install -r examples/flax/vision/requirements.txt
@@ -41,14 +41,14 @@ local tpus = import 'templates/tpus.libsonnet';
 
       # Ignore CommandException for the rest workers in TPU pod
       gsutil -m cp -r ./vit-imagenette $(MODEL_DIR) || exit 0
-    ||| % (self.scriptConfig { extraFlags: config.extraFlags }),
+    ||| % (self.scriptConfig { extraFlags: std.join(' ', config.extraFlags) }),
   },
 
   local func = mixins.Functional {
-    extraFlags+:: '--model_type vit --num_train_epochs 5 \\',
+    extraFlags+:: ['--model_type vit', '--num_train_epochs 5'],
   },
   local conv = mixins.Convergence {
-    extraFlags+:: '--model_name_or_path google/vit-base-patch16-224-in21k --num_train_epochs 30 \\',
+    extraFlags+:: ['--model_name_or_path google/vit-base-patch16-224-in21k', '--num_train_epochs 30'],
 
     metricConfig+: {
       sourceMap+:: {
@@ -71,13 +71,13 @@ local tpus = import 'templates/tpus.libsonnet';
   },
 
   local v2 = common.tpuVmBaseImage {
-    extraFlags+:: '--per_device_train_batch_size 32 --per_device_eval_batch_size 32',
+    extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
   local v3 = common.tpuVmBaseImage {
-    extraFlags+:: '--per_device_train_batch_size 32 --per_device_eval_batch_size 32',
+    extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
   local v4 = common.tpuVmV4Base {
-    extraFlags+:: '--per_device_train_batch_size 64 --per_device_eval_batch_size 64',
+    extraFlags+:: ['--per_device_train_batch_size 64', '--per_device_eval_batch_size 64'],
   },
 
   local v2_8 = {

--- a/tests/jax/latest/imagenet.libsonnet
+++ b/tests/jax/latest/imagenet.libsonnet
@@ -17,7 +17,7 @@ local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
   local functional = mixins.Functional {
-    extraFlags:: '--config.num_epochs=1',
+    extraFlags+:: ['--config.num_epochs=1'],
     extraConfig:: 'default.py',
   },
   local convergence = mixins.Convergence {
@@ -31,7 +31,7 @@ local tpus = import 'templates/tpus.libsonnet';
   },
   local v3_32 = {
     accelerator: tpus.v3_32,
-    extraFlags+:: ' --config.batch_size=$((32*256))',
+    extraFlags+:: ['--config.batch_size=$((32*256))'],
   },
   local imagenet = common.runFlaxLatest {
     modelName:: 'imagenet',

--- a/tests/jax/latest/mnist.libsonnet
+++ b/tests/jax/latest/mnist.libsonnet
@@ -17,7 +17,7 @@ local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
   local functional = mixins.Functional {
-    extraFlags:: '--config.num_epochs=1',
+    extraFlags+:: ['--config.num_epochs=1'],
     extraConfig:: 'default.py',
   },
   local convergence = mixins.Convergence {
@@ -31,7 +31,7 @@ local tpus = import 'templates/tpus.libsonnet';
   },
   local v3_32 = {
     accelerator: tpus.v3_32,
-    extraFlags+:: ' --config.batch_size=$((32*256))',
+    extraFlags+:: ['--config.batch_size=$((32*256))'],
   },
   local mnist = common.runFlaxLatest {
     modelName:: 'mnist',

--- a/tests/jax/latest/wmt.libsonnet
+++ b/tests/jax/latest/wmt.libsonnet
@@ -18,12 +18,12 @@ local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
   local functional = mixins.Functional {
-    extraFlags:: '--config.num_train_steps=10 --config.per_device_batch_size=16',
+    extraFlags+:: ['--config.num_train_steps=10', '--config.per_device_batch_size=16'],
     extraConfig:: 'default.py',
   },
   local convergence = mixins.Convergence {
     extraConfig:: 'default.py',
-    extraFlags:: '--config.reverse_translation=True  --config.per_device_batch_size=32',
+    extraFlags+:: ['--config.reverse_translation=True', '--config.per_device_batch_size=32'],
   },
   local v3_8 = {
     accelerator: tpus.v3_8,
@@ -33,7 +33,7 @@ local tpus = import 'templates/tpus.libsonnet';
   },
   local wmt = common.runFlaxLatest {
     modelName:: 'wmt',
-    extraDeps:: 'tensorflow_text sentencepiece',
+    extraDeps+:: ['tensorflow_text sentencepiece'],
   },
   configs: [
     wmt + functional + v2_8,


### PR DESCRIPTION
This change updates the `extraFlags` and `extraDeps` fields to be lists rather than strings.

This catches a few bugs with the flags (e.g. extra backslash in `--num_train_epochs 3 \--per_device_train_batch_size 16`), which may result in a change in behavior of the tests.