### PR TITLE
Adding profiler test for WMT model, adding dependencies for WMT

### DIFF
--- a/tests/jax/latest/wmt.libsonnet
+++ b/tests/jax/latest/wmt.libsonnet
@@ -25,6 +25,11 @@ local tpus = import 'templates/tpus.libsonnet';
     extraConfig:: 'default.py',
     extraFlags+:: ['--config.reverse_translation=True', '--config.per_device_batch_size=32'],
   },
+  local profile = mixins.Functional {
+    mode: 'profile',
+    extraFlags+:: ['--config.num_train_steps=40', '--config.per_device_batch_size=16'],
+    extraConfig:: 'default.py',
+  },
   local v3_8 = {
     accelerator: tpus.v3_8,
   },
@@ -33,10 +38,17 @@ local tpus = import 'templates/tpus.libsonnet';
   },
   local wmt = common.runFlaxLatest {
     modelName:: 'wmt',
-    extraDeps+:: ['tensorflow_text sentencepiece'],
+    extraDeps+:: ['tensorflow_text sentencepiece', 'protobuf==3.20.*', 'tensorflow_datasets'],
+  },
+  local wmt_profiling = wmt {
+    local config = self,
+    testScript+:: |||
+      gsutil -q stat $(MODEL_DIR)/plugins/profile/*/*.xplane.pb
+    ||| % (self.scriptConfig {}),
   },
   configs: [
     wmt + functional + v2_8,
     wmt + convergence + v3_8 + timeouts.Hours(20),
+    wmt_profiling + profile + v3_8 + timeouts.Hours(1),
   ],
 }

--- a/tests/jax/latest/wmt.libsonnet
+++ b/tests/jax/latest/wmt.libsonnet
@@ -38,7 +38,7 @@ local tpus = import 'templates/tpus.libsonnet';
   },
   local wmt = common.runFlaxLatest {
     modelName:: 'wmt',
-    extraDeps+:: ['tensorflow_text sentencepiece', 'protobuf==3.20.*', 'tensorflow_datasets'],
+    extraDeps+:: ['tensorflow_text sentencepiece protobuf==3.20.* tensorflow_datasets'],
   },
   local wmt_profiling = wmt {
     local config = self,
@@ -49,6 +49,6 @@ local tpus = import 'templates/tpus.libsonnet';
   configs: [
     wmt + functional + v2_8,
     wmt + convergence + v3_8 + timeouts.Hours(20),
-    wmt_profiling + profile + v3_8 + timeouts.Hours(1),
+    wmt_profiling + profile + v3_8 + timeouts.Minutes(40),
   ],
 }


### PR DESCRIPTION
1. Adding a profiler test - "flax-latest-wmt-profile-v3-8-1vm" which runs the WMT model and verifies the existence of a trace.
2. Including WMT model dependencies, i.e. correct version of protobuf ( to avoid incompatibility issues with TF ) and tensorflow_datasets.

( Issues are not related to this XL-ML test directly, but dependencies of WMT model itself.

Protobuf 3.20.* was needed to avoid tensorflow import error-
"TypeError: Descriptors cannot not be created directly.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower)."
 
 tensorflow_datasets import was needed because tensorflow_datasets is also imported in WMT. )
 