### PR TITLE
Update python-ops.libsonnet to install expecttest

### DIFF
--- a/tests/pytorch/nightly/python-ops.libsonnet
+++ b/tests/pytorch/nightly/python-ops.libsonnet
@@ -47,6 +47,7 @@ local utils = import 'templates/utils.libsonnet';
       tpuVmExtraSetup: |||
         echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
         echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
+        pip install expecttest
       |||,
     },
   },


### PR DESCRIPTION
Since we moved python-op tests to 1VM, tests are failing with:
```
Traceback (most recent call last):
  File "/home/xl-ml-test/pytorch/xla/test/../../test/test_view_ops.py", line 11, in <module>
    from torch.testing._internal.common_utils import (
  File "/home/xl-ml-test/.local/lib/python3.8/site-packages/torch/testing/_internal/common_utils.py", line 57, in <module>
    import expecttest
ModuleNotFoundError: No module named 'expecttest'
```
This PR adds install statement to `expecttest`.