### PR TITLE
Add SPMD tests to PyTorch resnet50

### DIFF
--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -22,14 +22,22 @@ local tpus = import 'templates/tpus.libsonnet';
 {
   local resnet50 = common.PyTorchTest {
     modelName: 'resnet50-mp',
+    trainScript: 'pytorch/xla/test/test_train_mp_imagenet.py',
+    batch_size: null,
     command: [
       'python3',
-      'pytorch/xla/test/test_train_mp_imagenet.py',
+      self.trainScript,
       '--model=resnet50',
       '--log_steps=200',
-    ] + if self.flags.modelDir != null then [
-      '--logdir=%s' % self.flags.modelDir,
-    ] else [],
+    ] + (
+      if self.flags.modelDir != null then [
+        '--logdir=%s' % self.flags.modelDir,
+      ] else []
+    ) + (
+      if self.batch_size != null then [
+        '--batch_size=%s' % self.batch_size,
+      ] else []
+    ),
     flags:: {
       modelDir: '$(MODEL_DIR)',
     },
@@ -90,11 +98,11 @@ local tpus = import 'templates/tpus.libsonnet';
   local v4_8 = {
     accelerator: tpus.v4_8,
     // Keep same global batch size as v3
-    command+: ['--batch_size=256'],
+    batch_size: 256,
   },
   local v4_32 = {
     accelerator: tpus.v4_32,
-    command+: ['--batch_size=256'],
+    batch_size: 256,
   },
 
   local gpu = common.GpuMixin {
@@ -143,6 +151,15 @@ local tpus = import 'templates/tpus.libsonnet';
   local pjrt = tpuVm + experimental.PjRt {
     modelName: 'resnet50-pjrt',
   },
+  local spmd(sharding) = pjrt {
+    // Include sharding spec in the test name
+    modelName: std.join('-', ['resnet50-spmd'] + sharding),
+    trainScript: 'pytorch/xla/test/spmd/test_train_spmd_imagenet.py',
+    command+: ['--sharding=' + std.join(',', sharding)],
+    // Keep the same global batch size. In SPMD, the global batch size is
+    // divided across all devices.
+    batch_size: self.accelerator.size * 128,
+  },
 
   configs: [
     // XRT
@@ -169,5 +186,8 @@ local tpus = import 'templates/tpus.libsonnet';
     resnet50 + convergence + v4_8 + timeouts.Hours(14) + pjrt + pjrt_ddp,
     resnet50 + fake_data + v4_32 + timeouts.Hours(2) + pjrt,
     resnet50 + convergence + v4_32 + timeouts.Hours(24) + pjrt,
+    // SPMD
+    resnet50 + functional + v4_8 + timeouts.Hours(2) + spmd(['batch']),
+    resnet50 + functional + v4_8 + timeouts.Hours(2) + spmd(['spatial']),
   ],
 }


### PR DESCRIPTION
# Description
This change adds single-host SPMD tests for resnet50 with batch and spatial sharding.

# Tests
One-shots `pt-nightly-resnet50-spmd-batch-func-v4-8-1vm` and `pt-nightly-resnet50-spmd-spatial-func-v4-8-1vm` pass

# Checklist
Before submitting this PR, please make sure (put X in square brackets):

* [x]  I have performed a self-review of my code.
* [x]  I have necessary comments in my code, particularly in hard-to-understand areas.
* [x]  I have run one-shot tests and provided workload links above if applicable.
* [x]  I have made or will make corresponding changes to the doc if needed.