### PR TITLE
Changes related to tf 2.12.0rc1 tests and fixed gpu scheduling issue

### DIFF
--- a/tests/tensorflow/r2.12/base.libsonnet
+++ b/tests/tensorflow/r2.12/base.libsonnet
@@ -106,7 +106,7 @@ local volumes = import 'templates/volumes.libsonnet';
                   accelerator_type: %(acceleratorName)s,
                   runtime_version: %(softwareVersion)s,
                   network_config: {enable_external_ips: true},
-                  boot_disk: {source_image: 'projects/cloud-tpu-v2-images-dev/global/images/tpu-vm-tf-2-12-0-20230218'},
+                  boot_disk: {source_image: 'projects/cloud-tpu-v2-images-dev/global/images/tpu-vm-tf-2-12-0-20230308'},
                   metadata: {
                     'ssh-keys': 'xl-ml-test:$(cat /scripts/id_rsa.pub)',
                     'startup-script': %(startupScript)s,

--- a/tests/tensorflow/r2.12/common.libsonnet
+++ b/tests/tensorflow/r2.12/common.libsonnet
@@ -23,7 +23,7 @@ local mixins = import 'templates/mixins.libsonnet';
 
     frameworkPrefix: 'tf-r2.12.0',
     tpuSettings+: {
-      softwareVersion: '2.11.0',
+      softwareVersion: '2.12.0',
     },
     imageTag: 'r2.12.0',
     podTemplate+:: {
@@ -90,9 +90,9 @@ local mixins = import 'templates/mixins.libsonnet';
     local config = self,
     tpuSettings+: {
       softwareVersion: if config.accelerator.replicas == 1 then
-        'tpu-vm-tf-2.11.0'
+        'tpu-vm-tf-2.12.0'
       else
-        'tpu-vm-tf-2.11.0-pod',
+        'tpu-vm-tf-2.12.0-pod',
     },
     podTemplate+:: {
       spec+: {

--- a/tests/tensorflow/r2.12/common.libsonnet
+++ b/tests/tensorflow/r2.12/common.libsonnet
@@ -145,7 +145,7 @@ local mixins = import 'templates/mixins.libsonnet';
     schedule: functional_schedule,
   },
   Convergence:: mixins.Convergence {
-    schedule: '0 5 * * 2,6',
+    schedule: '0 5 * * 0,4',
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {

--- a/tests/tensorflow/r2.12/common.libsonnet
+++ b/tests/tensorflow/r2.12/common.libsonnet
@@ -26,65 +26,68 @@ local mixins = import 'templates/mixins.libsonnet';
       softwareVersion: '2.12.0',
     },
     imageTag: 'r2.12.0',
-    podTemplate+:: {
-      spec+: {
-        initContainerMap+:: {
-          'tpu-version': {
-            image: config.podTemplate.spec.containerMap.train.image,
-            env+: [
-              {
-                name: 'TPU_NAME',
-                valueFrom: {
-                  fieldRef: {
-                    fieldPath: "metadata.annotations['name.cloud-tpus.google.com/train']",
+    podTemplate+:: if config.accelerator.type == 'tpu' then
+      {
+        spec+: {
+          initContainerMap+:: {
+            'tpu-version': {
+              image: config.podTemplate.spec.containerMap.train.image,
+              env+: [
+                {
+                  name: 'TPU_NAME',
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: "metadata.annotations['name.cloud-tpus.google.com/train']",
+                    },
                   },
                 },
-              },
-              {
-                name: 'POD_UID',
-                valueFrom: {
-                  fieldRef: {
-                    fieldPath: 'metadata.uid',
+                {
+                  name: 'POD_UID',
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: 'metadata.uid',
+                    },
                   },
                 },
+              ],
+              local tpuCreateSettings = {
+                acceleratorName: std.escapeStringBash(config.accelerator.name),
+                softwareVersion: std.escapeStringBash(config.tpuSettings.softwareVersion),
+                startupScript: std.escapeStringBash(config.tpuSettings.tpuVmStartupScript),
+                sleepTime: config.tpuSettings.tpuVmCreateSleepSeconds,
+                testName: std.strReplace(config.testName, '.', '-'),
               },
-            ],
-            local tpuCreateSettings = {
-              acceleratorName: std.escapeStringBash(config.accelerator.name),
-              softwareVersion: std.escapeStringBash(config.tpuSettings.softwareVersion),
-              startupScript: std.escapeStringBash(config.tpuSettings.tpuVmStartupScript),
-              sleepTime: config.tpuSettings.tpuVmCreateSleepSeconds,
-              testName: std.strReplace(config.testName, '.', '-'),
+              command: [
+                'python3',
+                '-c',
+                |||
+                  import os
+                  import tensorflow as tf
+                  import urllib
+                  import json
+                  import cloud_tpu_client
+                  import sys
+                  print('python version: ' + str(sys.version))
+                  print('tf_version: ' + str(tf.__version__))
+                  print(str(tf.__file__))
+                  ctc = cloud_tpu_client.Client(tpu=os.path.basename('$(TPU_NAME)'), zone=os.path.dirname('$(TPU_NAME)'))
+                  ctc.wait_for_healthy()
+                  ctc.configure_tpu_version('2.12.0', restart_type='always')
+                  ctc.wait_for_healthy()
+                  _VERSION_SWITCHER_ENDPOINT = 'http://{}:8475/requestversion'
+                  url = _VERSION_SWITCHER_ENDPOINT.format(ctc.network_endpoints()[0]['ipAddress'])
+                  req = urllib.request.Request(url)
+                  resp = urllib.request.urlopen(req)
+                  version_details = json.loads(resp.read())
+                  print(version_details)
+                |||,
+              ],
             },
-            command: [
-              'python3',
-              '-c',
-              |||
-                import os
-                import tensorflow as tf
-                import urllib
-                import json
-                import cloud_tpu_client
-                import sys
-                print('python version: ' + str(sys.version))
-                print('tf_version: ' + str(tf.__version__))
-                print(str(tf.__file__))
-                ctc = cloud_tpu_client.Client(tpu=os.path.basename('$(TPU_NAME)'), zone=os.path.dirname('$(TPU_NAME)'))
-                ctc.wait_for_healthy()
-                ctc.configure_tpu_version('2.12.0', restart_type='always')
-                ctc.wait_for_healthy()
-                _VERSION_SWITCHER_ENDPOINT = 'http://{}:8475/requestversion'
-                url = _VERSION_SWITCHER_ENDPOINT.format(ctc.network_endpoints()[0]['ipAddress'])
-                req = urllib.request.Request(url)
-                resp = urllib.request.urlopen(req)
-                version_details = json.loads(resp.read())
-                print(version_details)
-              |||,
-            ],
           },
         },
-      },
-    },
+      }
+    else
+      {},
   },
   tpuVm:: experimental.TensorFlowTpuVmMixin {
     local config = self,


### PR DESCRIPTION
# Description
Several changes are made related to tf 2.12.0rc1. 
1) changed the tpu vm image that reflects rc1
2) adjusted software versions from 2.11 to 2.12
3) fixed bug for running gpu tests
4) changed convergence test schedule
# Tests
Change 1) no test is needed since the image built successfully
Change 2) tested by spinning up TPU nodes and VMs separately
Change 3) tested by 3 successful oneshot tests, one for TPU node, one for TPU VM, and one for GPU
Change 4) no test needed
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.