### PR TITLE
Add script to schedule tests

### DIFF
--- a/scripts/schedule_tests.sh
+++ b/scripts/schedule_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+if [[ -z "${XLML_TEST_TYPE}" ]]; then
+    echo "Please set XLML_TEST_TYPE"
+    exit 1
+else
+    test_type="${XLML_TEST_TYPE}"
+fi
+
+regions=(us-central1 us-central2 europe-west4)
+for region in ${regions[@]}; do
+
+    gcloud container clusters get-credentials xl-ml-test-"$region" --region "$region" --project xl-ml-test
+    for i in $(kubectl get cronjobs -n automated -o name | grep "$test_type"); do
+        echo "$i"
+        jobName=$(echo "$i" | awk -F/ '{print $2}')
+        echo "Creating $jobName"
+        kubectl create job --from="$i" "$jobName" -n automated
+    done
+done

--- a/scripts/schedule_tests.sh
+++ b/scripts/schedule_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Create UUID for job creation / lookup
+uuid=$(uuidgen)
+
 # First, check that the type is set
 if [[ -z "${XLML_TEST_TYPE}" ]]; then
     echo "Please set XLML_TEST_TYPE"
@@ -19,7 +22,9 @@ for region in ${regions[@]}; do
 
         # Finally, parse the jobname from the cronjob and create the new job
         jobName=$(echo "$i" | awk -F/ '{print $2}')
-        echo "Creating $jobName"
-        kubectl create job --from="$i" "$jobName" -n automated
+        echo "Creating $jobName-$uuid"
+        kubectl create job --from="$i" "$jobName-$uuid" -n automated
     done
 done
+
+echo "Find the scheduled jobs by filtering with the uuid: $uuid"

--- a/scripts/schedule_tests.sh
+++ b/scripts/schedule_tests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# First, check that the type is set
 if [[ -z "${XLML_TEST_TYPE}" ]]; then
     echo "Please set XLML_TEST_TYPE"
     exit 1
@@ -6,12 +8,16 @@ else
     test_type="${XLML_TEST_TYPE}"
 fi
 
+# Loop over regions and connect to each cluster
 regions=(us-central1 us-central2 europe-west4)
 for region in ${regions[@]}; do
-
     gcloud container clusters get-credentials xl-ml-test-"$region" --region "$region" --project xl-ml-test
+
+    # Loop over cron jobs, grepping for the test type
     for i in $(kubectl get cronjobs -n automated -o name | grep "$test_type"); do
         echo "$i"
+
+        # Finally, parse the jobname from the cronjob and create the new job
         jobName=$(echo "$i" | awk -F/ '{print $2}')
         echo "Creating $jobName"
         kubectl create job --from="$i" "$jobName" -n automated

--- a/scripts/schedule_tests.sh
+++ b/scripts/schedule_tests.sh
@@ -1,7 +1,25 @@
 #!/bin/bash
 
+regions=(us-central1 us-central2 europe-west4)
+
+function schedule()
+{
+    # Loop over regions and connect to each cluster
+    for region in ${regions[@]}; do
+        gcloud container clusters get-credentials xl-ml-test-"$region" --region "$region" --project xl-ml-test >/dev/null 2>&1
+
+        # Loop over cron jobs, grepping for the test type
+        for i in $(kubectl get cronjobs -n automated -o name | grep "$test_type"); do
+            # Finally, parse the jobname from the cronjob and create the new job
+            jobName=$(echo "$i" | awk -F/ '{print $2}')
+            echo "Creating $jobName-$uuid"
+            kubectl create job --from="$i" "$jobName-$uuid" -n automated
+        done
+    done
+}
+
 # Create UUID for job creation / lookup
-uuid=$(uuidgen)
+uuid=$(uuidgen -r | awk -F- '{print $1}')
 
 # First, check that the type is set
 if [[ -z "${XLML_TEST_TYPE}" ]]; then
@@ -11,20 +29,25 @@ else
     test_type="${XLML_TEST_TYPE}"
 fi
 
-# Loop over regions and connect to each cluster
-regions=(us-central1 us-central2 europe-west4)
+echo "Fetching all jobs of type $test_type"
+
+# Loop over regions to count the total number of jobs
+total_jobs=0
 for region in ${regions[@]}; do
-    gcloud container clusters get-credentials xl-ml-test-"$region" --region "$region" --project xl-ml-test
-
-    # Loop over cron jobs, grepping for the test type
-    for i in $(kubectl get cronjobs -n automated -o name | grep "$test_type"); do
-        echo "$i"
-
-        # Finally, parse the jobname from the cronjob and create the new job
-        jobName=$(echo "$i" | awk -F/ '{print $2}')
-        echo "Creating $jobName-$uuid"
-        kubectl create job --from="$i" "$jobName-$uuid" -n automated
-    done
+    gcloud container clusters get-credentials xl-ml-test-"$region" --region "$region" --project xl-ml-test >/dev/null 2>&1
+    jobs_in_region=$(kubectl get cronjobs -n automated -o name | grep -o "$test_type" | wc -l)
+    total_jobs=$((total_jobs+jobs_in_region))
 done
 
-echo "Find the scheduled jobs by filtering with the uuid: $uuid"
+# Confirm that the jobs should be scheduled
+echo "Scheduling $total_jobs jobs of the type $test_type."
+read -p "Is this correct? (If so, press 'y') " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  echo "Scheduling jobs..."
+  schedule
+  echo "All jobs have been scheduled. Find the scheduled jobs by filtering with the uuid: $uuid"
+else
+  echo "Aborting"
+fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,6 +70,17 @@ In case you want to run multiple tests, you might find it convenient to combine 
 Please be mindful of the resources in the project before running this.
 
 
+### Scheduling jobs for all tests of a given type
+
+If you want to run a group of tests, e.g. all `pt-nightly` tests, you can do so using the `schedule_tests.sh` script. You will need to set the `XLML_TEST_TYPE` based on the root of the test, e.g.
+
+```bash
+XLML_TEST_TYPE=pt-nightly ./scripts/schedule_tests.sh
+```
+
+This should only be done when absolutely necessary, e.g. during release testing.
+
+
 ## Creating a New Test
 
 To create a new test, start by copying a similar file from the same ML framework and version. Update the training commands as necessary, and add that file to the `targets.jsonnet` in the same directory.


### PR DESCRIPTION
# Description

Adds a script to schedule a batch of oneshots for one type of test, based on matching the start of the jobname. For example, if we want to run all of the `pt-nightly` tests, we can run `XLML_TEST_TYPE=pt-nightly ./scripts/schedule_tests.sh`. It connects to every cluster on which we have tests, gathers the tests from those clusters, and creates the jobs.

# Tests

This can be used for any test, but doesn't modify the test itself.

**Instruction and/or command lines to reproduce your tests:** ...

Run something like `XLML_TEST_TYPE=pt-nightly ./scripts/schedule_tests.sh`

**List links for your tests (use go/shortn-gen for any internal link):** ...

Example: http://shortn/_FEDtYR413y

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.