### PR TITLE
Update E2E test names in JAX

### DIFF
--- a/tests/jax/latest/flax-bart-wiki_summary.libsonnet
+++ b/tests/jax/latest/flax-bart-wiki_summary.libsonnet
@@ -19,8 +19,8 @@ local tpus = import 'templates/tpus.libsonnet';
 {
   local hf_bart_common = common.JaxTest + common.huggingFace {
     local config = self,
-    frameworkPrefix: 'flax-latest',
-    modelName:: 'hf-bart',
+    frameworkPrefix: 'flax.latest',
+    modelName:: 'bart-wiki.summary',
     extraFlags:: [],
     testScript:: |||
       %(installPackages)s

--- a/tests/jax/latest/flax-bert-glue_mnli.libsonnet
+++ b/tests/jax/latest/flax-bert-glue_mnli.libsonnet
@@ -1,0 +1,83 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local common = import '../common.libsonnet';
+local latest_common = import 'common.libsonnet';
+local mixins = import 'templates/mixins.libsonnet';
+local timeouts = import 'templates/timeouts.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+{
+  local hf_bert_mnli = latest_common.hfBertCommon {
+    modelName+: '.mnli',
+    extraFlags+: ['--task_name mnli', '--max_seq_length 512', '--eval_steps 1000'],
+  },
+
+  local functional = mixins.Functional {
+    extraFlags+: ['--num_train_epochs 1'],
+    extraConfig:: 'default.py',
+  },
+
+  local convergence = mixins.Convergence {
+    extraConfig:: 'default.py',
+    extraFlags+: ['--num_train_epochs 3', '--learning_rate 2e-5', '--eval_steps 500'],
+    metricConfig+: {
+      sourceMap+:: {
+        tensorboard+: {
+          aggregateAssertionsMap+:: {
+            'eval/accurary': {
+              FINAL: {
+                fixed_value: {
+                  comparison: 'GREATER',
+                  value: 0.84,
+                },
+                inclusive_bounds: false,
+                wait_for_n_data_points: 0,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
+  local v2 = common.tpuVmBaseImage {
+    extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
+  },
+  local v3 = common.tpuVmBaseImage {
+    extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
+  },
+  local v4 = common.tpuVmV4Base {
+    extraFlags+:: ['--per_device_train_batch_size 8', '--per_device_eval_batch_size 8'],
+  },
+
+  local v2_8 = v2 {
+    accelerator: tpus.v2_8,
+  },
+  local v3_8 = v3 {
+    accelerator: tpus.v3_8,
+  },
+  local v4_8 = v4 {
+    accelerator: tpus.v4_8,
+  },
+  local v4_32 = v4 {
+    accelerator: tpus.v4_32,
+  },
+
+  configs: [
+    hf_bert_mnli + convergence + v4_32,
+    hf_bert_mnli + functional + v4_8,
+    hf_bert_mnli + functional + v3_8,
+    hf_bert_mnli + functional + v2_8 + timeouts.Minutes(75),
+  ],
+}

--- a/tests/jax/latest/flax-resnet-imagenet.libsonnet
+++ b/tests/jax/latest/flax-resnet-imagenet.libsonnet
@@ -34,7 +34,8 @@ local tpus = import 'templates/tpus.libsonnet';
     extraFlags+:: ['--config.batch_size=$((32*256))'],
   },
   local imagenet = common.runFlaxLatest {
-    modelName:: 'imagenet',
+    folderName:: 'imagenet',
+    modelName:: 'resnet-imagenet',
     extraDeps+:: ['tensorflow-cpu tensorflow-datasets'],
   },
   configs: [

--- a/tests/jax/latest/flax-vit-imagenette.libsonnet
+++ b/tests/jax/latest/flax-vit-imagenette.libsonnet
@@ -19,8 +19,8 @@ local tpus = import 'templates/tpus.libsonnet';
 {
   local hf_vit_common = common.JaxTest + common.huggingFace {
     local config = self,
-    frameworkPrefix: 'flax-latest',
-    modelName:: 'hf-vit',
+    frameworkPrefix: 'flax.latest',
+    modelName:: 'vit-imagenette',
     extraFlags:: [],
     testScript:: |||
       %(installPackages)s

--- a/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
+++ b/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
@@ -40,7 +40,8 @@ local tpus = import 'templates/tpus.libsonnet';
     accelerator: tpus.v2_8,
   },
   local wmt = common.runFlaxLatest {
-    modelName:: 'wmt',
+    folderName:: 'wmt',
+    modelName:: 'wmt-wmt17.translate',
     extraDeps+:: ['tensorflow-cpu tensorflow-datasets tensorflow_text sentencepiece'],
   },
   local wmt_profiling = wmt {

--- a/tests/jax/latest/targets.jsonnet
+++ b/tests/jax/latest/targets.jsonnet
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License,
 
-local hf_bart = import 'hf-bart.libsonnet';
-local hf_glue = import 'hf-glue.libsonnet';
-local hf_vit = import 'hf-vit.libsonnet';
-local imagenet = import 'imagenet.libsonnet';
-local wmt = import 'wmt.libsonnet';
+local hf_bart = import 'flax-bart-wiki_summary.libsonnet';
+local hf_bert_mnli = import 'flax-bert-glue_mnli.libsonnet';
+local hf_bert_mrpc = import 'flax-bert-glue_mrpc.libsonnet';
+local resnet = import 'flax-resnet-imagenet.libsonnet';
+local hf_vit = import 'flax-vit-imagenette.libsonnet';
+local wmt = import 'flax-wmt-wmt17_translate.libsonnet';
 
 // Add new models here
 std.flattenArrays([
   hf_bart.configs,
   hf_vit.configs,
-  hf_glue.configs,
-  imagenet.configs,
+  hf_bert_mnli.configs,
+  hf_bert_mrpc.configs,
+  resnet.configs,
   wmt.configs,
 ])


### PR DESCRIPTION
# Description

Update E2E model test and file names based on [guidelines](http://shortn/_khhZ7Y5OSe). At high level:
* A file name will be a combination of framework name, model name, and dataset name.
* A test name will be a combination of framework version, model name, dataset name, test type, and TPU type.

One example of file name:
* Previous name: `imagenet.libsonnet`
* New name: `flax-resnet-imagenet.libsonnet`

One example of test name:
* Previous name: `flax-latest-wmt-conv-v3-32`
* New name:
  * JAX: `flax.latest-wmt-wmt17.translate-conv-v3-32`
  * TF: `tf.r.2.12.0-wmt-wmt17.translate-conv-v3-32`
* Note that a job name can only be lower case alphanumeric characters, `-` or `.` (`-` and `.` are used for partition purpose, and will help UI filtering).  The TPU type`v3.32` may be quite uncommon and also invalid argument for accelerator.  But I am happy to make this change in test name only if we want to.

Main changes:
* Update all file and test names in JAX.
* Please see Naming Convention section in this [doc](http://shortn/_17GL6YOzVi) for each test & file name change.
* Add dataset info into `modelName` config instead of adding a new field to avoid many if/else statement in Jsonnet config (other frameworks do not have this dataset info, i.e. PyTorch, PAX, etc).
* Split `hf_glue` file into 2 files as they are using different sub-datasets for `mnli` and `mrpc` tasks.

# Tests

Please describe the tests that you ran on TPUs to verify changes.

**Instruction and/or command lines to reproduce your tests:** 

```
./scripts/run-oneshot.sh -t <test_name>
```

**List links for your tests (use go/shortn-gen for any internal link):** 
I tested one in each file:
* [flax.latest-bart-wiki.summary-func-v2-8](http://shortn/_iuBJjmmnBU)
* [flax.latest-bert-glue.mnli-func-v4-8](http://shortn/_5f3itW9rHL)
* [flax.latest-bert-glue.mrpc-func-v3-8](http://shortn/_5yvn0VPm2u)
* [flax.latest-resnet-imagenet-func-v2-8](http://shortn/_MIi4rMGwce)
* [flax.latest-vit-imagenette-func-v4-8](http://shortn/_WgSHISf2rp)
* [flax.latest-wmt-wmt17.translate-profile-v3-8](http://shortn/_TIuT2aXt70)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.