### PR TITLE
Add pip install cmake to cpp op tests

### DIFF
--- a/tests/pytorch/nightly/cpp-ops.libsonnet
+++ b/tests/pytorch/nightly/cpp-ops.libsonnet
@@ -42,6 +42,7 @@ local utils = import 'templates/utils.libsonnet';
       tpuVmExtraSetup: |||
         echo 'export PATH=~/.local/bin:$PATH' >> ~/.bash_profile
         echo 'export XLA_USE_BF16=1' >> ~/.bash_profile
+        pip install cmake
       |||,
     },
   },


### PR DESCRIPTION
Since we moved to 1vm, cpp op tests have been failing for a while with:
```
pytorch/xla/test/cpp/run_tests.sh: line 53: cmake: command not found
```
This is because cpp op tests actually builds pytorch/xla in the cpp/run_tests.sh script. And our new `tpu_vm_base` image, unlike our older v2/v3 TPUVM images, don't have `cmake` preinstalled. 