### PR TITLE
Extend running time limit for bert test

### DIFF
--- a/tests/jax/latest/flax-bert-glue_mnli.libsonnet
+++ b/tests/jax/latest/flax-bert-glue_mnli.libsonnet
@@ -77,7 +77,7 @@ local tpus = import 'templates/tpus.libsonnet';
   configs: [
     hf_bert_mnli + convergence + v4_32,
     hf_bert_mnli + functional + v4_8,
-    hf_bert_mnli + functional + v3_8,
+    hf_bert_mnli + functional + v3_8 + timeouts.Minutes(75),
     hf_bert_mnli + functional + v2_8 + timeouts.Minutes(75),
   ],
 }


### PR DESCRIPTION
# Description

Extend running time limit for BERT test on glue mnli to avoid time-out issue.

# Tests

**Instruction and/or command lines to reproduce your tests:** 

```
./scripts/run-oneshot.sh -t <test_name>
```

**List links for your tests (use go/shortn-gen for any internal link):** 
* Tested [flax.latest-bert-glue.mnli-func-v3-8](http://shortn/_TtzGRG6Iui)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.