### PR TITLE
Ensure dpkg lock is released after udpate

### DIFF
--- a/tests/pytorch/experimental.libsonnet
+++ b/tests/pytorch/experimental.libsonnet
@@ -86,6 +86,9 @@ local utils = import 'templates/utils.libsonnet';
 
                 cat > workersetup.sh << TEST_SCRIPT_EOF
                 sudo apt-get -y update
+                // Ensure lock is released after udpate
+                sudo kill -9 $(lsof /var/lib/dpkg/lock-frontend | awk '{print $2}')
+                sudo dpkg --configure -a
                 sudo apt-get -y install nfs-common
                 sudo mkdir /datasets && sudo mount $(PYTORCH_DATA_LOCATION) /datasets
 


### PR DESCRIPTION
To prevent test failures due to dpkg lock hold after update:
```
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
```
This is a noop, if the lock is already released.