### PR TITLE
[PT/XLA] Move end-to-end tests to PJRT C API

### DIFF
--- a/tests/pytorch/experimental.libsonnet
+++ b/tests/pytorch/experimental.libsonnet
@@ -121,7 +121,7 @@ local utils = import 'templates/utils.libsonnet';
   PjRt:: {
     tpuSettings+: {
       tpuVmExports: |||
-        export PJRT_DEVICE=TPU
+        export PJRT_DEVICE=TPU_C_API
       |||,
       tpuVmXlaDistPrefix: null,
       tpuVmMainCommandWorkers: 'all',

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -237,17 +237,7 @@ local utils = import 'templates/utils.libsonnet';
   },
 
   local pjrt = tpuVm + experimental.PjRt {
-    tpuSettings+: {
-      tpuVmExtraSetup+: |||
-        pip3 install tqdm
-        git clone -b tpu --single-branch https://github.com/darisoy/fairseq.git fairseq-pjrt/
-        pip install --editable ./fairseq-pjrt
-      |||,
-    },
     modelName: 'fs-transformer-pjrt',
-    paramsOverride+: {
-      scriptPath: 'fairseq-pjrt/train.py',
-    },
   },
 
   local v3_8 = {
@@ -271,8 +261,8 @@ local utils = import 'templates/utils.libsonnet';
     transformer + v4_8 + functional_no_save + timeouts.Hours(1) + tpuVm,
     transformer + v3_32 + functional_no_save + timeouts.Hours(1) + tpuVm,
     transformer + v4_8 + convergence + timeouts.Hours(25) + pjrt + mixins.Experimental,
-    transformer + v4_8 + functional_no_save + timeouts.Hours(1) + pjrt + mixins.Experimental,
+    transformer + v4_8 + functional_no_save + timeouts.Hours(1) + pjrt,
     transformer + v4_32 + convergence + timeouts.Hours(25) + tpuVm + mixins.Experimental,
-    transformer + v4_32 + convergence + timeouts.Hours(25) + pjrt + mixins.Experimental,
+    transformer + v4_32 + convergence + timeouts.Hours(25) + pjrt,
   ],
 }


### PR DESCRIPTION
Fix FS transformer test by switching back to original XRT code and re-enabled PJRT tests.

Started all 3 PJRT models (ResNet50, FS Transformer, and DLRM) manually to confirm they start training without crashing.