### PR TITLE
[Migrate Tests from TPU2VM to TPUVM] Moving python op tests from TPU2VM to TPUVM on xl-ml-test

### DIFF
--- a/tests/pytorch/nightly/python-ops.libsonnet
+++ b/tests/pytorch/nightly/python-ops.libsonnet
@@ -39,9 +39,24 @@ local utils = import 'templates/utils.libsonnet';
   local v3_8 = {
     accelerator: tpus.v3_8,
   },
+  local tpuVm = common.PyTorchTpuVmMixin {
+    tpuSettings+: {
+      tpuVmExports+: |||
+        export XLA_USE_BF16=$(XLA_USE_BF16)
+      |||,
+      tpuVmExtraSetup: |||
+        pip install tensorboardX google-cloud-storage
+        git clone --recursive https://github.com/pytorch-tpu/examples.git tpu-examples/
+        pip install --editable ./tpu-examples/deps/fairseq
+        echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
+        echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
+      |||,
+    },
+  },
+
 
   configs: [
-    operations + v2_8 + common.Functional + timeouts.Hours(6),
-    operations + v3_8 + common.Functional + timeouts.Hours(6),
+    operations + v2_8 + common.Functional + timeouts.Hours(6) + tpuVm,
+    operations + v3_8 + common.Functional + timeouts.Hours(6) + tpuVm,
   ],
 }

--- a/tests/pytorch/nightly/python-ops.libsonnet
+++ b/tests/pytorch/nightly/python-ops.libsonnet
@@ -45,9 +45,8 @@ local utils = import 'templates/utils.libsonnet';
         export XLA_USE_BF16=$(XLA_USE_BF16)
       |||,
       tpuVmExtraSetup: |||
-        pip install tensorboardX google-cloud-storage
+        pip install google-cloud-storage
         git clone --recursive https://github.com/pytorch-tpu/examples.git tpu-examples/
-        pip install --editable ./tpu-examples/deps/fairseq
         echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
         echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
       |||,

--- a/tests/pytorch/nightly/python-ops.libsonnet
+++ b/tests/pytorch/nightly/python-ops.libsonnet
@@ -45,8 +45,6 @@ local utils = import 'templates/utils.libsonnet';
         export XLA_USE_BF16=$(XLA_USE_BF16)
       |||,
       tpuVmExtraSetup: |||
-        pip install google-cloud-storage
-        git clone --recursive https://github.com/pytorch-tpu/examples.git tpu-examples/
         echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
         echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
       |||,


### PR DESCRIPTION
After tested python op tests locally in TPUVM environment, failed python op tests has been disabled in https://github.com/pytorch/xla/pull/4299;

To let xl-ml-test start to test python op tests under PyTorch/XLA-nightly on TPUVM, modify the `tests/pytorch/nightly/python-ops.libsonnet` to do this test environment change.