### PR TITLE
[PyTorch/XLA] Lower convergence rate for mnist DDP

### DIFF
--- a/tests/pytorch/nightly/mnist.libsonnet
+++ b/tests/pytorch/nightly/mnist.libsonnet
@@ -58,6 +58,27 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
+  // DDP converges worse than MP.
+  local convergence_ddp = convergence {
+    metricConfig+: {
+      sourceMap+:: {
+        tensorboard+: {
+          aggregateAssertionsMap+:: {
+            'Accuracy/test': {
+              FINAL: {
+                fixed_value: {
+                  comparison: 'GREATER',
+                  value: 97.0,
+                },
+                inclusive_bounds: false,
+                wait_for_n_data_points: 0,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 
   local v2_8 = {
     accelerator: tpus.v2_8,
@@ -100,7 +121,7 @@ local utils = import 'templates/utils.libsonnet';
     mnist + convergence + v2_8 + timeouts.Hours(1) + mixins.Experimental,
     mnist + convergence + v2_8 + timeouts.Hours(1) + tpuVm + mixins.Experimental,
     mnist + convergence + v2_8 + timeouts.Hours(1) + pjrt,
-    mnist + convergence + v2_8 + timeouts.Hours(1) + pjrt + pjrt_ddp,
+    mnist + convergence_ddp + v2_8 + timeouts.Hours(1) + pjrt + pjrt_ddp,
     mnist + convergence + v4_8 + timeouts.Hours(1) + pjrt + mixins.Experimental,
     mnist + convergence + v100x4 + timeouts.Hours(6) + mixins.Experimental,
   ],

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -89,7 +89,7 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
   // DDP converges worse than MP.
-  local convergence_ddp = cconvergence {
+  local convergence_ddp = convergence {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -89,13 +89,7 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
   // DDP converges worse than MP.
-  local convergence_ddp = common.Convergence {
-    local config = self,
-
-    command+: [
-      '--num_epochs=90',
-      '--datadir=/datasets/imagenet',
-    ],
+  local convergence_ddp = cconvergence {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {

--- a/tests/pytorch/r2.0/mnist.libsonnet
+++ b/tests/pytorch/r2.0/mnist.libsonnet
@@ -58,6 +58,27 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
+  // DDP converges worse than MP.
+  local convergence_ddp = convergence {
+    metricConfig+: {
+      sourceMap+:: {
+        tensorboard+: {
+          aggregateAssertionsMap+:: {
+            'Accuracy/test': {
+              FINAL: {
+                fixed_value: {
+                  comparison: 'GREATER',
+                  value: 97.0,
+                },
+                inclusive_bounds: false,
+                wait_for_n_data_points: 0,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 
   local v2_8 = {
     accelerator: tpus.v2_8,
@@ -100,7 +121,7 @@ local utils = import 'templates/utils.libsonnet';
     mnist + convergence + v2_8 + timeouts.Hours(1) + mixins.Experimental,
     mnist + convergence + v2_8 + timeouts.Hours(1) + tpuVm + mixins.Experimental,
     mnist + convergence + v2_8 + timeouts.Hours(1) + pjrt,
-    mnist + convergence + v2_8 + timeouts.Hours(1) + pjrt + pjrt_ddp,
+    mnist + convergence_ddp + v2_8 + timeouts.Hours(1) + pjrt + pjrt_ddp,
     mnist + convergence + v4_8 + timeouts.Hours(1) + pjrt + mixins.Experimental,
     mnist + convergence + v100x4 + timeouts.Hours(6) + mixins.Experimental,
   ],

--- a/tests/pytorch/r2.0/resnet50-mp.libsonnet
+++ b/tests/pytorch/r2.0/resnet50-mp.libsonnet
@@ -81,13 +81,7 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
   // DDP converges worse than MP.
-  local convergence_ddp = common.Convergence {
-    local config = self,
-
-    command+: [
-      '--num_epochs=90',
-      '--datadir=/datasets/imagenet',
-    ],
+  local convergence_ddp = convergence {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {


### PR DESCRIPTION
# Description

DDP has a known issue that it converges slower than mp. Let's use the slower rate.

# Tests

CI

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.