### PR TITLE
add functional tests for pod for Pax-on-Cloud

### DIFF
--- a/templates/tpus.libsonnet
+++ b/templates/tpus.libsonnet
@@ -68,5 +68,6 @@ local base = import 'base.libsonnet';
   v2_32: self.TpuSpec { version: 2, size: 32 },
   v3_32: self.TpuSpec { version: 3, size: 32 },
   v4_8: self.TpuSpec { version: 4, size: 8 },
+  v4_16: self.TpuSpec { version: 4, size: 16 },
   v4_32: self.TpuSpec { version: 4, size: 32 },
 }

--- a/tests/pax/nightly/lmcloudspmdadam.libsonnet
+++ b/tests/pax/nightly/lmcloudspmdadam.libsonnet
@@ -1,0 +1,15 @@
+local common = import 'common.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+
+{
+  local lmspmdadam = common.NightlyPaxTest + common.Functional {
+    modelName:: 'lmcloudspmdadam',
+    expPath:: 'tasks.lm.params.c4.LmCloudSpmdAdamLimitSteps',
+  },
+  local v4_16 = {
+    accelerator: tpus.v4_16,
+  },
+  configs: [
+    lmspmdadam + v4_16,
+  ],
+}

--- a/tests/pax/nightly/lmtransformeradam.libsonnet
+++ b/tests/pax/nightly/lmtransformeradam.libsonnet
@@ -10,7 +10,11 @@ local tpus = import 'templates/tpus.libsonnet';
   local v4_8 = {
     accelerator: tpus.v4_8,
   },
+  local v4_16 = {
+    accelerator: tpus.v4_16,
+  },
   configs: [
     lmtransformeradam + v4_8,
+    lmtransformeradam + v4_16,
   ],
 }

--- a/tests/pax/nightly/targets.jsonnet
+++ b/tests/pax/nightly/targets.jsonnet
@@ -13,6 +13,7 @@
 // limitations under the License,
 
 local c4spmd1b_pretraining = import 'c4spmd1b.libsonnet';
+local lmcloudspmdadam = import 'lmcloudspmdadam.libsonnet';
 local spmd = import 'lmspmd2b.libsonnet';
 local transformer = import 'lmtransformeradam.libsonnet';
 
@@ -21,4 +22,5 @@ std.flattenArrays([
   c4spmd1b_pretraining.configs,
   spmd.configs,
   transformer.configs,
+  lmcloudspmdadam.configs,
 ])


### PR DESCRIPTION
# Description

We are adding two functional tests for v4-16 on Pax-on-Cloud

# Tests


**Instruction and/or command lines to reproduce your tests:** ...

./scripts/run-oneshot.sh -t pax-nightly-lmtransformeradam-func-v4-16-1vm
./scripts/run-oneshot.sh -t pax-nightly-LmCloudSpmdAdam-func-v4-16-1vm

**List links for your tests (use go/shortn-gen for any internal link):** ...
http://shortn/_9Dufvp9ViB
http://shortn/_1ZZrZdLN1o

# Checklist

- [√  ] I have performed a self-review of my code.
- [ √ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ √ ] I have run one-shot tests and provided workload links above if applicable. 
- [ √] I have made or will make corresponding changes to the doc if needed.