### PR TITLE
Adding profiler test for the WMT JAX model

### DIFF
--- a/tests/jax/latest/wmt.libsonnet
+++ b/tests/jax/latest/wmt.libsonnet
@@ -25,6 +25,12 @@ local tpus = import 'templates/tpus.libsonnet';
     extraConfig:: 'default.py',
     extraFlags+:: ['--config.reverse_translation=True', '--config.per_device_batch_size=32'],
   },
+  local profile = {
+    mode: 'profile',
+    timeout: timeouts.one_hour,
+    extraFlags+:: ['--config.num_train_steps=40', '--config.per_device_batch_size=16'],
+    extraConfig:: 'default.py',
+  },
   local v3_8 = {
     accelerator: tpus.v3_8,
   },
@@ -35,8 +41,15 @@ local tpus = import 'templates/tpus.libsonnet';
     modelName:: 'wmt',
     extraDeps+:: ['tensorflow_text sentencepiece'],
   },
+  local wmt_profiling = wmt {
+    local config = self,
+    testScript+:: |||
+       gsutil -q stat $(MODEL_DIR)/plugins/profile/*/*.xplane.pb
+    ||| % (self.scriptConfig{}),
+  },
   configs: [
     wmt + functional + v2_8,
     wmt + convergence + v3_8 + timeouts.Hours(20),
+    wmt_profiling + profile + v3_8,
   ],
 }

--- a/tests/jax/latest/wmt.libsonnet
+++ b/tests/jax/latest/wmt.libsonnet
@@ -25,7 +25,7 @@ local tpus = import 'templates/tpus.libsonnet';
     extraConfig:: 'default.py',
     extraFlags+:: ['--config.reverse_translation=True', '--config.per_device_batch_size=32'],
   },
-  local profile = {
+  local profile = mixins.Functional {
     mode: 'profile',
     timeout: timeouts.one_hour,
     extraFlags+:: ['--config.num_train_steps=40', '--config.per_device_batch_size=16'],
@@ -39,7 +39,7 @@ local tpus = import 'templates/tpus.libsonnet';
   },
   local wmt = common.runFlaxLatest {
     modelName:: 'wmt',
-    extraDeps+:: ['tensorflow_text sentencepiece'],
+    extraDeps+:: ['tensorflow_text sentencepiece', 'protobuf==3.20.*', 'tensorflow_datasets'],
   },
   local wmt_profiling = wmt {
     local config = self,

--- a/tests/pytorch/nightly/python-ops.libsonnet
+++ b/tests/pytorch/nightly/python-ops.libsonnet
@@ -39,9 +39,21 @@ local utils = import 'templates/utils.libsonnet';
   local v3_8 = {
     accelerator: tpus.v3_8,
   },
+  local tpuVm = common.PyTorchTpuVmMixin {
+    tpuSettings+: {
+      tpuVmExports+: |||
+        export XLA_USE_BF16=$(XLA_USE_BF16)
+      |||,
+      tpuVmExtraSetup: |||
+        echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
+        echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
+      |||,
+    },
+  },
+
 
   configs: [
-    operations + v2_8 + common.Functional + timeouts.Hours(6),
-    operations + v3_8 + common.Functional + timeouts.Hours(6),
+    operations + v2_8 + common.Functional + timeouts.Hours(6) + tpuVm,
+    operations + v3_8 + common.Functional + timeouts.Hours(6) + tpuVm,
   ],
 }


### PR DESCRIPTION
Goal: To add a profiler test for the WMT model and check that gsutil is able to locate the trace file.
```
./scripts/list-tests.sh | grep "flax-latest-wmt"
flax-latest-wmt-conv-v3-8-1vm
flax-latest-wmt-func-v2-8-1vm
flax-latest-wmt-profile-v3-8-1vm
```
Here flax-latest-wmt-profile-v3-8-1vm is the newly added test

```
./scripts/run-oneshot.sh -t $TEST_NAME
...
+ gsutil -q stat 'gs://xl-ml-test-us-central1/output/flax-latest/wmt/profile/v3-8/flax-latest-wmt-profile-v3-8-1vm-8mk2d/plugins/profile/*/*.xplane.pb'
+ exit_code=0
...
```
In the future, this exit code will be used to build logic to verify the trace programmatically.


