### PR TITLE
Clone upstream in common test setup

### DIFF
--- a/tests/pytorch/r2.0/common.libsonnet
+++ b/tests/pytorch/r2.0/common.libsonnet
@@ -103,9 +103,7 @@ local volumes = import 'templates/volumes.libsonnet';
         sudo pip3 install mkl mkl-include cloud-tpu-client
         sudo apt-get -y update
         sudo apt-get install -y libomp5
-        # No need to check out the PyTorch repository, but check out PT/XLA at
-        # pytorch/xla anyway
-        mkdir pytorch
+        git clone https://github.com/pytorch/pytorch.git -b release/2.0
         cd pytorch
         git clone https://github.com/pytorch/xla.git -b r2.0
       |||,


### PR DESCRIPTION
# Description

Quick fix to run upstream tests in pytorch r2.0

# Tests

Affects all pt-2.0 tests, specifically python ops test

**Instruction and/or command lines to reproduce your tests:** ...

Run the python ops tests in pt-2.0 as a oneshot

**List links for your tests (use go/shortn-gen for any internal link):** ...

http://shortn/_fm21SVYUdU

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.