### PR TITLE
Add test for HF VIT MAE

### DIFF
--- a/tests/pytorch/nightly/hf-glue.libsonnet
+++ b/tests/pytorch/nightly/hf-glue.libsonnet
@@ -82,7 +82,7 @@ local utils = import 'templates/utils.libsonnet';
         '--overwrite_cache=true',
         '--tpu_metrics_debug=true',
         '--per_device_train_batch_size=%d ' % config.paramsOverride.per_device_train_batch_size,
-        '--per_device_eval_batch_size=%d ' % config.paramsOverride.per_device_train_batch_size,
+        '--per_device_eval_batch_size=%d ' % config.paramsOverride.per_device_eval_batch_size,
       ],
     },
     command: utils.scriptCommand(

--- a/tests/pytorch/nightly/hf-mae.libsonnet
+++ b/tests/pytorch/nightly/hf-mae.libsonnet
@@ -23,7 +23,7 @@ local utils = import 'templates/utils.libsonnet';
     git clone https://github.com/huggingface/transformers.git
     cd transformers && pip install .
     git log -1
-    pip install datasets evaluate sklearn
+    pip install datasets evaluate scikit-learn
     pip install -r examples/pytorch/_tests_requirements.txt
   |||,
   local command_copy_metrics = |||
@@ -40,7 +40,6 @@ local utils = import 'templates/utils.libsonnet';
         self.scriptPath,
         '--num_cores=%d' % config.paramsOverride.tpuCores,
         'examples/pytorch/image-pretraining/run_mae.py',
-        '--model_name=%s' % config.paramsOverride.model_name,
         '--dataset_name=cifar10',
         '--remove_unused_columns=False',
         '--label_names=pixel_values',
@@ -65,8 +64,6 @@ local utils = import 'templates/utils.libsonnet';
         '--output_dir=MAE',
         '--overwrite_output_dir=true',
         '--logging_dir=./tensorboard-metrics',
-        '--task_name=MAE',
-        '--overwrite_cache=true',
         '--tpu_metrics_debug=true',
       ],
     },
@@ -133,7 +130,7 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local pjrt = tpuVm + experimental.PjRt {
-    modelName: 'hf-mae-pjrt',
+    modelName: 'hf-vit-mae-pjrt',
   },
   local v2_8 = {
     accelerator: tpus.v2_8,
@@ -145,8 +142,7 @@ local utils = import 'templates/utils.libsonnet';
     accelerator: tpus.v4_8,
   },
   configs: [
-    hf_mae + v2_8 + hf_vit_mae + timeouts.Hours(2) + pjrt,
-    hf_mae + v3_8 + hf_vit_mae + timeouts.Hours(2) + pjrt,
-    hf_mae + v4_8 + hf_vit_mae + timeouts.Hours(2) + pjrt,
+    hf_mae + v3_8 + hf_vit_mae + timeouts.Hours(2) + tpuVm,
+    hf_mae + v4_8 + hf_vit_mae + timeouts.Hours(2) + tpuVm,
   ],
 }

--- a/tests/pytorch/nightly/hf-mae.libsonnet
+++ b/tests/pytorch/nightly/hf-mae.libsonnet
@@ -145,8 +145,8 @@ local utils = import 'templates/utils.libsonnet';
     accelerator: tpus.v4_8,
   },
   configs: [
-    hf_mae + v2_8 + hf_vit_mae + timeouts.Hours(2),
-    hf_mae + v3_8 + hf_vit_mae + timeouts.Hours(2),
-    hf_mae + v4_8 + hf_vit_mae + timeouts.Hours(2),
+    hf_mae + v2_8 + hf_vit_mae + timeouts.Hours(2) + pjrt,
+    hf_mae + v3_8 + hf_vit_mae + timeouts.Hours(2) + pjrt,
+    hf_mae + v4_8 + hf_vit_mae + timeouts.Hours(2) + pjrt,
   ],
 }

--- a/tests/pytorch/nightly/hf-mae.libsonnet
+++ b/tests/pytorch/nightly/hf-mae.libsonnet
@@ -1,0 +1,152 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local experimental = import '../experimental.libsonnet';
+local common = import 'common.libsonnet';
+local timeouts = import 'templates/timeouts.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+local utils = import 'templates/utils.libsonnet';
+
+{
+  local command_common = |||
+    git clone https://github.com/huggingface/transformers.git
+    cd transformers && pip install .
+    git log -1
+    pip install datasets evaluate sklearn
+    pip install -r examples/pytorch/_tests_requirements.txt
+  |||,
+  local command_copy_metrics = |||
+    gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
+  |||,
+  local hf_mae = common.PyTorchTest {
+    local config = self,
+    modelName: 'hf-glue',
+    paramsOverride:: {
+      scriptPath: 'examples/pytorch/xla_spawn.py',
+      tpuCores: config.accelerator.numCores,
+      trainCommand: [
+        'python3',
+        self.scriptPath,
+        '--num_cores=%d' % config.paramsOverride.tpuCores,
+        'examples/pytorch/image-pretraining/run_mae.py',
+        '--model_name=%s' % config.paramsOverride.model_name,
+        '--dataset_name=cifar10',
+        '--remove_unused_columns=False',
+        '--label_names=pixel_values'
+        '--mask_ratio=0.75'
+        '--norm_pix_loss=True'
+        '--do_train=true',
+        '--do_eval=true',
+        '--base_learning_rate=1.5e-4',
+        '--lr_scheduler_type=cosine',
+        '--weight_decay=0.05',
+        '--num_train_epochs=3',
+        '--warmup_ratio=0.05',
+        '--per_device_train_batch_size=%d ' % config.paramsOverride.per_device_train_batch_size,
+        '--per_device_eval_batch_size=%d ' % config.paramsOverride.per_device_eval_batch_size,
+        '--logging_strategy=steps',
+        '--logging_steps=30',
+        '--evaluation_strategy=epoch',
+        '--save_strategy=epoch',
+        '--load_best_model_at_end=True',
+        '--save_total_limit=3',
+        '--seed=1337',
+        '--output_dir=MAE',
+        '--overwrite_output_dir=true',
+        '--logging_dir=./tensorboard-metrics',
+        '--task_name=MAE'
+        '--overwrite_cache=true',
+        '--tpu_metrics_debug=true',
+      ],
+    },
+    command: utils.scriptCommand(
+      |||
+        %s 
+        %s 
+        %s 
+      ||| % [
+        command_common,
+        utils.toCommandString(self.paramsOverride.trainCommand),
+        command_copy_metrics,
+      ]
+    ),
+    podTemplate+:: {
+      spec+: {
+        containerMap+: {
+          train+: {
+            resources+: {
+              requests: {
+                cpu: '12.0',
+                memory: '80Gi',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  local hf_vit_mae = common.Convergence {
+    modelName: 'hf-vit-mae',
+    paramsOverride+:: {
+      model_name: 'vit-mae',
+      per_device_train_batch_size: 8,
+      per_device_eval_batch_size: 8,
+    },
+    metricConfig+: {
+      sourceMap+:: {
+        tensorboard+: {
+          aggregateAssertionsMap+:: {
+            'eval/accuracy': {
+              FINAL: {
+                fixed_value: {
+                  comparison: 'GREATER',
+                  value: 0.85,
+                },
+                inclusive_bounds: false,
+                wait_for_n_data_points: 0,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  local tpuVm = common.PyTorchTpuVmMixin {
+    tpuSettings+: {
+      tpuVmExports+: |||
+        export XLA_USE_BF16=$(XLA_USE_BF16)
+      |||,
+      tpuVmExtraSetup: |||
+        echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
+      |||,
+    },
+  },
+  local pjrt = tpuVm + experimental.PjRt {
+    modelName: 'hf-mae-pjrt',
+  },
+  local v2_8 = {
+    accelerator: tpus.v2_8,
+  },
+  local v3_8 = {
+    accelerator: tpus.v3_8,
+  },
+  local v4_8 = {
+    accelerator: tpus.v4_8,
+  },
+  configs: [
+    hf_mae + v2_8 + hf_vit_mae + timeouts.Hours(2),
+    hf_mae + v3_8 + hf_vit_mae + timeouts.Hours(2),
+    hf_mae + v4_8 + hf_vit_mae + timeouts.Hours(2),
+  ],
+}

--- a/tests/pytorch/nightly/hf-mae.libsonnet
+++ b/tests/pytorch/nightly/hf-mae.libsonnet
@@ -31,7 +31,7 @@ local utils = import 'templates/utils.libsonnet';
   |||,
   local hf_mae = common.PyTorchTest {
     local config = self,
-    modelName: 'hf-glue',
+    modelName: 'hf-mae',
     paramsOverride:: {
       scriptPath: 'examples/pytorch/xla_spawn.py',
       tpuCores: config.accelerator.numCores,
@@ -43,9 +43,9 @@ local utils = import 'templates/utils.libsonnet';
         '--model_name=%s' % config.paramsOverride.model_name,
         '--dataset_name=cifar10',
         '--remove_unused_columns=False',
-        '--label_names=pixel_values'
-        '--mask_ratio=0.75'
-        '--norm_pix_loss=True'
+        '--label_names=pixel_values',
+        '--mask_ratio=0.75',
+        '--norm_pix_loss=True',
         '--do_train=true',
         '--do_eval=true',
         '--base_learning_rate=1.5e-4',
@@ -65,7 +65,7 @@ local utils = import 'templates/utils.libsonnet';
         '--output_dir=MAE',
         '--overwrite_output_dir=true',
         '--logging_dir=./tensorboard-metrics',
-        '--task_name=MAE'
+        '--task_name=MAE',
         '--overwrite_cache=true',
         '--tpu_metrics_debug=true',
       ],

--- a/tests/pytorch/nightly/targets.jsonnet
+++ b/tests/pytorch/nightly/targets.jsonnet
@@ -17,6 +17,7 @@ local dlrm = import 'dlrm.libsonnet';
 local fairseqTransformer = import 'fs-transformer.libsonnet';
 local huggingfaceGlue = import 'hf-glue.libsonnet';
 local huggingfaceLanguageModeling = import 'hf-lm.libsonnet';
+local huggingfaceVitMae = import 'hf-mae.libsonnet';
 local mnist = import 'mnist.libsonnet';
 local pythonOperations = import 'python-ops.libsonnet';
 local resnet50_mp = import 'resnet50-mp.libsonnet';
@@ -33,6 +34,7 @@ std.flattenArrays([
   fairseqTransformer.configs,
   huggingfaceGlue.configs,
   huggingfaceLanguageModeling.configs,
+  huggingfaceVitMae.configs,
   mnist.configs,
   pythonOperations.configs,
   resnet50_mp.configs,


### PR DESCRIPTION
Pretrain a ViT as an MAE using https://github.com/huggingface/transformers/blob/main/examples/pytorch/image-pretraining/run_mae.py 

Upstream dependency: https://github.com/huggingface/transformers/pull/21551

v3 passing: https://pantheon.corp.google.com/kubernetes/job/us-central1/oneshots-us-central1/default/pt-nightly-hf-vit-mae-conv-v3-8-1vm-rqmkz/details?jsmode=o&mods=allow_workbench_image_override&project=xl-ml-test&pageState=(%22savedViews%22:(%22i%22:%22d6eacf2f34904f27a5109e5f61063ca5%22,%22c%22:%5B%5D,%22n%22:%5B%5D))

v4 passing: https://pantheon.corp.google.com/kubernetes/pod/us-central2/xl-ml-test-us-central2/default/pt-nightly-hf-vit-mae-conv-v4-8-1vm-7mdp9-wgt8l/details?jsmode=o&mods=allow_workbench_image_override&project=xl-ml-test