### PR TITLE
Remove k8s/**/gen from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 bazel-*
 **/__pycache__
-k8s/*/gen/


### PR DESCRIPTION
The is preventing any changes from being reflected on the `gen` branch.