### PR TITLE
Update get_metadata location

### DIFF
--- a/tests/multipods/jax/unit_tests/orbax_async_checkpoint_test.py
+++ b/tests/multipods/jax/unit_tests/orbax_async_checkpoint_test.py
@@ -14,7 +14,8 @@ import portpicker
 import time
 from google.cloud import storage
 from jax._src.lib import xla_bridge
-from jax._src.cloud_tpu_init import running_in_cloud_tpu_vm, get_metadata
+from jax._src.cloud_tpu_init import running_in_cloud_tpu_vm
+from jax._src.clusters.cloud_tpu_cluster import get_metadata"
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 os.environ["JAX_USE_PJRT_C_API_ON_TPU"] = "1"


### PR DESCRIPTION
PR https://github.com/google/jax/pull/14008 moved get_metadata to cloud_tpu_cluster.py