### PR TITLE
Typo: software version need to 2.11.0 to create TPU node and then we …

### DIFF
--- a/tests/tensorflow/r2.11/common.libsonnet
+++ b/tests/tensorflow/r2.11/common.libsonnet
@@ -23,7 +23,7 @@ local mixins = import 'templates/mixins.libsonnet';
 
     frameworkPrefix: 'tf-r2.11.1',
     tpuSettings+: {
-      softwareVersion: '2.11.1',
+      softwareVersion: '2.11.0',
     },
     imageTag: 'r2.11.1',
     podTemplate+:: if config.accelerator.type == 'tpu' then


### PR DESCRIPTION
software version need to 2.11.0 to create TPU node and then we switch it with 2.11.1

# Description

Fixed a typo. 

# Tests

Run the test - http://shortn/_6j2aaFognG

**Instruction and/or command lines to reproduce your tests:** ...

./scripts/run-oneshot.sh -t tf-r2.11.1-keras-api-ctl-v2-8

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [*] I have performed a self-review of my code.
- [*] I have necessary comments in my code, particularly in hard-to-understand areas.
- [*] I have run one-shot tests and provided workload links above if applicable. 
- [*] I have made or will make corresponding changes to the doc if needed.