### PR TITLE
reduce rate of scheduling for tf 2.12.0 conv tests

### DIFF
--- a/tests/tensorflow/r2.12/common.libsonnet
+++ b/tests/tensorflow/r2.12/common.libsonnet
@@ -139,7 +139,7 @@ local mixins = import 'templates/mixins.libsonnet';
   },
   // Override default schedule for Functional.
   RunNightly:: {
-    schedule: '0 5 * * *',
+    schedule: '0 5 * * 2,6',
   },
   Convergence:: mixins.Convergence {
     metricConfig+: {


### PR DESCRIPTION
# Description

Changed scheduler for tensorflow 2.12.0 convergence tests to twice a week. This will allow the convergence tests that take over a day to run without interruption.
# Tests
None
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.