### PR TITLE
Added configuration so that 2VM TF 2.12 tests use TF version 2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bazel-*
 **/__pycache__
+k8s/*/gen/


### PR DESCRIPTION
Since the 2vm tests cannot find tf software version 2.12.0, we have to use tf 2.11.0, and then switch to tf 2.12.0 manually. This has to be done for both red and green vm