### PR TITLE
Update nightly common.libsonnet to pull pytorch as well

### DIFF
--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -98,7 +98,7 @@ local volumes = import 'templates/volumes.libsonnet';
           https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch-nightly-cp38-cp38-linux_x86_64.whl \
           https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torchvision-nightly-cp38-cp38-linux_x86_64.whl \
           'torch_xla[tpuvm] @ https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-nightly-cp38-cp38-linux_x86_64.whl'
-        git clone https://github.com/pytorch/pytorch.git
+        git clone --depth=1 https://github.com/pytorch/pytorch.git
         cd pytorch
         git clone https://github.com/pytorch/xla.git
       |||,

--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -98,9 +98,7 @@ local volumes = import 'templates/volumes.libsonnet';
           https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch-nightly-cp38-cp38-linux_x86_64.whl \
           https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torchvision-nightly-cp38-cp38-linux_x86_64.whl \
           'torch_xla[tpuvm] @ https://storage.googleapis.com/tpu-pytorch/wheels/tpuvm/torch_xla-nightly-cp38-cp38-linux_x86_64.whl'
-        # No need to check out the PyTorch repository, but check out PT/XLA at
-        # pytorch/xla anyway
-        mkdir pytorch
+        git clone https://github.com/pytorch/pytorch.git
         cd pytorch
         git clone https://github.com/pytorch/xla.git
       |||,


### PR DESCRIPTION
Our nightly python-op tests were failing with:
```
python3: can't open file '/home/xl-ml-test/pytorch/xla/test/../../test/test_view_ops.py': [Errno 2] No such file or directory
```
Previously, we didn't pull pytorch. This PR updates the common.libsonnet to pull the pytorch as well. 