### PR TITLE
Fix undetectable checklist in PR body

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Please describe the tests that you ran on TPUs to verify changes.
 # Checklist
 
 Before submitting this PR, please make sure (put X in square brackets):
-- [] I have performed a self-review of my code.
-- [] I have necessary comments in my code, particularly in hard-to-understand areas.
-- [] I have run one-shot tests and provided workload links above if applicable. 
-- [] I have made or will make corresponding changes to the doc if needed.
+- [ ] I have performed a self-review of my code.
+- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
+- [ ] I have run one-shot tests and provided workload links above if applicable. 
+- [ ] I have made or will make corresponding changes to the doc if needed.


### PR DESCRIPTION
# Description

Previously deleted space in the square brackets ([#821](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/pull/821)) for developer convenience, which makes them undetectable in PR checks. 

Fix the issue by adding space back. 

# Tests

Manually tested it in my personal repo: https://github.com/RissyRan/Ad-hoc-test-repo.

**Instruction and/or command lines to reproduce your tests:** 
1. Create PR.
2. Manually tested checks.

**List links for your tests (use go/shortn-gen for any internal link):** 
1. Detectable checklist with 1 space, and checks fail without marking completed [link](https://github.com/RissyRan/Ad-hoc-test-repo/pull/9).
2. Undetectable checklist without space, and checks pass without marking completed. This is unexpected [link](https://github.com/RissyRan/Ad-hoc-test-repo/pull/10). 
3. Unfortunately, checklist are undetectable if it's not `[ ]` or `[x]`. Test [link](https://github.com/RissyRan/Ad-hoc-test-repo/pull/11).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.