### PR TITLE
[PT/XLA] Fix DDP paths and timeouts

### DIFF
--- a/tests/pytorch/nightly/mnist.libsonnet
+++ b/tests/pytorch/nightly/mnist.libsonnet
@@ -87,14 +87,6 @@ local utils = import 'templates/utils.libsonnet';
   },
   local pjrt = tpuVm + experimental.PjRt {
     modelName+: '-pjrt',
-    command: [
-      'python3',
-      'pytorch/xla/test/pjrt/test_train_pjrt_mnist.py',
-    ] + super.command[2:],
-    // TODO: re-enable TensorBoard summaries when they don't cause a crash
-    flags+:: {
-      modelDir: null,
-    },
   },
   local pjrt_ddp = {
     modelName+: '-ddp',

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -117,7 +117,7 @@ local tpus = import 'templates/tpus.libsonnet';
     modelName+: '-torch-ddp',
     tpuSettings+: {
       tpuVmExports+: |||
-        export MASTER_ADDR=1
+        export MASTER_ADDR=localhost
         export MASTER_PORT=12355
       |||,
     },
@@ -164,9 +164,9 @@ local tpus = import 'templates/tpus.libsonnet';
     resnet50 + fake_data + v3_8 + timeouts.Hours(2) + pjrt + pjrt_ddp,
     resnet50 + fake_data + v3_32 + timeouts.Hours(1) + pjrt,
     resnet50 + fake_data + v4_8 + timeouts.Hours(2) + pjrt,
-    resnet50 + convergence + v4_8 + timeouts.Hours(24) + pjrt,
+    resnet50 + convergence + v4_8 + timeouts.Hours(14) + pjrt,
     resnet50 + fake_data + v4_8 + timeouts.Hours(2) + pjrt + pjrt_ddp,
-    resnet50 + convergence + v4_8 + timeouts.Hours(2) + pjrt + pjrt_ddp,
+    resnet50 + convergence + v4_8 + timeouts.Hours(14) + pjrt + pjrt_ddp,
     resnet50 + fake_data + v4_32 + timeouts.Hours(2) + pjrt,
     resnet50 + convergence + v4_32 + timeouts.Hours(24) + pjrt,
   ],


### PR DESCRIPTION
Tested new MNIST path manually. 

Set timeout with less headroom for ResNet50 convergence based on historical duration.