### PR TITLE
Fix 2VM paths based on the new RedVM docker image 

### DIFF
--- a/tests/tensorflow/r2.12/common.libsonnet
+++ b/tests/tensorflow/r2.12/common.libsonnet
@@ -100,12 +100,12 @@ local mixins = import 'templates/mixins.libsonnet';
   },
   TfVisionTest:: self.ModelGardenTest + common.TfNlpVisionMixin {
     scriptConfig+: {
-      runnerPath: '/usr/share/tpu/models/official/vision/train.py',
+      runnerPath: '/usr/share/models/official/vision/train.py',
     },
   },
   TfNlpTest:: self.ModelGardenTest + common.TfNlpVisionMixin {
     scriptConfig+: {
-      runnerPath: '/usr/share/tpu/models/official/nlp/train.py',
+      runnerPath: '/usr/share/models/official/nlp/train.py',
     },
   },
   local functional_schedule = '0 3 * * *',

--- a/tests/tensorflow/r2.12/common.libsonnet
+++ b/tests/tensorflow/r2.12/common.libsonnet
@@ -23,9 +23,71 @@ local mixins = import 'templates/mixins.libsonnet';
 
     frameworkPrefix: 'tf-r2.12.0',
     tpuSettings+: {
-      softwareVersion: '2.12.0',
+      softwareVersion: '2.11.0',
     },
     imageTag: 'r2.12.0',
+    podTemplate+:: {
+      spec+: {
+        initContainerMap+:: {
+          'tpu-version': {
+            image: config.podTemplate.spec.containerMap.train.image,
+            env+: [
+              {
+                name: 'TPU_NAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: "metadata.annotations['name.cloud-tpus.google.com/train']",
+                  },
+                },
+              },
+              {
+                name: 'POD_UID',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'metadata.uid',
+                  },
+                },
+              },
+            ],
+            local tpuCreateSettings = {
+              acceleratorName: std.escapeStringBash(config.accelerator.name),
+              softwareVersion: std.escapeStringBash(config.tpuSettings.softwareVersion),
+              startupScript: std.escapeStringBash(config.tpuSettings.tpuVmStartupScript),
+              sleepTime: config.tpuSettings.tpuVmCreateSleepSeconds,
+              testName: std.strReplace(config.testName, '.', '-'),
+            },
+            command: [
+              'python3',
+              '-c',
+              |||
+                import importlib_metadata
+                import os
+                import re
+                import tensorflow as tf
+                import urllib
+                import json
+                import cloud_tpu_client
+                import sys
+                print('python version: ' + str(sys.version))
+                print('tf_version: ' + str(tf.__version__))
+                print(str(tf.__file__))
+
+                ctc = cloud_tpu_client.Client(tpu=os.path.basename('$(TPU_NAME)'), zone=os.path.dirname('$(TPU_NAME)'))
+                ctc.wait_for_healthy()
+                ctc.configure_tpu_version('2.12.0', restart_type='always')
+                ctc.wait_for_healthy()
+                _VERSION_SWITCHER_ENDPOINT = 'http://{}:8475/requestversion'
+                url = _VERSION_SWITCHER_ENDPOINT.format(ctc.network_endpoints()[0]['ipAddress'])
+                req = urllib.request.Request(url)
+                resp = urllib.request.urlopen(req)
+                version_details = json.loads(resp.read())
+                print(version_details)
+              |||,
+            ],
+          },
+        },
+      },
+    },
   },
   tpuVm:: experimental.TensorFlowTpuVmMixin {
     local config = self,
@@ -38,12 +100,12 @@ local mixins = import 'templates/mixins.libsonnet';
   },
   TfVisionTest:: self.ModelGardenTest + common.TfNlpVisionMixin {
     scriptConfig+: {
-      runnerPath: 'official/vision/train.py',
+      runnerPath: '/usr/share/tpu/models/official/vision/train.py',
     },
   },
   TfNlpTest:: self.ModelGardenTest + common.TfNlpVisionMixin {
     scriptConfig+: {
-      runnerPath: 'official/nlp/train.py',
+      runnerPath: '/usr/share/tpu/models/official/nlp/train.py',
     },
   },
   local functional_schedule = '0 3 * * *',

--- a/tests/tensorflow/r2.12/dlrm.libsonnet
+++ b/tests/tensorflow/r2.12/dlrm.libsonnet
@@ -92,7 +92,7 @@ local tpus = import 'templates/tpus.libsonnet';
     },
     command: [
       'python3',
-      '/usr/share/tpu/models/official/recommendation/ranking/train.py',
+      '/usr/share/models/official/recommendation/ranking/train.py',
       '--params_override=%s' % (std.manifestYamlDoc(self.paramsOverride) + '\n'),
       '--model_dir=$(MODEL_DIR)',
     ],

--- a/tests/tensorflow/r2.12/dlrm.libsonnet
+++ b/tests/tensorflow/r2.12/dlrm.libsonnet
@@ -92,7 +92,7 @@ local tpus = import 'templates/tpus.libsonnet';
     },
     command: [
       'python3',
-      'official/recommendation/ranking/train.py',
+      '/usr/share/tpu/models/official/recommendation/ranking/train.py',
       '--params_override=%s' % (std.manifestYamlDoc(self.paramsOverride) + '\n'),
       '--model_dir=$(MODEL_DIR)',
     ],

--- a/tests/tensorflow/r2.12/experimental.libsonnet
+++ b/tests/tensorflow/r2.12/experimental.libsonnet
@@ -43,7 +43,7 @@ local mixins = import 'templates/mixins.libsonnet';
                 set -x
                 set -u
                 ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \
-                  'pip install -r /usr/share/tpu/models/official/requirements.txt'
+                  'pip install -r /usr/share/models/official/requirements.txt'
                 ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \
                   'pip install tensorflow-recommenders --no-deps'
                 ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \

--- a/tests/tensorflow/r2.12/mnist.libsonnet
+++ b/tests/tensorflow/r2.12/mnist.libsonnet
@@ -23,7 +23,7 @@ local tpus = import 'templates/tpus.libsonnet';
     modelName: 'mnist',
     command: [
       'python3',
-      '/usr/share/tpu/models/official/legacy/image_classification/mnist_main.py',
+      '/usr/share/models/official/legacy/image_classification/mnist_main.py',
       '--data_dir=%s' % self.flags.dataDir,
       '--model_dir=%s' % self.flags.modelDir,
     ],

--- a/tests/tensorflow/r2.12/mnist.libsonnet
+++ b/tests/tensorflow/r2.12/mnist.libsonnet
@@ -23,7 +23,7 @@ local tpus = import 'templates/tpus.libsonnet';
     modelName: 'mnist',
     command: [
       'python3',
-      'official/legacy/image_classification/mnist_main.py',
+      '/usr/share/tpu/models/official/legacy/image_classification/mnist_main.py',
       '--data_dir=%s' % self.flags.dataDir,
       '--model_dir=%s' % self.flags.modelDir,
     ],

--- a/tests/tensorflow/r2.12/nlp-mnli.libsonnet
+++ b/tests/tensorflow/r2.12/nlp-mnli.libsonnet
@@ -25,7 +25,7 @@ local utils = import 'templates/utils.libsonnet';
     scriptConfig+: {
       experiment: 'bert/sentence_prediction_text',
       configFiles: [
-        '/usr/share/tpu/models/official/nlp/configs/experiments/glue_mnli_text.yaml',
+        '/usr/share/models/official/nlp/configs/experiments/glue_mnli_text.yaml',
       ],
       paramsOverride+: {
         task+: {

--- a/tests/tensorflow/r2.12/nlp-mnli.libsonnet
+++ b/tests/tensorflow/r2.12/nlp-mnli.libsonnet
@@ -25,7 +25,7 @@ local utils = import 'templates/utils.libsonnet';
     scriptConfig+: {
       experiment: 'bert/sentence_prediction_text',
       configFiles: [
-        'official/nlp/configs/experiments/glue_mnli_text.yaml',
+        '/usr/share/tpu/models/official/nlp/configs/experiments/glue_mnli_text.yaml',
       ],
       paramsOverride+: {
         task+: {

--- a/tests/tensorflow/r2.12/vision-imagenet.libsonnet
+++ b/tests/tensorflow/r2.12/vision-imagenet.libsonnet
@@ -36,7 +36,7 @@ local utils = import 'templates/utils.libsonnet';
     modelName: 'vision-resnetrs',
     scriptConfig+: {
       experiment: 'resnet_rs_imagenet',
-      configFiles: ['/usr/share/tpu/models/official/vision/configs/experiments/image_classification/imagenet_resnetrs50_i160.yaml'],
+      configFiles: ['/usr/share/models/official/vision/configs/experiments/image_classification/imagenet_resnetrs50_i160.yaml'],
     },
   },
   local functional = common.Functional {

--- a/tests/tensorflow/r2.12/vision-imagenet.libsonnet
+++ b/tests/tensorflow/r2.12/vision-imagenet.libsonnet
@@ -36,7 +36,7 @@ local utils = import 'templates/utils.libsonnet';
     modelName: 'vision-resnetrs',
     scriptConfig+: {
       experiment: 'resnet_rs_imagenet',
-      configFiles: ['official/vision/configs/experiments/image_classification/imagenet_resnetrs50_i160.yaml'],
+      configFiles: ['/usr/share/tpu/models/official/vision/configs/experiments/image_classification/imagenet_resnetrs50_i160.yaml'],
     },
   },
   local functional = common.Functional {


### PR DESCRIPTION
Change paths because we setup our redvm test docker image according to tf_vm.sh as opposed to old way of copying repo to home directory.

New docker file script
```
FROM python:3.9.16-bullseye

RUN python3 -m pip install --upgrade pip

ADD tf_vm.sh /
RUN chmod +777 tf_vm.sh
RUN /tf_vm.sh

ADD setup.sh /
RUN chmod +777 setup.sh

ADD entrypoint.sh /
RUN chmod +777 entrypoint.sh

ENTRYPOINT ["/entrypoint.sh"]
```