### PR TITLE
If a requirements.txt exists in a FLAX example, install it

### DIFF
--- a/tests/jax/latest/common.libsonnet
+++ b/tests/jax/latest/common.libsonnet
@@ -49,6 +49,10 @@ local tpus = import 'templates/tpus.libsonnet';
       pip install -e .
       cd examples/%(modelName)s
 
+      if [ ! -z $(ls | grep 'requirements.txt') ]; then
+        pip install -r requirements.txt
+      fi
+
       export GCS_BUCKET=$(MODEL_DIR)
       export TFDS_DATA_DIR=$(TFDS_DIR)
 


### PR DESCRIPTION
Fixes `flax-latest-imagenet-*` tests.

See [example test](https://pantheon.corp.google.com/kubernetes/job/us-central1/oneshots-us-central1/default/flax-latest-imagenet-conv-v3-8-1vm-2td98/details?e=13803378&jsmode=o&mods=allow_workbench_image_override&project=xl-ml-test) passing.