### PR TITLE
added importlib-metadata as a requirement for metrics handler

### DIFF
--- a/metrics/handler/requirements.txt
+++ b/metrics/handler/requirements.txt
@@ -2,6 +2,7 @@ absl-py~=1.0.0
 google-auth==1.24.0
 google-cloud-bigquery==2.5.0
 google-cloud-secret-manager==2.1.0
+importlib-metadata~=6.0.0
 jinja2>=3.0
 numpy~=1.23.0
 protobuf==3.15.0


### PR DESCRIPTION
Deploying metrics handler with bazelisk ran into an error without importlib-metadata.