### PR TITLE
Update hf-lm.libsonnet to install pathlib

### DIFF
--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -192,6 +192,7 @@ local utils = import 'templates/utils.libsonnet';
         pip install tensorboardX google-cloud-storage
         echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
         echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
+        pip install pathlib
       |||,
     },
   },

--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -23,7 +23,7 @@ local utils = import 'templates/utils.libsonnet';
     cd transformers && pip install .
     git log -1
     pip install datasets evaluate scikit-learn
-    python examples/pytorch/xla_spawn.py \
+    python3 examples/pytorch/xla_spawn.py \
       --num_cores 8 \
       examples/pytorch/language-modeling/run_mlm.py \
       --logging_dir ./tensorboard-metrics \

--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -189,7 +189,7 @@ local utils = import 'templates/utils.libsonnet';
         export XLA_USE_BF16=$(XLA_USE_BF16)
       |||,
       tpuVmExtraSetup: |||
-        pip install tensorboardX google-cloud-storage pathlib
+        pip install tensorboardX google-cloud-storage
         echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
         echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
       |||,

--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -189,10 +189,9 @@ local utils = import 'templates/utils.libsonnet';
         export XLA_USE_BF16=$(XLA_USE_BF16)
       |||,
       tpuVmExtraSetup: |||
-        pip install tensorboardX google-cloud-storage
+        pip install tensorboardX google-cloud-storage pathlib
         echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
         echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
-        pip install pathlib
       |||,
     },
   },


### PR DESCRIPTION
Since we moved python-op tests to 1VM, tests are failing with:
```
Traceback (most recent call last):
  File "examples/pytorch/xla_spawn.py", line 30, in <module>
    from pathlib import Path
ImportError: No module named pathlib
```
This PR adds install statement to `pathlib`.