### PR TITLE
Cleaned TF 2.9 and 2.11 tests and modified schedule for 2.12 convergence…

### DIFF
--- a/tests/tensorflow/r2.11/common.libsonnet
+++ b/tests/tensorflow/r2.11/common.libsonnet
@@ -48,7 +48,7 @@ local mixins = import 'templates/mixins.libsonnet';
   },
   local functional_schedule = '0 4 * * *',
   Functional:: mixins.Functional {
-    schedule: functional_schedule,
+    schedule: null, 
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -70,7 +70,7 @@ local mixins = import 'templates/mixins.libsonnet';
   },
   // Override default schedule for Functional.
   RunNightly:: {
-    schedule: functional_schedule,
+    schedule: null,
   },
   Convergence:: mixins.Convergence {
     schedule: null,

--- a/tests/tensorflow/r2.11/common.libsonnet
+++ b/tests/tensorflow/r2.11/common.libsonnet
@@ -48,7 +48,7 @@ local mixins = import 'templates/mixins.libsonnet';
   },
   local functional_schedule = '0 4 * * *',
   Functional:: mixins.Functional {
-    schedule: null, 
+    schedule: null,
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {

--- a/tests/tensorflow/r2.12/common.libsonnet
+++ b/tests/tensorflow/r2.12/common.libsonnet
@@ -139,9 +139,10 @@ local mixins = import 'templates/mixins.libsonnet';
   },
   // Override default schedule for Functional.
   RunNightly:: {
-    schedule: '0 5 * * 2,6',
+    schedule: functional_schedule,
   },
   Convergence:: mixins.Convergence {
+    schedule: '0 5 * * 2,6',
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {

--- a/tests/tensorflow/r2.9/common.libsonnet
+++ b/tests/tensorflow/r2.9/common.libsonnet
@@ -50,9 +50,9 @@ local mixins = import 'templates/mixins.libsonnet';
       runnerPath: 'official/nlp/train.py',
     },
   },
-  local functional_schedule = '0 21 * * *',
+  local functional_schedule = null,
   Functional:: mixins.Functional {
-    schedule: null,
+    schedule: functional_schedule,
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {

--- a/tests/tensorflow/r2.9/keras-api.libsonnet
+++ b/tests/tensorflow/r2.9/keras-api.libsonnet
@@ -38,7 +38,6 @@ local utils = import 'templates/utils.libsonnet';
     mode: 'api',
     timeout: timeouts.one_hour,
     // Run at 2AM PST daily
-    schedule: '0 10 * * *',
     tpuSettings+: {
       preemptible: true,
     },


### PR DESCRIPTION
… tests

# Description

1. Cleaned up TF 2.9 and 2.11 unnecessary tests. 
2. Modified TF 2.12 convergence tests schedule

# Tests

cleanup and regenerating tests didn't throw any error. I haven't any other new tests.

**Instruction and/or command lines to reproduce your tests:** ...

Assuming user is on root directory of ml-testing-accelerators 

run 

` ./scripts/gen-tests.sh `

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ x] I have performed a self-review of my code.
- [ x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ x] I have run one-shot tests and provided workload links above if applicable. 
- [ x] I have made or will make corresponding changes to the doc if needed.