### PR TITLE
Update sklearn to scikit-learn

### DIFF
--- a/tests/pytorch/nightly/hf-glue.libsonnet
+++ b/tests/pytorch/nightly/hf-glue.libsonnet
@@ -23,7 +23,7 @@ local utils = import 'templates/utils.libsonnet';
     git clone https://github.com/huggingface/transformers.git
     cd transformers && pip install .
     git log -1
-    pip install datasets evaluate sklearn
+    pip install datasets evaluate scikit-learn
     pip install -r examples/pytorch/_tests_requirements.txt
   |||,
   local command_copy_metrics = |||

--- a/tests/pytorch/r2.0/hf-glue.libsonnet
+++ b/tests/pytorch/r2.0/hf-glue.libsonnet
@@ -23,7 +23,7 @@ local utils = import 'templates/utils.libsonnet';
     git clone https://github.com/huggingface/transformers.git
     cd transformers && pip install .
     git log -1
-    pip install datasets evaluate sklearn
+    pip install datasets evaluate scikit-learn
     pip install -r examples/pytorch/_tests_requirements.txt
   |||,
   local command_copy_metrics = |||


### PR DESCRIPTION
# Description

Tests are failing because of an import error

```
Here is how to fix this error in the main use cases:
- use 'pip install scikit-learn' rather than 'pip install sklearn'
- replace 'sklearn' by 'scikit-learn' in your pip requirements files
(requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
- if the 'sklearn' package is used by one of your dependencies,
it would be great if you take some time to track which package uses
'sklearn' instead of 'scikit-learn' and report it to their issue tracker
- as a last resort, set the environment variable
SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
```

# Tests

Hf Glue, running one-shot now. Will update with results.

**Instruction and/or command lines to reproduce your tests:** ...

Test: `pt-2.0-hf-glue-roberta-l-conv-v4-8-1vm`

**List links for your tests (use go/shortn-gen for any internal link):** ...

Still failing, but no longer with sklearn error.

https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22xl-ml-test%22%0Aresource.labels.location%3D%22us-central2%22%0Aresource.labels.cluster_name%3D%22xl-ml-test-us-central2%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fcontroller-uid%3D%2220f00c03-731e-44ed-8923-3c4ef2d558b3%22;cursorTimestamp=2023-02-24T19:44:43.670383325Z?e=13802955&jsmode=o&mods=allow_workbench_image_override&project=xl-ml-test

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.