### PR TITLE
Refactor tests to support adding this repository as a submodule

### DIFF
--- a/tests/jax/compilation-cache.libsonnet
+++ b/tests/jax/compilation-cache.libsonnet
@@ -16,7 +16,8 @@ local common = import 'common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 
 {
-  local compilationCacheTest = common.JaxTest + mixins.Functional {
+  local compilationCacheTest = self.compilationCacheTest,
+  compilationCacheTest:: common.JaxTest + mixins.Functional {
     modelName: 'compilation-cache-test',
 
     testScript:: |||

--- a/tests/jax/latest/flax-bart-wiki_summary.libsonnet
+++ b/tests/jax/latest/flax-bart-wiki_summary.libsonnet
@@ -17,7 +17,8 @@ local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local hf_bart_common = common.JaxTest + common.huggingFace {
+  local hf_bart_common = self.hf_bart_common,
+  hf_bart_common:: common.JaxTest + common.huggingFace {
     local config = self,
     frameworkPrefix: 'flax.latest',
     modelName:: 'bart-wiki.summary',
@@ -48,10 +49,12 @@ local tpus = import 'templates/tpus.libsonnet';
     ||| % (self.scriptConfig { extraFlags: std.join(' ', config.extraFlags) }),
   },
 
-  local func = mixins.Functional {
+  local func = self.func,
+  func:: mixins.Functional {
     extraFlags+:: ['--num_train_epochs 3'],
   },
-  local conv = mixins.Convergence {
+  local conv = self.conv,
+  conv:: mixins.Convergence {
     extraFlags+:: ['--num_train_epochs 30'],
 
     metricConfig+: {
@@ -74,27 +77,33 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_8 = common.tpuVmBaseImage {
+  local v2_8 = self.v2_8,
+  v2_8:: common.tpuVmBaseImage {
     accelerator: tpus.v2_8,
     extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
-  local v2_32 = common.tpuVmBaseImage {
+  local v2_32 = self.v2_32,
+  v2_32:: common.tpuVmBaseImage {
     accelerator: tpus.v2_32,
     extraFlags+:: ['--per_device_train_batch_size 8', '--per_device_eval_batch_size 8'],
   },
-  local v3_8 = common.tpuVmBaseImage {
+  local v3_8 = self.v3_8,
+  v3_8:: common.tpuVmBaseImage {
     accelerator: tpus.v3_8,
     extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
-  local v3_32 = common.tpuVmBaseImage {
+  local v3_32 = self.v3_32,
+  v3_32:: common.tpuVmBaseImage {
     accelerator: tpus.v3_32,
     extraFlags+:: ['--per_device_train_batch_size 16', '--per_device_eval_batch_size 16'],
   },
-  local v4_8 = common.tpuVmV4Base {
+  local v4_8 = self.v4_8,
+  v4_8:: common.tpuVmV4Base {
     accelerator: tpus.v4_8,
     extraFlags+:: ['--per_device_train_batch_size 64', '--per_device_eval_batch_size 64'],
   },
-  local v4_32 = common.tpuVmV4Base {
+  local v4_32 = self.v4_32,
+  v4_32:: common.tpuVmV4Base {
     accelerator: tpus.v4_32,
     extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },

--- a/tests/jax/latest/flax-bert-glue_mnli.libsonnet
+++ b/tests/jax/latest/flax-bert-glue_mnli.libsonnet
@@ -18,17 +18,20 @@ local mixins = import 'templates/mixins.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
-  local hf_bert_mnli = latest_common.hfBertCommon {
+  local hf_bert_mnli = self.hf_bert_mnli,
+  hf_bert_mnli:: latest_common.hfBertCommon {
     modelName+: '.mnli',
     extraFlags+: ['--task_name mnli', '--max_seq_length 512', '--eval_steps 1000'],
   },
 
-  local functional = mixins.Functional {
+  local functional = self.functional,
+  functional:: mixins.Functional {
     extraFlags+: ['--num_train_epochs 1'],
     extraConfig:: 'default.py',
   },
 
-  local convergence = mixins.Convergence {
+  local convergence = self.convergence,
+  convergence:: mixins.Convergence {
     extraConfig:: 'default.py',
     extraFlags+: ['--num_train_epochs 3', '--learning_rate 2e-5', '--eval_steps 500'],
     metricConfig+: {
@@ -51,26 +54,33 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2 = common.tpuVmBaseImage {
+  local v2 = self.v2,
+  v2:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
   },
-  local v3 = common.tpuVmBaseImage {
+  local v3 = self.v3,
+  v3:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
   },
-  local v4 = common.tpuVmV4Base {
+  local v4 = self.v4,
+  v4:: common.tpuVmV4Base {
     extraFlags+:: ['--per_device_train_batch_size 8', '--per_device_eval_batch_size 8'],
   },
 
-  local v2_8 = v2 {
+  local v2_8 = self.v2_8,
+  v2_8:: v2 {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = v3 {
+  local v3_8 = self.v3_8,
+  v3_8:: v3 {
     accelerator: tpus.v3_8,
   },
-  local v4_8 = v4 {
+  local v4_8 = self.v4_8,
+  v4_8:: v4 {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = v4 {
+  local v4_32 = self.v4_32,
+  v4_32:: v4 {
     accelerator: tpus.v4_32,
   },
 

--- a/tests/jax/latest/flax-bert-glue_mrpc.libsonnet
+++ b/tests/jax/latest/flax-bert-glue_mrpc.libsonnet
@@ -17,17 +17,20 @@ local latest_common = import 'common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
-  local hf_bert_mrpc = latest_common.hfBertCommon {
+  local hf_bert_mrpc = self.hf_bert_mrpc,
+  hf_bert_mrpc:: latest_common.hfBertCommon {
     modelName+: '.mrpc',
     extraFlags+: ['--task_name mrpc', '--max_seq_length 128', '--eval_steps 100'],
   },
 
-  local functional = mixins.Functional {
+  local functional = self.functional,
+  functional:: mixins.Functional {
     extraFlags+: ['--num_train_epochs 1'],
     extraConfig:: 'default.py',
   },
 
-  local convergence = mixins.Convergence {
+  local convergence = self.convergence,
+  convergence:: mixins.Convergence {
     extraConfig:: 'default.py',
     extraFlags+: ['--num_train_epochs 3', '--learning_rate 2e-5', '--eval_steps 500'],
     metricConfig+: {
@@ -50,26 +53,33 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2 = common.tpuVmBaseImage {
+  local v2 = self.v2,
+  v2:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
   },
-  local v3 = common.tpuVmBaseImage {
+  local v3 = self.v3,
+  v3:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
   },
-  local v4 = common.tpuVmV4Base {
+  local v4 = self.v4,
+  v4:: common.tpuVmV4Base {
     extraFlags+:: ['--per_device_train_batch_size 8', '--per_device_eval_batch_size 8'],
   },
 
-  local v2_8 = v2 {
+  local v2_8 = self.v2_8,
+  v2_8:: v2 {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = v3 {
+  local v3_8 = self.v3_8,
+  v3_8:: v3 {
     accelerator: tpus.v3_8,
   },
-  local v4_8 = v4 {
+  local v4_8 = self.v4_8,
+  v4_8:: v4 {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = v4 {
+  local v4_32 = self.v4_32,
+  v4_32:: v4 {
     accelerator: tpus.v4_32,
   },
 

--- a/tests/jax/latest/flax-resnet-imagenet.libsonnet
+++ b/tests/jax/latest/flax-resnet-imagenet.libsonnet
@@ -16,24 +16,30 @@ local common = import 'common.libsonnet';
 local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
-  local functional = mixins.Functional {
+  local functional = self.functional,
+  functional:: mixins.Functional {
     extraFlags+:: ['--config.num_epochs=1'],
     extraConfig:: 'default.py',
   },
-  local convergence = mixins.Convergence {
+  local convergence = self.convergence,
+  convergence:: mixins.Convergence {
     extraConfig:: 'tpu.py',
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
     extraFlags+:: ['--config.batch_size=$((32*256))'],
   },
-  local imagenet = common.runFlaxLatest {
+  local imagenet = self.imagenet,
+  imagenet:: common.runFlaxLatest {
     folderName:: 'imagenet',
     modelName:: 'resnet-imagenet',
     extraDeps+:: ['tensorflow-cpu tensorflow-datasets'],

--- a/tests/jax/latest/flax-vit-imagenette.libsonnet
+++ b/tests/jax/latest/flax-vit-imagenette.libsonnet
@@ -17,7 +17,8 @@ local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local hf_vit_common = common.JaxTest + common.huggingFace {
+  local hf_vit_common = self.hf_vit_common,
+  hf_vit_common:: common.JaxTest + common.huggingFace {
     local config = self,
     frameworkPrefix: 'flax.latest',
     modelName:: 'vit-imagenette',
@@ -44,10 +45,12 @@ local tpus = import 'templates/tpus.libsonnet';
     ||| % (self.scriptConfig { extraFlags: std.join(' ', config.extraFlags) }),
   },
 
-  local func = mixins.Functional {
+  local func = self.func,
+  func:: mixins.Functional {
     extraFlags+:: ['--model_type vit', '--num_train_epochs 5'],
   },
-  local conv = mixins.Convergence {
+  local conv = self.conv,
+  conv:: mixins.Convergence {
     extraFlags+:: ['--model_name_or_path google/vit-base-patch16-224-in21k', '--num_train_epochs 30'],
 
     metricConfig+: {
@@ -70,32 +73,41 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2 = common.tpuVmBaseImage {
+  local v2 = self.v2,
+  v2:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
-  local v3 = common.tpuVmBaseImage {
+  local v3 = self.v3,
+  v3:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
-  local v4 = common.tpuVmV4Base {
+  local v4 = self.v4,
+  v4:: common.tpuVmV4Base {
     extraFlags+:: ['--per_device_train_batch_size 64', '--per_device_eval_batch_size 64'],
   },
 
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
   },
 

--- a/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
+++ b/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
@@ -17,34 +17,42 @@ local mixins = import 'templates/mixins.libsonnet';
 local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 {
-  local functional = mixins.Functional {
+  local functional = self.functional,
+  functional:: mixins.Functional {
     extraFlags+:: ['--config.num_train_steps=10', '--config.per_device_batch_size=16'],
     extraConfig:: 'default.py',
   },
-  local convergence = mixins.Convergence {
+  local convergence = self.convergence,
+  convergence:: mixins.Convergence {
     extraConfig:: 'default.py',
     extraFlags+:: ['--config.reverse_translation=True', '--config.per_device_batch_size=32', '--config.num_train_steps=70000'],
   },
-  local profile = mixins.Functional {
+  local profile = self.profile,
+  profile:: mixins.Functional {
     mode: 'profile',
     extraFlags+:: ['--config.num_train_steps=40', '--config.per_device_batch_size=16'],
     extraConfig:: 'default.py',
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local wmt = common.runFlaxLatest {
+  local wmt = self.wmt,
+  wmt:: common.runFlaxLatest {
     folderName:: 'wmt',
     modelName:: 'wmt-wmt17.translate',
     extraDeps+:: ['tensorflow-cpu tensorflow-datasets tensorflow_text sentencepiece'],
   },
-  local wmt_profiling = wmt {
+  local wmt_profiling = self.wmt_profiling,
+  wmt_profiling:: wmt {
     local config = self,
     testScript+:: |||
       gsutil -q stat $(MODEL_DIR)/plugins/profile/*/*.xplane.pb

--- a/tests/jax/pod-test.libsonnet
+++ b/tests/jax/pod-test.libsonnet
@@ -17,7 +17,8 @@ local mixins = import 'templates/mixins.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local podTest = common.JaxTest + mixins.Functional {
+  local podTest = self.podTest,
+  podTest:: common.JaxTest + mixins.Functional {
     modelName: 'pod-%s-%s' % [self.jaxlibVersion, self.tpuSettings.softwareVersion],
 
     testScript:: |||
@@ -44,7 +45,8 @@ local tpus = import 'templates/tpus.libsonnet';
     ||| % self.scriptConfig,
   },
 
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
   },
 

--- a/tests/pax/nightly/c4spmd1b.libsonnet
+++ b/tests/pax/nightly/c4spmd1b.libsonnet
@@ -2,12 +2,14 @@ local common = import 'common.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local c4spmd1b_pretraining = common.NightlyPaxTest + common.Convergence {
+  local c4spmd1b_pretraining = self.c4spmd1b_pretraining,
+  c4spmd1b_pretraining:: common.NightlyPaxTest + common.Convergence {
     modelName:: 'c4spmd1b-pretraining',
     expPath:: 'tasks.lm.params.c4.C4Spmd1BAdam4ReplicasLimitSteps',
     extraFlags:: [],
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/pax/nightly/lmcloudspmdadam.libsonnet
+++ b/tests/pax/nightly/lmcloudspmdadam.libsonnet
@@ -2,11 +2,13 @@ local common = import 'common.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local lmspmdadam = common.NightlyPaxTest + common.Functional {
+  local lmspmdadam = self.lmspmdadam,
+  lmspmdadam:: common.NightlyPaxTest + common.Functional {
     modelName:: 'lmcloudspmdadam',
     expPath:: 'tasks.lm.params.c4.LmCloudSpmdAdamLimitSteps',
   },
-  local v4_16 = {
+  local v4_16 = self.v4_16,
+  v4_16:: {
     accelerator: tpus.v4_16,
   },
   configs: [

--- a/tests/pax/nightly/lmspmd2b.libsonnet
+++ b/tests/pax/nightly/lmspmd2b.libsonnet
@@ -2,12 +2,14 @@ local common = import 'common.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local lmspmd2b = common.NightlyPaxTest + common.Functional {
+  local lmspmd2b = self.lmspmd2b,
+  lmspmd2b:: common.NightlyPaxTest + common.Functional {
     modelName:: 'lmspmd2b',
     expPath:: 'tasks.lm.params.lm_cloud.LmCloudSpmd2BLimitSteps',
     extraFlags:: ['--jax_fully_async_checkpoint=False'],
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/pax/nightly/lmtransformeradam.libsonnet
+++ b/tests/pax/nightly/lmtransformeradam.libsonnet
@@ -2,15 +2,18 @@ local common = import 'common.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local lmtransformeradam = common.NightlyPaxTest + common.Functional {
+  local lmtransformeradam = self.lmtransformeradam,
+  lmtransformeradam:: common.NightlyPaxTest + common.Functional {
     modelName: 'lmtransformeradam',
     expPath:: 'tasks.lm.params.lm_cloud.LmCloudTransformerAdamLimitSteps',
     extraFlags:: ['--jax_fully_async_checkpoint=False', '--pmap_use_tensorstore=True'],
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local v4_16 = {
+  local v4_16 = self.v4_16,
+  v4_16:: {
     accelerator: tpus.v4_16,
   },
   configs: [

--- a/tests/pax/stable/lmspmd2b.libsonnet
+++ b/tests/pax/stable/lmspmd2b.libsonnet
@@ -2,12 +2,14 @@ local common = import 'common.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local lmspmd2b = common.StablePaxTest + common.Functional {
+  local lmspmd2b = self.lmspmd2b,
+  lmspmd2b:: common.StablePaxTest + common.Functional {
     modelName:: 'lmspmd2b',
     expPath:: 'tasks.lm.params.lm_cloud.LmCloudSpmd2BLimitSteps',
     extraFlags:: [],
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/pax/stable/lmtransformeradam.libsonnet
+++ b/tests/pax/stable/lmtransformeradam.libsonnet
@@ -2,12 +2,14 @@ local common = import 'common.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local lmtransformeradam = common.StablePaxTest + common.Functional {
+  local lmtransformeradam = self.lmtransformeradam,
+  lmtransformeradam:: common.StablePaxTest + common.Functional {
     modelName: 'lmtransformeradam',
     expPath:: 'tasks.lm.params.lm_cloud.LmCloudTransformerAdamLimitSteps',
     extraFlags:: ['--jax_fully_async_checkpoint=False', '--pmap_use_tensorstore=True'],
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/pytorch/nightly/cpp-ops.libsonnet
+++ b/tests/pytorch/nightly/cpp-ops.libsonnet
@@ -19,7 +19,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local operations = common.PyTorchTest {
+  local operations = self.operations,
+  operations:: common.PyTorchTest {
     modelName: 'cpp-ops',
     command: [
       'bash',
@@ -34,7 +35,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -46,10 +48,12 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
 

--- a/tests/pytorch/nightly/dlrm.libsonnet
+++ b/tests/pytorch/nightly/dlrm.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local dlrm = common.PyTorchTest {
+  local dlrm = self.dlrm,
+  dlrm:: common.PyTorchTest {
     local config = self,
 
     modelName: 'dlrm',
@@ -60,7 +61,8 @@ local utils = import 'templates/utils.libsonnet';
     cpu: '9.0',
     memory: '30Gi',
   },
-  local dlrm_convergence = common.PyTorchTest {
+  local dlrm_convergence = self.dlrm_convergence,
+  dlrm_convergence:: common.PyTorchTest {
     modelName: 'dlrm-convergence',
 
     volumeMap+: {
@@ -81,7 +83,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local one_core = common.Functional {
+  local one_core = self.one_core,
+  one_core:: common.Functional {
     modelName: 'dlrm-onecore',
     paramsOverride+:: {
       miniBatchSize: 256,
@@ -96,7 +99,8 @@ local utils = import 'templates/utils.libsonnet';
       ||| % utils.toCommandString(self.paramsOverride.trainCommand),
     ),
   },
-  local seq_fwd = common.Functional {
+  local seq_fwd = self.seq_fwd,
+  seq_fwd:: common.Functional {
     modelName: 'dlrm-seq-fwd',
     paramsOverride+:: {
       miniBatchSize: 2048,
@@ -110,7 +114,8 @@ local utils = import 'templates/utils.libsonnet';
       ||| % utils.toCommandString(self.paramsOverride.trainCommand),
     ),
   },
-  local mp_fwd = common.Functional {
+  local mp_fwd = self.mp_fwd,
+  mp_fwd:: common.Functional {
     modelName: 'dlrm-mp-fwd',
     paramsOverride+:: {
       miniBatchSize: 2048,
@@ -123,7 +128,8 @@ local utils = import 'templates/utils.libsonnet';
       ||| % utils.toCommandString(self.paramsOverride.trainCommand),
     ),
   },
-  local mp_dp_fwd = common.Functional {
+  local mp_dp_fwd = self.mp_dp_fwd,
+  mp_dp_fwd:: common.Functional {
     modelName: 'dlrm-mpdp-fwd',
     paramsOverride+:: {
       miniBatchSize: 2048,
@@ -138,7 +144,8 @@ local utils = import 'templates/utils.libsonnet';
     ),
   },
 
-  local criteo_kaggle = common.Convergence {
+  local criteo_kaggle = self.criteo_kaggle,
+  criteo_kaggle:: common.Convergence {
     paramsOverride+:: {
       miniBatchSize: 128,
       archSparseFeatureSize: 16,
@@ -173,7 +180,8 @@ local utils = import 'templates/utils.libsonnet';
     ),
   },
 
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExtraSetup: |||
         pip3 install tqdm scikit-learn tensorboardX google-cloud-storage
@@ -186,17 +194,21 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'dlrm-pjrt',
   },
 
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
   },
   configs: [

--- a/tests/pytorch/nightly/fs-transformer.libsonnet
+++ b/tests/pytorch/nightly/fs-transformer.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local transformer = common.PyTorchTest {
+  local transformer = self.transformer,
+  transformer:: common.PyTorchTest {
     local config = self,
 
     modelName: 'fs-transformer',
@@ -89,13 +90,15 @@ local utils = import 'templates/utils.libsonnet';
   },
 
   // Run the test over a small subset of the data.
-  local base_functional = common.Functional {
+  local base_functional = self.base_functional,
+  base_functional:: common.Functional {
     paramsOverride+:: {
       logSteps: 10,
       inputShape: ['128x64'],
     },
   },
-  local checkpoint_local = base_functional {
+  local checkpoint_local = self.checkpoint_local,
+  checkpoint_local:: base_functional {
     modelName: 'fs-checkpoint-local',
     paramsOverride+:: {
       trainSubset: 'test',
@@ -114,7 +117,8 @@ local utils = import 'templates/utils.libsonnet';
       ]
     ),
   },
-  local checkpoint_gcs = base_functional {
+  local checkpoint_gcs = self.checkpoint_gcs,
+  checkpoint_gcs:: base_functional {
     modelName: 'fs-checkpoint-gcs',
     paramsOverride+:: {
       trainSubset: 'test',
@@ -147,7 +151,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local functional_no_save = base_functional {
+  local functional_no_save = self.functional_no_save,
+  functional_no_save:: base_functional {
     local config = self,
     paramsOverride+:: {
       trainSubset: 'valid',
@@ -160,7 +165,8 @@ local utils = import 'templates/utils.libsonnet';
     command: self.paramsOverride.trainCommand,
   },
 
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
 
     paramsOverride+:: {
@@ -221,7 +227,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -236,20 +243,25 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'fs-transformer-pjrt',
   },
 
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
   },
   configs: [

--- a/tests/pytorch/nightly/hf-fsmt.libsonnet
+++ b/tests/pytorch/nightly/hf-fsmt.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 {
   // FSMT = FairSeq MachineTranslation
   // Model doc: https://huggingface.co/docs/transformers/model_doc/fsmt
-  local fsmt = common.PyTorchTest {
+  local fsmt = self.fsmt,
+  fsmt:: common.PyTorchTest {
     modelName: 'hf-fsmt',
     volumeMap+: {
       datasets: common.datasetsVolume,
@@ -32,18 +33,21 @@ local tpus = import 'templates/tpus.libsonnet';
     ],
   },
 
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     command+: [
       '--short_data',
     ],
   },
   local convergence = common.Convergence,
 
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
 
-  local pjrt = common.PyTorchTpuVmMixin + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: common.PyTorchTpuVmMixin + experimental.PjRt {
     modelName+: '-pjrt',
     tpuSettings+: {
       tpuVmExtraSetup: |||

--- a/tests/pytorch/nightly/hf-fsmt.libsonnet
+++ b/tests/pytorch/nightly/hf-fsmt.libsonnet
@@ -39,7 +39,9 @@ local tpus = import 'templates/tpus.libsonnet';
       '--short_data',
     ],
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
+  convergence:: common.Convergence,
 
   local v4_8 = self.v4_8,
   v4_8:: {

--- a/tests/pytorch/nightly/hf-fsmt.libsonnet
+++ b/tests/pytorch/nightly/hf-fsmt.libsonnet
@@ -41,7 +41,6 @@ local tpus = import 'templates/tpus.libsonnet';
   },
   local convergence = self.convergence,
   convergence:: common.Convergence,
-  convergence:: common.Convergence,
 
   local v4_8 = self.v4_8,
   v4_8:: {

--- a/tests/pytorch/nightly/hf-glue.libsonnet
+++ b/tests/pytorch/nightly/hf-glue.libsonnet
@@ -29,7 +29,8 @@ local utils = import 'templates/utils.libsonnet';
   local command_copy_metrics = |||
     gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
   |||,
-  local bert_base_cased = common.Convergence {
+  local bert_base_cased = self.bert_base_cased,
+  bert_base_cased:: common.Convergence {
     modelName: 'hf-glue-bert-b-c',
     paramsOverride+:: {
       model_name_or_path: 'bert-base-cased',
@@ -55,7 +56,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local hf_glue = common.PyTorchTest {
+  local hf_glue = self.hf_glue,
+  hf_glue:: common.PyTorchTest {
     local config = self,
     modelName: 'hf-glue',
     paramsOverride:: {
@@ -87,9 +89,9 @@ local utils = import 'templates/utils.libsonnet';
     },
     command: utils.scriptCommand(
       |||
-        %s 
-        %s 
-        %s 
+        %s
+        %s
+        %s
       ||| % [
         command_common,
         utils.toCommandString(self.paramsOverride.trainCommand),
@@ -111,7 +113,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local xlnet_large_cased = common.Convergence {
+  local xlnet_large_cased = self.xlnet_large_cased,
+  xlnet_large_cased:: common.Convergence {
     modelName: 'hf-glue-xlnet-l-c',
     paramsOverride+:: {
       model_name_or_path: 'xlnet-large-cased',
@@ -137,7 +140,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local roberta_large = common.Convergence {
+  local roberta_large = self.roberta_large,
+  roberta_large:: common.Convergence {
     modelName: 'hf-glue-roberta-l',
     paramsOverride+:: {
       model_name_or_path: 'roberta-large',
@@ -163,7 +167,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local distilbert_base_uncased = common.Convergence {
+  local distilbert_base_uncased = self.distilbert_base_uncased,
+  distilbert_base_uncased:: common.Convergence {
     modelName: 'hf-glue-distilbert-b-uc',
     paramsOverride+:: {
       model_name_or_path: 'distilbert-base-uncased',
@@ -189,7 +194,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -199,16 +205,20 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'hf-glue-pjrt',
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -42,7 +42,8 @@ local utils = import 'templates/utils.libsonnet';
   local command_copy_metrics = |||
     gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
   |||,
-  local roberta_base_fine = common.Convergence {
+  local roberta_base_fine = self.roberta_base_fine,
+  roberta_base_fine:: common.Convergence {
     modelName: 'hf-mlm-roberta-b-fine',
     command: utils.scriptCommand(
       |||
@@ -73,7 +74,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local bert_base_fine = common.Convergence {
+  local bert_base_fine = self.bert_base_fine,
+  bert_base_fine:: common.Convergence {
     modelName: 'hf-mlm-bert-b-fine',
     command: utils.scriptCommand(
       |||
@@ -104,7 +106,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local roberta_base_pre = common.Convergence {
+  local roberta_base_pre = self.roberta_base_pre,
+  roberta_base_pre:: common.Convergence {
     modelName: 'hf-mlm-roberta-b-pre',
     command: utils.scriptCommand(
       |||
@@ -135,7 +138,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local bert_base_pre = common.Convergence {
+  local bert_base_pre = self.bert_base_pre,
+  bert_base_pre:: common.Convergence {
     modelName: 'hf-mlm-bert-b-pre',
     command: utils.scriptCommand(
       |||
@@ -166,7 +170,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local hf_lm = common.PyTorchTest {
+  local hf_lm = self.hf_lm,
+  hf_lm:: common.PyTorchTest {
     modelName: 'hf-lm',
     podTemplate+:: {
       spec+: {
@@ -183,7 +188,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -195,10 +201,12 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
   configs: [

--- a/tests/pytorch/nightly/hf-mae.libsonnet
+++ b/tests/pytorch/nightly/hf-mae.libsonnet
@@ -29,7 +29,8 @@ local utils = import 'templates/utils.libsonnet';
   local command_copy_metrics = |||
     gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
   |||,
-  local hf_mae = common.PyTorchTest {
+  local hf_mae = self.hf_mae,
+  hf_mae:: common.PyTorchTest {
     local config = self,
     modelName: 'hf-mae',
     paramsOverride:: {
@@ -69,9 +70,9 @@ local utils = import 'templates/utils.libsonnet';
     },
     command: utils.scriptCommand(
       |||
-        %s 
-        %s 
-        %s 
+        %s
+        %s
+        %s
       ||| % [
         command_common,
         utils.toCommandString(self.paramsOverride.trainCommand),
@@ -93,7 +94,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local hf_vit_mae = common.Convergence {
+  local hf_vit_mae = self.hf_vit_mae,
+  hf_vit_mae:: common.Convergence {
     modelName: 'hf-vit-mae',
     paramsOverride+:: {
       model_name: 'vit-mae',
@@ -119,7 +121,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -129,16 +132,20 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'hf-vit-mae-pjrt',
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/pytorch/nightly/mnist.libsonnet
+++ b/tests/pytorch/nightly/mnist.libsonnet
@@ -21,7 +21,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local mnist = common.PyTorchTest {
+  local mnist = self.mnist,
+  mnist:: common.PyTorchTest {
     modelName: 'mnist',
     volumeMap+: {
       datasets: common.datasetsVolume,
@@ -38,7 +39,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -59,7 +61,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   // DDP converges worse than MP.
-  local convergence_ddp = convergence {
+  local convergence_ddp = self.convergence_ddp,
+  convergence_ddp:: convergence {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -80,13 +83,16 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local gpu = common.GpuMixin {
+  local gpu = self.gpu,
+  gpu:: common.GpuMixin {
     // Disable XLA metrics report on GPU
     command+: [
       '--nometrics_debug',
@@ -95,21 +101,25 @@ local utils = import 'templates/utils.libsonnet';
       modelDir: null,
     },
   },
-  local v100x4 = gpu {
+  local v100x4 = self.v100x4,
+  v100x4:: gpu {
     accelerator: gpus.teslaV100 { count: 4 },
   },
 
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExtraSetup: |||
         pip install tensorboardX google-cloud-storage
       |||,
     },
   },
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName+: '-pjrt',
   },
-  local pjrt_ddp = {
+  local pjrt_ddp = self.pjrt_ddp,
+  pjrt_ddp:: {
     modelName+: '-ddp',
     command+: [
       '--ddp',

--- a/tests/pytorch/nightly/python-ops.libsonnet
+++ b/tests/pytorch/nightly/python-ops.libsonnet
@@ -18,7 +18,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local operations = common.PyTorchTest {
+  local operations = self.operations,
+  operations:: common.PyTorchTest {
     modelName: 'python-ops',
     command: [
       'bash',
@@ -33,13 +34,16 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -20,7 +20,8 @@ local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local resnet50 = common.PyTorchTest {
+  local resnet50 = self.resnet50,
+  resnet50:: common.PyTorchTest {
     modelName: 'resnet50-mp',
     trainScript: 'pytorch/xla/test/test_train_mp_imagenet.py',
     batch_size: null,
@@ -49,19 +50,22 @@ local tpus = import 'templates/tpus.libsonnet';
     memory: '400Gi',
   },
 
-  local fake_data = common.Functional {
+  local fake_data = self.fake_data,
+  fake_data:: common.Functional {
     mode: 'fake',
     command+: [
       '--fake_data',
     ],
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     command+: [
       '--num_epochs=2',
       '--datadir=/datasets/imagenet-mini',
     ],
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
 
     command+: [
@@ -89,7 +93,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
   // DDP converges worse than MP.
-  local convergence_ddp = convergence {
+  local convergence_ddp = self.convergence_ddp,
+  convergence_ddp:: convergence {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -111,23 +116,28 @@ local tpus = import 'templates/tpus.libsonnet';
   },
 
 
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
     // Keep same global batch size as v3
     batch_size: 256,
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
     batch_size: 256,
   },
 
-  local gpu = common.GpuMixin {
+  local gpu = self.gpu,
+  gpu:: common.GpuMixin {
     cpu: '7.0',
     memory: '40Gi',
 
@@ -139,11 +149,13 @@ local tpus = import 'templates/tpus.libsonnet';
       modelDir: null,
     },
   },
-  local v100x4 = gpu {
+  local v100x4 = self.v100x4,
+  v100x4:: gpu {
     accelerator: gpus.teslaV100 { count: 4 },
   },
 
-  local xrt_ddp = {
+  local xrt_ddp = self.xrt_ddp,
+  xrt_ddp:: {
     modelName+: '-torch-ddp',
     tpuSettings+: {
       tpuVmExports+: |||
@@ -155,7 +167,8 @@ local tpus = import 'templates/tpus.libsonnet';
       '--ddp',
     ],
   },
-  local pjrt_ddp = {
+  local pjrt_ddp = self.pjrt_ddp,
+  pjrt_ddp:: {
     modelName+: '-ddp',
     command+: [
       '--ddp',
@@ -163,17 +176,20 @@ local tpus = import 'templates/tpus.libsonnet';
     ],
   },
 
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExtraSetup: |||
         pip install tensorboardX google-cloud-storage
       |||,
     },
   },
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'resnet50-pjrt',
   },
-  local spmd(sharding) = pjrt {
+  local spmd(sharding) = self.spmd(sharding),
+  spmd(sharding):: pjrt {
     // Include sharding spec in the test name
     modelName: std.join('-', ['resnet50-spmd'] + sharding),
     trainScript: 'pytorch/xla/test/spmd/test_train_spmd_imagenet.py',

--- a/tests/pytorch/nightly/roberta-pre.libsonnet
+++ b/tests/pytorch/nightly/roberta-pre.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local roberta = common.PyTorchTest {
+  local roberta = self.roberta,
+  roberta:: common.PyTorchTest {
     local config = self,
 
     modelName: 'roberta-pre',
@@ -82,7 +83,8 @@ local utils = import 'templates/utils.libsonnet';
     cpu: '9.0',
     memory: '30Gi',
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -96,13 +98,15 @@ local utils = import 'templates/utils.libsonnet';
       wpsTarget: 10000,
     },
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     paramsOverride+: {
       maxEpoch: 5,
       wpsTarget: 19000,
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExtraSetup: |||
         git clone --recursive https://github.com/pytorch-tpu/examples.git tpu-examples/
@@ -111,10 +115,12 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
   configs: [

--- a/tests/pytorch/nightly/sd-model.libsonnet
+++ b/tests/pytorch/nightly/sd-model.libsonnet
@@ -19,7 +19,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local sd_model = common.PyTorchTest {
+  local sd_model = self.sd_model,
+  sd_model:: common.PyTorchTest {
     local config = self,
     modelName: 'sd-model',
     paramsOverride:: {
@@ -34,7 +35,8 @@ local utils = import 'templates/utils.libsonnet';
     },
     command: self.paramsOverride.trainCommand,
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XRT_TPU_CONFIG="localservice;0;localhost:51011"
@@ -71,7 +73,8 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/pytorch/nightly/unet3d.libsonnet
+++ b/tests/pytorch/nightly/unet3d.libsonnet
@@ -20,7 +20,7 @@ local utils = import 'templates/utils.libsonnet';
 
 {
   local command_common = |||
-    git clone https://github.com/pytorch-tpu/training.git unet3d_test 
+    git clone https://github.com/pytorch-tpu/training.git unet3d_test
     pip3 install -r unet3d_test/image_segmentation/pytorch/requirements.txt
     pip3 install tqdm
 
@@ -45,7 +45,8 @@ local utils = import 'templates/utils.libsonnet';
     --debug \
     --device xla
   |||,
-  local unet3d = common.PyTorchTest {
+  local unet3d = self.unet3d,
+  unet3d:: common.PyTorchTest {
     modelName: 'unet3d',
 
     volumeMap+: {
@@ -54,7 +55,8 @@ local utils = import 'templates/utils.libsonnet';
     cpu: '9.0',
     memory: '30Gi',
   },
-  local conv = common.Convergence {
+  local conv = self.conv,
+  conv:: common.Convergence {
     command: utils.scriptCommand(
       |||
         %(command_common)s \
@@ -68,10 +70,12 @@ local utils = import 'templates/utils.libsonnet';
       ||| % command_common
     ),
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
 
     tpuSettings+: {
 

--- a/tests/pytorch/nightly/wav2vec2.libsonnet
+++ b/tests/pytorch/nightly/wav2vec2.libsonnet
@@ -34,7 +34,8 @@ local utils = import 'templates/utils.libsonnet';
     --config-dir fairseq/examples/wav2vec/config/pretraining   \
     --config-name wav2vec2_large_librivox_tpu.yaml \
   |||,
-  local w2v2 = common.PyTorchTest {
+  local w2v2 = self.w2v2,
+  w2v2:: common.PyTorchTest {
     modelName: 'w2v2',
 
     volumeMap+: {
@@ -43,12 +44,14 @@ local utils = import 'templates/utils.libsonnet';
     cpu: '9.0',
     memory: '30Gi',
   },
-  local func = common.Functional {
+  local func = self.func,
+  func:: common.Functional {
     command: utils.scriptCommand(
       command_common % 500
     ),
   },
-  local conv = common.Convergence {
+  local conv = self.conv,
+  conv:: common.Convergence {
     command: utils.scriptCommand(
       (command_common % 50000) + |||
         2>&1 | tee training_logs.txt
@@ -62,7 +65,8 @@ local utils = import 'templates/utils.libsonnet';
 
     ),
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -76,7 +80,8 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
   configs: [

--- a/tests/pytorch/r2.0/cpp-ops.libsonnet
+++ b/tests/pytorch/r2.0/cpp-ops.libsonnet
@@ -19,7 +19,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local operations = common.PyTorchTest {
+  local operations = self.operations,
+  operations:: common.PyTorchTest {
     modelName: 'cpp-ops',
     command: [
       'bash',
@@ -34,7 +35,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -46,10 +48,12 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
 

--- a/tests/pytorch/r2.0/dlrm.libsonnet
+++ b/tests/pytorch/r2.0/dlrm.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local dlrm = common.PyTorchTest {
+  local dlrm = self.dlrm,
+  dlrm:: common.PyTorchTest {
     local config = self,
 
     modelName: 'dlrm',
@@ -60,7 +61,8 @@ local utils = import 'templates/utils.libsonnet';
     cpu: '9.0',
     memory: '30Gi',
   },
-  local dlrm_convergence = common.PyTorchTest {
+  local dlrm_convergence = self.dlrm_convergence,
+  dlrm_convergence:: common.PyTorchTest {
     modelName: 'dlrm-convergence',
 
     volumeMap+: {
@@ -81,7 +83,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local one_core = common.Functional {
+  local one_core = self.one_core,
+  one_core:: common.Functional {
     modelName: 'dlrm-onecore',
     paramsOverride+:: {
       miniBatchSize: 256,
@@ -96,7 +99,8 @@ local utils = import 'templates/utils.libsonnet';
       ||| % utils.toCommandString(self.paramsOverride.trainCommand),
     ),
   },
-  local seq_fwd = common.Functional {
+  local seq_fwd = self.seq_fwd,
+  seq_fwd:: common.Functional {
     modelName: 'dlrm-seq-fwd',
     paramsOverride+:: {
       miniBatchSize: 2048,
@@ -110,7 +114,8 @@ local utils = import 'templates/utils.libsonnet';
       ||| % utils.toCommandString(self.paramsOverride.trainCommand),
     ),
   },
-  local mp_fwd = common.Functional {
+  local mp_fwd = self.mp_fwd,
+  mp_fwd:: common.Functional {
     modelName: 'dlrm-mp-fwd',
     paramsOverride+:: {
       miniBatchSize: 2048,
@@ -123,7 +128,8 @@ local utils = import 'templates/utils.libsonnet';
       ||| % utils.toCommandString(self.paramsOverride.trainCommand),
     ),
   },
-  local mp_dp_fwd = common.Functional {
+  local mp_dp_fwd = self.mp_dp_fwd,
+  mp_dp_fwd:: common.Functional {
     modelName: 'dlrm-mpdp-fwd',
     paramsOverride+:: {
       miniBatchSize: 2048,
@@ -138,7 +144,8 @@ local utils = import 'templates/utils.libsonnet';
     ),
   },
 
-  local criteo_kaggle = common.Convergence {
+  local criteo_kaggle = self.criteo_kaggle,
+  criteo_kaggle:: common.Convergence {
     paramsOverride+:: {
       miniBatchSize: 128,
       archSparseFeatureSize: 16,
@@ -173,7 +180,8 @@ local utils = import 'templates/utils.libsonnet';
     ),
   },
 
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExtraSetup: |||
         pip3 install tqdm scikit-learn tensorboardX google-cloud-storage
@@ -186,17 +194,21 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'dlrm-pjrt',
   },
 
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
   },
   configs: [

--- a/tests/pytorch/r2.0/fs-transformer.libsonnet
+++ b/tests/pytorch/r2.0/fs-transformer.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local transformer = common.PyTorchTest {
+  local transformer = self.transformer,
+  transformer:: common.PyTorchTest {
     local config = self,
 
     modelName: 'fs-transformer',
@@ -89,13 +90,15 @@ local utils = import 'templates/utils.libsonnet';
   },
 
   // Run the test over a small subset of the data.
-  local base_functional = common.Functional {
+  local base_functional = self.base_functional,
+  base_functional:: common.Functional {
     paramsOverride+:: {
       logSteps: 10,
       inputShape: ['128x64'],
     },
   },
-  local checkpoint_local = base_functional {
+  local checkpoint_local = self.checkpoint_local,
+  checkpoint_local:: base_functional {
     modelName: 'fs-checkpoint-local',
     paramsOverride+:: {
       trainSubset: 'test',
@@ -114,7 +117,8 @@ local utils = import 'templates/utils.libsonnet';
       ]
     ),
   },
-  local checkpoint_gcs = base_functional {
+  local checkpoint_gcs = self.checkpoint_gcs,
+  checkpoint_gcs:: base_functional {
     modelName: 'fs-checkpoint-gcs',
     paramsOverride+:: {
       trainSubset: 'test',
@@ -147,7 +151,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local functional_no_save = base_functional {
+  local functional_no_save = self.functional_no_save,
+  functional_no_save:: base_functional {
     local config = self,
     paramsOverride+:: {
       trainSubset: 'valid',
@@ -160,7 +165,8 @@ local utils = import 'templates/utils.libsonnet';
     command: self.paramsOverride.trainCommand,
   },
 
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
 
     paramsOverride+:: {
@@ -221,7 +227,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -236,20 +243,25 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'fs-transformer-pjrt',
   },
 
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
   },
   configs: [

--- a/tests/pytorch/r2.0/hf-fsmt.libsonnet
+++ b/tests/pytorch/r2.0/hf-fsmt.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 {
   // FSMT = FairSeq MachineTranslation
   // Model doc: https://huggingface.co/docs/transformers/model_doc/fsmt
-  local fsmt = common.PyTorchTest {
+  local fsmt = self.fsmt,
+  fsmt:: common.PyTorchTest {
     modelName: 'hf-fsmt',
     volumeMap+: {
       datasets: common.datasetsVolume,
@@ -32,18 +33,21 @@ local tpus = import 'templates/tpus.libsonnet';
     ],
   },
 
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     command+: [
       '--short_data',
     ],
   },
   local convergence = common.Convergence,
 
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
 
-  local pjrt = common.PyTorchTpuVmMixin + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: common.PyTorchTpuVmMixin + experimental.PjRt {
     modelName+: '-pjrt',
     tpuSettings+: {
       tpuVmExtraSetup: |||

--- a/tests/pytorch/r2.0/hf-fsmt.libsonnet
+++ b/tests/pytorch/r2.0/hf-fsmt.libsonnet
@@ -39,7 +39,8 @@ local tpus = import 'templates/tpus.libsonnet';
       '--short_data',
     ],
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
 
   local v4_8 = self.v4_8,
   v4_8:: {

--- a/tests/pytorch/r2.0/hf-glue.libsonnet
+++ b/tests/pytorch/r2.0/hf-glue.libsonnet
@@ -29,7 +29,8 @@ local utils = import 'templates/utils.libsonnet';
   local command_copy_metrics = |||
     gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
   |||,
-  local bert_base_cased = common.Convergence {
+  local bert_base_cased = self.bert_base_cased,
+  bert_base_cased:: common.Convergence {
     modelName: 'hf-glue-bert-b-c',
     paramsOverride+:: {
       model_name_or_path: 'bert-base-cased',
@@ -55,7 +56,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local hf_glue = common.PyTorchTest {
+  local hf_glue = self.hf_glue,
+  hf_glue:: common.PyTorchTest {
     local config = self,
     modelName: 'hf-glue',
     paramsOverride:: {
@@ -87,9 +89,9 @@ local utils = import 'templates/utils.libsonnet';
     },
     command: utils.scriptCommand(
       |||
-        %s 
-        %s 
-        %s 
+        %s
+        %s
+        %s
       ||| % [
         command_common,
         utils.toCommandString(self.paramsOverride.trainCommand),
@@ -111,7 +113,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local xlnet_large_cased = common.Convergence {
+  local xlnet_large_cased = self.xlnet_large_cased,
+  xlnet_large_cased:: common.Convergence {
     modelName: 'hf-glue-xlnet-l-c',
     paramsOverride+:: {
       model_name_or_path: 'xlnet-large-cased',
@@ -137,7 +140,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local roberta_large = common.Convergence {
+  local roberta_large = self.roberta_large,
+  roberta_large:: common.Convergence {
     modelName: 'hf-glue-roberta-l',
     paramsOverride+:: {
       model_name_or_path: 'roberta-large',
@@ -163,7 +167,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local distilbert_base_uncased = common.Convergence {
+  local distilbert_base_uncased = self.distilbert_base_uncased,
+  distilbert_base_uncased:: common.Convergence {
     modelName: 'hf-glue-distilbert-b-uc',
     paramsOverride+:: {
       model_name_or_path: 'distilbert-base-uncased',
@@ -189,7 +194,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -199,16 +205,20 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'hf-glue-pjrt',
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/pytorch/r2.0/hf-lm.libsonnet
+++ b/tests/pytorch/r2.0/hf-lm.libsonnet
@@ -42,7 +42,8 @@ local utils = import 'templates/utils.libsonnet';
   local command_copy_metrics = |||
     gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
   |||,
-  local roberta_base_fine = common.Convergence {
+  local roberta_base_fine = self.roberta_base_fine,
+  roberta_base_fine:: common.Convergence {
     modelName: 'hf-mlm-roberta-b-fine',
     command: utils.scriptCommand(
       |||
@@ -73,7 +74,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local bert_base_fine = common.Convergence {
+  local bert_base_fine = self.bert_base_fine,
+  bert_base_fine:: common.Convergence {
     modelName: 'hf-mlm-bert-b-fine',
     command: utils.scriptCommand(
       |||
@@ -104,7 +106,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local roberta_base_pre = common.Convergence {
+  local roberta_base_pre = self.roberta_base_pre,
+  roberta_base_pre:: common.Convergence {
     modelName: 'hf-mlm-roberta-b-pre',
     command: utils.scriptCommand(
       |||
@@ -135,7 +138,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local bert_base_pre = common.Convergence {
+  local bert_base_pre = self.bert_base_pre,
+  bert_base_pre:: common.Convergence {
     modelName: 'hf-mlm-bert-b-pre',
     command: utils.scriptCommand(
       |||
@@ -166,7 +170,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local hf_lm = common.PyTorchTest {
+  local hf_lm = self.hf_lm,
+  hf_lm:: common.PyTorchTest {
     modelName: 'hf-lm',
     podTemplate+:: {
       spec+: {
@@ -183,7 +188,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -195,10 +201,12 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
   configs: [

--- a/tests/pytorch/r2.0/hf-mae.libsonnet
+++ b/tests/pytorch/r2.0/hf-mae.libsonnet
@@ -29,7 +29,8 @@ local utils = import 'templates/utils.libsonnet';
   local command_copy_metrics = |||
     gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)
   |||,
-  local hf_mae = common.PyTorchTest {
+  local hf_mae = self.hf_mae,
+  hf_mae:: common.PyTorchTest {
     local config = self,
     modelName: 'hf-mae',
     paramsOverride:: {
@@ -69,9 +70,9 @@ local utils = import 'templates/utils.libsonnet';
     },
     command: utils.scriptCommand(
       |||
-        %s 
-        %s 
-        %s 
+        %s
+        %s
+        %s
       ||| % [
         command_common,
         utils.toCommandString(self.paramsOverride.trainCommand),
@@ -93,7 +94,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local hf_vit_mae = common.Convergence {
+  local hf_vit_mae = self.hf_vit_mae,
+  hf_vit_mae:: common.Convergence {
     modelName: 'hf-vit-mae',
     paramsOverride+:: {
       model_name: 'vit-mae',
@@ -119,7 +121,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)
@@ -129,16 +132,20 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'hf-vit-mae-pjrt',
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/pytorch/r2.0/mnist.libsonnet
+++ b/tests/pytorch/r2.0/mnist.libsonnet
@@ -21,7 +21,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local mnist = common.PyTorchTest {
+  local mnist = self.mnist,
+  mnist:: common.PyTorchTest {
     modelName: 'mnist',
     volumeMap+: {
       datasets: common.datasetsVolume,
@@ -38,7 +39,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -59,7 +61,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   // DDP converges worse than MP.
-  local convergence_ddp = convergence {
+  local convergence_ddp = self.convergence_ddp,
+  convergence_ddp:: convergence {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -80,13 +83,16 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local gpu = common.GpuMixin {
+  local gpu = self.gpu,
+  gpu:: common.GpuMixin {
     // Disable XLA metrics report on GPU
     command+: [
       '--nometrics_debug',
@@ -95,21 +101,25 @@ local utils = import 'templates/utils.libsonnet';
       modelDir: null,
     },
   },
-  local v100x4 = gpu {
+  local v100x4 = self.v100x4,
+  v100x4:: gpu {
     accelerator: gpus.teslaV100 { count: 4 },
   },
 
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExtraSetup: |||
         pip install tensorboardX google-cloud-storage
       |||,
     },
   },
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName+: '-pjrt',
   },
-  local pjrt_ddp = {
+  local pjrt_ddp = self.pjrt_ddp,
+  pjrt_ddp:: {
     modelName+: '-ddp',
     command+: [
       '--ddp',

--- a/tests/pytorch/r2.0/python-ops.libsonnet
+++ b/tests/pytorch/r2.0/python-ops.libsonnet
@@ -18,7 +18,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local operations = common.PyTorchTest {
+  local operations = self.operations,
+  operations:: common.PyTorchTest {
     modelName: 'python-ops',
     command: [
       'bash',
@@ -33,13 +34,16 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XLA_USE_BF16=$(XLA_USE_BF16)

--- a/tests/pytorch/r2.0/resnet50-mp.libsonnet
+++ b/tests/pytorch/r2.0/resnet50-mp.libsonnet
@@ -20,7 +20,8 @@ local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local resnet50 = common.PyTorchTest {
+  local resnet50 = self.resnet50,
+  resnet50:: common.PyTorchTest {
     modelName: 'resnet50-mp',
     command: [
       'python3',
@@ -41,19 +42,22 @@ local tpus = import 'templates/tpus.libsonnet';
     memory: '400Gi',
   },
 
-  local fake_data = common.Functional {
+  local fake_data = self.fake_data,
+  fake_data:: common.Functional {
     mode: 'fake',
     command+: [
       '--fake_data',
     ],
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     command+: [
       '--num_epochs=2',
       '--datadir=/datasets/imagenet-mini',
     ],
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
 
     command+: [
@@ -81,7 +85,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
   // DDP converges worse than MP.
-  local convergence_ddp = convergence {
+  local convergence_ddp = self.convergence_ddp,
+  convergence_ddp:: convergence {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -102,23 +107,28 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
     // Keep same global batch size as v3
     command+: ['--batch_size=256'],
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
     command+: ['--batch_size=256'],
   },
 
-  local gpu = common.GpuMixin {
+  local gpu = self.gpu,
+  gpu:: common.GpuMixin {
     cpu: '7.0',
     memory: '40Gi',
 
@@ -130,11 +140,13 @@ local tpus = import 'templates/tpus.libsonnet';
       modelDir: null,
     },
   },
-  local v100x4 = gpu {
+  local v100x4 = self.v100x4,
+  v100x4:: gpu {
     accelerator: gpus.teslaV100 { count: 4 },
   },
 
-  local xrt_ddp = {
+  local xrt_ddp = self.xrt_ddp,
+  xrt_ddp:: {
     modelName+: '-torch-ddp',
     tpuSettings+: {
       tpuVmExports+: |||
@@ -146,7 +158,8 @@ local tpus = import 'templates/tpus.libsonnet';
       '--ddp',
     ],
   },
-  local pjrt_ddp = {
+  local pjrt_ddp = self.pjrt_ddp,
+  pjrt_ddp:: {
     modelName+: '-ddp',
     command+: [
       '--ddp',
@@ -154,14 +167,16 @@ local tpus = import 'templates/tpus.libsonnet';
     ],
   },
 
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExtraSetup: |||
         pip install tensorboardX google-cloud-storage
       |||,
     },
   },
-  local pjrt = tpuVm + experimental.PjRt {
+  local pjrt = self.pjrt,
+  pjrt:: tpuVm + experimental.PjRt {
     modelName: 'resnet50-pjrt',
   },
 

--- a/tests/pytorch/r2.0/roberta-pre.libsonnet
+++ b/tests/pytorch/r2.0/roberta-pre.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local roberta = common.PyTorchTest {
+  local roberta = self.roberta,
+  roberta:: common.PyTorchTest {
     local config = self,
 
     modelName: 'roberta-pre',
@@ -82,7 +83,8 @@ local utils = import 'templates/utils.libsonnet';
     cpu: '9.0',
     memory: '30Gi',
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     metricConfig+: {
       sourceMap+:: {
         tensorboard+: {
@@ -96,13 +98,15 @@ local utils = import 'templates/utils.libsonnet';
       wpsTarget: 10000,
     },
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     paramsOverride+: {
       maxEpoch: 5,
       wpsTarget: 19000,
     },
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExtraSetup: |||
         git clone --recursive https://github.com/pytorch-tpu/examples.git tpu-examples/
@@ -111,10 +115,12 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
   configs: [

--- a/tests/pytorch/r2.0/sd-model.libsonnet
+++ b/tests/pytorch/r2.0/sd-model.libsonnet
@@ -19,7 +19,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local sd_model = common.PyTorchTest {
+  local sd_model = self.sd_model,
+  sd_model:: common.PyTorchTest {
     local config = self,
     modelName: 'sd-model',
     paramsOverride:: {
@@ -34,7 +35,8 @@ local utils = import 'templates/utils.libsonnet';
     },
     command: self.paramsOverride.trainCommand,
   },
-  local tpuVm = common.PyTorchTpuVmMixin {
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.PyTorchTpuVmMixin {
     tpuSettings+: {
       tpuVmExports+: |||
         export XRT_TPU_CONFIG="localservice;0;localhost:51011"
@@ -71,7 +73,8 @@ local utils = import 'templates/utils.libsonnet';
       |||,
     },
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
   configs: [

--- a/tests/tensorflow/experimental.libsonnet
+++ b/tests/tensorflow/experimental.libsonnet
@@ -42,11 +42,11 @@ local mixins = import 'templates/mixins.libsonnet';
               |||
                 set -x
                 set -u
-                ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \
+                gcloud alpha compute tpus tpu-vm ssh xl-ml-test@$(cat /scripts/tpu_name) --zone=$(cat /scripts/zone) --ssh-key-file=/scripts/id_rsa --strict-host-key-checking=no --internal-ip --command \
                   'pip install -r /usr/share/tpu/models/official/requirements.txt'
-                ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \
+                gcloud alpha compute tpus tpu-vm ssh xl-ml-test@$(cat /scripts/tpu_name) --zone=$(cat /scripts/zone) --ssh-key-file=/scripts/id_rsa --strict-host-key-checking=no --internal-ip --command \
                   'pip install tensorflow-recommenders --no-deps'
-                ssh -i scripts/id_rsa -o StrictHostKeyChecking=no xl-ml-test@$(cat /scripts/tpu_ip) \
+                gcloud alpha compute tpus tpu-vm ssh xl-ml-test@$(cat /scripts/tpu_name) --zone=$(cat /scripts/zone) --ssh-key-file=/scripts/id_rsa --strict-host-key-checking=no --internal-ip --command \
                   'cd /usr/share/tpu/models; %(env)s '%(testCommand)s
                 exit_code=$?
                 bash /scripts/cleanup.sh

--- a/tests/tensorflow/nightly/dlrm.libsonnet
+++ b/tests/tensorflow/nightly/dlrm.libsonnet
@@ -250,7 +250,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local tpuVm = experimental.TensorFlowTpuVmMixin,
+  local tpuVm = self.tpuVm,
+  tpuVm:: experimental.TensorFlowTpuVmMixin,
 
   configs: [
     dlrm + functional + v3_8,

--- a/tests/tensorflow/nightly/dlrm.libsonnet
+++ b/tests/tensorflow/nightly/dlrm.libsonnet
@@ -20,7 +20,8 @@ local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local dlrm = common.ModelGardenTest {
+  local dlrm = self.dlrm,
+  dlrm:: common.ModelGardenTest {
     modelName: 'ranking-dlrm',
     paramsOverride:: {
       runtime: {
@@ -97,7 +98,8 @@ local tpus = import 'templates/tpus.libsonnet';
       '--model_dir=$(MODEL_DIR)',
     ],
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     command+: [
       '--mode=train',
     ],
@@ -107,7 +109,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
 
     command+: [
@@ -120,7 +123,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local gpu_common = {
+  local gpu_common = self.gpu_common,
+  gpu_common:: {
     local config = self,
 
     paramsOverride+:: {
@@ -137,7 +141,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local cross_interaction = {
+  local cross_interaction = self.cross_interaction,
+  cross_interaction:: {
     modelName: 'ranking-dcn',
     local config = self,
 
@@ -150,14 +155,17 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v100 = gpu_common {
+  local v100 = self.v100,
+  v100:: gpu_common {
     accelerator: gpus.teslaV100,
   },
-  local v100x4 = v100 {
+  local v100x4 = self.v100x4,
+  v100x4:: v100 {
     accelerator: gpus.teslaV100 { count: 4 },
   },
 
-  local tpu_common = {
+  local tpu_common = self.tpu_common,
+  tpu_common:: {
     paramsOverride+:: {
       runtime+: {
         distribution_strategy: 'tpu',
@@ -166,7 +174,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_8 = tpu_common {
+  local v2_8 = self.v2_8,
+  v2_8:: tpu_common {
     accelerator: tpus.v2_8,
     paramsOverride+:: {
       task+: {
@@ -178,7 +187,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_32 = tpu_common {
+  local v2_32 = self.v2_32,
+  v2_32:: tpu_common {
     accelerator: tpus.v2_32,
     paramsOverride+:: {
       task+: {
@@ -190,7 +200,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_8 = tpu_common {
+  local v3_8 = self.v3_8,
+  v3_8:: tpu_common {
     accelerator: tpus.v3_8,
     paramsOverride+:: {
       task+: {
@@ -202,7 +213,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_32 = tpu_common {
+  local v3_32 = self.v3_32,
+  v3_32:: tpu_common {
     accelerator: tpus.v3_32,
     paramsOverride+:: {
       task+: {
@@ -214,7 +226,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v4_8 = tpu_common {
+  local v4_8 = self.v4_8,
+  v4_8:: tpu_common {
     accelerator: tpus.v4_8,
     paramsOverride+:: {
       task+: {
@@ -225,7 +238,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local v4_32 = tpu_common {
+  local v4_32 = self.v4_32,
+  v4_32:: tpu_common {
     accelerator: tpus.v4_32,
     paramsOverride+:: {
       task+: {

--- a/tests/tensorflow/nightly/keras-api.libsonnet
+++ b/tests/tensorflow/nightly/keras-api.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local keras_test = common.ModelGardenTest {
+  local keras_test = self.keras_test,
+  keras_test:: common.ModelGardenTest {
     testFeature:: error 'Must override `testFeature`',
     modelName: 'keras-api',
     isTPUPod:: error 'Must set `isTPUPod`',
@@ -38,7 +39,8 @@ local utils = import 'templates/utils.libsonnet';
     ),
   },
 
-  local API = common.RunNightly {
+  local API = self.API,
+  API:: common.RunNightly {
     mode: 'api',
     timeout: timeouts.one_hour,
     tpuSettings+: {
@@ -46,72 +48,86 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local connection = API {
+  local connection = self.connection,
+  connection:: API {
     mode: 'connection',
     testFeature:: 'aaa_connection',
   },
 
-  local custom_layers = API {
+  local custom_layers = self.custom_layers,
+  custom_layers:: API {
     mode: 'custom-layers',
     testFeature:: 'custom_layers_model',
   },
 
-  local custom_training_loop = API {
+  local custom_training_loop = self.custom_training_loop,
+  custom_training_loop:: API {
     mode: 'ctl',
     testFeature:: 'custom_training_loop',
   },
 
-  local feature_column = API {
+  local feature_column = self.feature_column,
+  feature_column:: API {
     mode: 'feature-column',
     testFeature:: 'feature_column',
   },
 
-  local rnn = API {
+  local rnn = self.rnn,
+  rnn:: API {
     mode: 'rnn',
     testFeature:: 'rnn',
   },
 
-  local preprocessing_layers = API {
+  local preprocessing_layers = self.preprocessing_layers,
+  preprocessing_layers:: API {
     mode: 'preprocess-layers',
     testFeature:: 'preprocessing_layers',
   },
 
-  local upsample = API {
+  local upsample = self.upsample,
+  upsample:: API {
     mode: 'upsample',
     testFeature:: 'upsample',
   },
 
-  local save_load_io_device_local = API {
+  local save_load_io_device_local = self.save_load_io_device_local,
+  save_load_io_device_local:: API {
     mode: 'save-load-localhost',
     testFeature:: 'save_and_load_io_device_local_drive',
   },
 
-  local save_and_load = API {
+  local save_and_load = self.save_and_load,
+  save_and_load:: API {
     mode: 'save-and-load',
     testFeature:: 'save_and_load.feature',
   },
 
-  local train_and_evaluate = API {
+  local train_and_evaluate = self.train_and_evaluate,
+  train_and_evaluate:: API {
     mode: 'train-and-evaluate',
     testFeature:: 'train_and_evaluate',
   },
 
-  local train_validation_dataset = API {
+  local train_validation_dataset = self.train_validation_dataset,
+  train_validation_dataset:: API {
     mode: 'train-eval-dataset',
     testFeature:: 'train_validation_dataset',
   },
 
-  local transfer_learning = API {
+  local transfer_learning = self.transfer_learning,
+  transfer_learning:: API {
     mode: 'transfer-learning',
     testFeature:: 'transfer_learning',
   },
 
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     isTPUPod: false,
   },
 
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
     isTPUPod: true,
   },

--- a/tests/tensorflow/nightly/keras-api.libsonnet
+++ b/tests/tensorflow/nightly/keras-api.libsonnet
@@ -132,7 +132,8 @@ local utils = import 'templates/utils.libsonnet';
     isTPUPod: true,
   },
 
-  local tpuVm = experimental.TensorFlowTpuVmMixin,
+  local tpuVm = self.tpuVm,
+  tpuVm:: experimental.TensorFlowTpuVmMixin,
 
   configs: [
     keras_test + v2_8 + connection,

--- a/tests/tensorflow/nightly/nlp-mnli.libsonnet
+++ b/tests/tensorflow/nightly/nlp-mnli.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local bert = common.TfNlpTest {
+  local bert = self.bert,
+  bert:: common.TfNlpTest {
     modelName: 'nlp-bert-mnli',
     scriptConfig+: {
       experiment: 'bert/sentence_prediction_text',
@@ -40,7 +41,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer+: {
@@ -51,16 +53,20 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local convergence = common.Convergence,
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
   configs: [

--- a/tests/tensorflow/nightly/nlp-mnli.libsonnet
+++ b/tests/tensorflow/nightly/nlp-mnli.libsonnet
@@ -52,7 +52,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
   local v2_8 = self.v2_8,
   v2_8:: {
     accelerator: tpus.v2_8,

--- a/tests/tensorflow/nightly/nlp-wmt.libsonnet
+++ b/tests/tensorflow/nightly/nlp-wmt.libsonnet
@@ -17,7 +17,8 @@ local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local transformer = common.TfNlpTest {
+  local transformer = self.transformer,
+  transformer:: common.TfNlpTest {
     modelName: 'nlp-wmt-transformer',
     scriptConfig+: {
       experiment: 'wmt_transformer/large',
@@ -28,7 +29,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer+: {
@@ -38,7 +40,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
     scriptConfig+: {
       paramsOverride+: {
@@ -49,7 +52,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -62,7 +66,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -74,7 +79,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
     scriptConfig+: {
       paramsOverride+: {
@@ -86,7 +92,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
     scriptConfig+: {
       paramsOverride+: {

--- a/tests/tensorflow/nightly/vision-coco.libsonnet
+++ b/tests/tensorflow/nightly/vision-coco.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local coco = {
+  local coco = self.coco,
+  coco:: {
     scriptConfig+: {
       trainFilePattern: '$(COCO_DIR)/train*',
       evalFilePattern: '$(COCO_DIR)/val*',
@@ -31,7 +32,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpu_common = {
+  local tpu_common = self.tpu_common,
+  tpu_common:: {
     local config = self,
     scriptConfig+: {
       paramsOverride+: {
@@ -43,19 +45,22 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local retinanet = common.TfVisionTest + coco {
+  local retinanet = self.retinanet,
+  retinanet:: common.TfVisionTest + coco {
     modelName: 'vision-retinanet',
     scriptConfig+: {
       experiment: 'retinanet_resnetfpn_coco',
     },
   },
-  local maskrcnn = common.TfVisionTest + coco {
+  local maskrcnn = self.maskrcnn,
+  maskrcnn:: common.TfVisionTest + coco {
     modelName: 'vision-maskrcnn',
     scriptConfig+: {
       experiment: 'maskrcnn_resnetfpn_coco',
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer+: {
@@ -67,7 +72,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local convergence = common.Convergence,
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -79,19 +85,24 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v3_8 = tpu_common {
+  local v3_8 = self.v3_8,
+  v3_8:: tpu_common {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = tpu_common {
+  local v2_32 = self.v2_32,
+  v2_32:: tpu_common {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = tpu_common {
+  local v3_32 = self.v3_32,
+  v3_32:: tpu_common {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = tpu_common {
+  local v4_8 = self.v4_8,
+  v4_8:: tpu_common {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = tpu_common {
+  local v4_32 = self.v4_32,
+  v4_32:: tpu_common {
     accelerator: tpus.v4_32,
   },
   local tpuVm = experimental.TensorFlowTpuVmMixin,

--- a/tests/tensorflow/nightly/vision-coco.libsonnet
+++ b/tests/tensorflow/nightly/vision-coco.libsonnet
@@ -71,7 +71,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
   local v2_8 = self.v2_8,
   v2_8:: {
     accelerator: tpus.v2_8,
@@ -105,7 +106,8 @@ local utils = import 'templates/utils.libsonnet';
   v4_32:: tpu_common {
     accelerator: tpus.v4_32,
   },
-  local tpuVm = experimental.TensorFlowTpuVmMixin,
+  local tpuVm = self.tpuVm,
+  tpuVm:: experimental.TensorFlowTpuVmMixin,
 
   local functionalTests = [
     benchmark + accelerator + functional

--- a/tests/tensorflow/nightly/vision-imagenet.libsonnet
+++ b/tests/tensorflow/nightly/vision-imagenet.libsonnet
@@ -53,7 +53,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
   local v2_8 = self.v2_8,
   v2_8:: {
     accelerator: tpus.v2_8,
@@ -90,7 +91,8 @@ local utils = import 'templates/utils.libsonnet';
   v4_32:: {
     accelerator: tpus.v4_32,
   },
-  local tpuVm = experimental.TensorFlowTpuVmMixin,
+  local tpuVm = self.tpuVm,
+  tpuVm:: experimental.TensorFlowTpuVmMixin,
 
   local functionalTests = [
     benchmark + accelerator + functional

--- a/tests/tensorflow/nightly/vision-imagenet.libsonnet
+++ b/tests/tensorflow/nightly/vision-imagenet.libsonnet
@@ -20,26 +20,30 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local imagenet = {
+  local imagenet = self.imagenet,
+  imagenet:: {
     scriptConfig+: {
       trainFilePattern: '$(IMAGENET_DIR)/train*',
       evalFilePattern: '$(IMAGENET_DIR)/valid*',
     },
   },
-  local resnet = common.TfVisionTest + imagenet {
+  local resnet = self.resnet,
+  resnet:: common.TfVisionTest + imagenet {
     modelName: 'vision-resnet',
     scriptConfig+: {
       experiment: 'resnet_imagenet',
     },
   },
-  local resnet_rs = common.TfVisionTest + imagenet {
+  local resnet_rs = self.resnet_rs,
+  resnet_rs:: common.TfVisionTest + imagenet {
     modelName: 'vision-resnetrs',
     scriptConfig+: {
       experiment: 'resnet_rs_imagenet',
       configFiles: ['official/vision/configs/experiments/image_classification/imagenet_resnetrs50_i160.yaml'],
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer: {
@@ -50,7 +54,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local convergence = common.Convergence,
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -65,19 +70,24 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
   },
   local tpuVm = experimental.TensorFlowTpuVmMixin,

--- a/tests/tensorflow/r2.11/dlrm.libsonnet
+++ b/tests/tensorflow/r2.11/dlrm.libsonnet
@@ -250,7 +250,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local tpuVm = common.tpuVm,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   configs: [
     dlrm + functional + v3_8,

--- a/tests/tensorflow/r2.11/dlrm.libsonnet
+++ b/tests/tensorflow/r2.11/dlrm.libsonnet
@@ -20,7 +20,8 @@ local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local dlrm = common.ModelGardenTest {
+  local dlrm = self.dlrm,
+  dlrm:: common.ModelGardenTest {
     modelName: 'ranking-dlrm',
     paramsOverride:: {
       runtime: {
@@ -97,7 +98,8 @@ local tpus = import 'templates/tpus.libsonnet';
       '--model_dir=$(MODEL_DIR)',
     ],
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     command+: [
       '--mode=train',
     ],
@@ -107,7 +109,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
 
     command+: [
@@ -120,7 +123,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local gpu_common = {
+  local gpu_common = self.gpu_common,
+  gpu_common:: {
     local config = self,
 
     paramsOverride+:: {
@@ -137,7 +141,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local cross_interaction = {
+  local cross_interaction = self.cross_interaction,
+  cross_interaction:: {
     modelName: 'ranking-dcn',
     local config = self,
 
@@ -150,14 +155,17 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v100 = gpu_common {
+  local v100 = self.v100,
+  v100:: gpu_common {
     accelerator: gpus.teslaV100,
   },
-  local v100x4 = v100 {
+  local v100x4 = self.v100x4,
+  v100x4:: v100 {
     accelerator: gpus.teslaV100 { count: 4 },
   },
 
-  local tpu_common = {
+  local tpu_common = self.tpu_common,
+  tpu_common:: {
     paramsOverride+:: {
       runtime+: {
         distribution_strategy: 'tpu',
@@ -166,7 +174,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_8 = tpu_common {
+  local v2_8 = self.v2_8,
+  v2_8:: tpu_common {
     accelerator: tpus.v2_8,
     paramsOverride+:: {
       task+: {
@@ -178,7 +187,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_32 = tpu_common {
+  local v2_32 = self.v2_32,
+  v2_32:: tpu_common {
     accelerator: tpus.v2_32,
     paramsOverride+:: {
       task+: {
@@ -190,7 +200,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_8 = tpu_common {
+  local v3_8 = self.v3_8,
+  v3_8:: tpu_common {
     accelerator: tpus.v3_8,
     paramsOverride+:: {
       task+: {
@@ -202,7 +213,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_32 = tpu_common {
+  local v3_32 = self.v3_32,
+  v3_32:: tpu_common {
     accelerator: tpus.v3_32,
     paramsOverride+:: {
       task+: {
@@ -214,7 +226,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v4_8 = tpu_common {
+  local v4_8 = self.v4_8,
+  v4_8:: tpu_common {
     accelerator: tpus.v4_8,
     paramsOverride+:: {
       task+: {
@@ -225,7 +238,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local v4_32 = tpu_common {
+  local v4_32 = self.v4_32,
+  v4_32:: tpu_common {
     accelerator: tpus.v4_32,
     paramsOverride+:: {
       task+: {

--- a/tests/tensorflow/r2.11/keras-api.libsonnet
+++ b/tests/tensorflow/r2.11/keras-api.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local keras_test = common.ModelGardenTest {
+  local keras_test = self.keras_test,
+  keras_test:: common.ModelGardenTest {
     testFeature:: error 'Must override `testFeature`',
     modelName: 'keras-api',
     isTPUPod:: error 'Must set `isTPUPod`',
@@ -38,7 +39,8 @@ local utils = import 'templates/utils.libsonnet';
     ),
   },
 
-  local API = common.RunNightly {
+  local API = self.API,
+  API:: common.RunNightly {
     mode: 'api',
     timeout: timeouts.one_hour,
     tpuSettings+: {
@@ -46,72 +48,86 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local connection = API {
+  local connection = self.connection,
+  connection:: API {
     mode: 'connection',
     testFeature:: 'aaa_connection',
   },
 
-  local custom_layers = API {
+  local custom_layers = self.custom_layers,
+  custom_layers:: API {
     mode: 'custom-layers',
     testFeature:: 'custom_layers_model',
   },
 
-  local custom_training_loop = API {
+  local custom_training_loop = self.custom_training_loop,
+  custom_training_loop:: API {
     mode: 'ctl',
     testFeature:: 'custom_training_loop',
   },
 
-  local feature_column = API {
+  local feature_column = self.feature_column,
+  feature_column:: API {
     mode: 'feature-column',
     testFeature:: 'feature_column',
   },
 
-  local rnn = API {
+  local rnn = self.rnn,
+  rnn:: API {
     mode: 'rnn',
     testFeature:: 'rnn',
   },
 
-  local preprocessing_layers = API {
+  local preprocessing_layers = self.preprocessing_layers,
+  preprocessing_layers:: API {
     mode: 'preprocess-layers',
     testFeature:: 'preprocessing_layers',
   },
 
-  local upsample = API {
+  local upsample = self.upsample,
+  upsample:: API {
     mode: 'upsample',
     testFeature:: 'upsample',
   },
 
-  local save_load_io_device_local = API {
+  local save_load_io_device_local = self.save_load_io_device_local,
+  save_load_io_device_local:: API {
     mode: 'save-load-localhost',
     testFeature:: 'save_and_load_io_device_local_drive',
   },
 
-  local save_and_load = API {
+  local save_and_load = self.save_and_load,
+  save_and_load:: API {
     mode: 'save-and-load',
     testFeature:: 'save_and_load.feature',
   },
 
-  local train_and_evaluate = API {
+  local train_and_evaluate = self.train_and_evaluate,
+  train_and_evaluate:: API {
     mode: 'train-and-evaluate',
     testFeature:: 'train_and_evaluate',
   },
 
-  local train_validation_dataset = API {
+  local train_validation_dataset = self.train_validation_dataset,
+  train_validation_dataset:: API {
     mode: 'train-eval-dataset',
     testFeature:: 'train_validation_dataset',
   },
 
-  local transfer_learning = API {
+  local transfer_learning = self.transfer_learning,
+  transfer_learning:: API {
     mode: 'transfer-learning',
     testFeature:: 'transfer_learning',
   },
 
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     isTPUPod: false,
   },
 
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
     isTPUPod: true,
   },

--- a/tests/tensorflow/r2.11/keras-api.libsonnet
+++ b/tests/tensorflow/r2.11/keras-api.libsonnet
@@ -132,7 +132,8 @@ local utils = import 'templates/utils.libsonnet';
     isTPUPod: true,
   },
 
-  local tpuVm = common.tpuVm,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   configs: [
     keras_test + v2_8 + connection,

--- a/tests/tensorflow/r2.11/nlp-mnli.libsonnet
+++ b/tests/tensorflow/r2.11/nlp-mnli.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local bert = common.TfNlpTest {
+  local bert = self.bert,
+  bert:: common.TfNlpTest {
     modelName: 'nlp-bert-mnli',
     scriptConfig+: {
       experiment: 'bert/sentence_prediction_text',
@@ -40,7 +41,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer+: {
@@ -51,16 +53,20 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local convergence = common.Convergence,
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
   configs: [

--- a/tests/tensorflow/r2.11/nlp-mnli.libsonnet
+++ b/tests/tensorflow/r2.11/nlp-mnli.libsonnet
@@ -52,7 +52,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
   local v2_8 = self.v2_8,
   v2_8:: {
     accelerator: tpus.v2_8,

--- a/tests/tensorflow/r2.11/nlp-wmt.libsonnet
+++ b/tests/tensorflow/r2.11/nlp-wmt.libsonnet
@@ -17,7 +17,8 @@ local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local transformer = common.TfNlpTest {
+  local transformer = self.transformer,
+  transformer:: common.TfNlpTest {
     modelName: 'nlp-wmt-transformer',
     scriptConfig+: {
       experiment: 'wmt_transformer/large',
@@ -28,7 +29,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer+: {
@@ -38,7 +40,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
     scriptConfig+: {
       paramsOverride+: {
@@ -49,7 +52,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -62,7 +66,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -74,7 +79,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
     scriptConfig+: {
       paramsOverride+: {
@@ -86,7 +92,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
     scriptConfig+: {
       paramsOverride+: {

--- a/tests/tensorflow/r2.11/vision-coco.libsonnet
+++ b/tests/tensorflow/r2.11/vision-coco.libsonnet
@@ -71,7 +71,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
   local v2_8 = self.v2_8,
   v2_8:: {
     accelerator: tpus.v2_8,
@@ -105,7 +106,8 @@ local utils = import 'templates/utils.libsonnet';
   v4_32:: tpu_common {
     accelerator: tpus.v4_32,
   },
-  local tpuVm = common.tpuVm,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   local functionalTests = [
     benchmark + accelerator + functional

--- a/tests/tensorflow/r2.11/vision-coco.libsonnet
+++ b/tests/tensorflow/r2.11/vision-coco.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local coco = {
+  local coco = self.coco,
+  coco:: {
     scriptConfig+: {
       trainFilePattern: '$(COCO_DIR)/train*',
       evalFilePattern: '$(COCO_DIR)/val*',
@@ -31,7 +32,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpu_common = {
+  local tpu_common = self.tpu_common,
+  tpu_common:: {
     local config = self,
     scriptConfig+: {
       paramsOverride+: {
@@ -43,19 +45,22 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local retinanet = common.TfVisionTest + coco {
+  local retinanet = self.retinanet,
+  retinanet:: common.TfVisionTest + coco {
     modelName: 'vision-retinanet',
     scriptConfig+: {
       experiment: 'retinanet_resnetfpn_coco',
     },
   },
-  local maskrcnn = common.TfVisionTest + coco {
+  local maskrcnn = self.maskrcnn,
+  maskrcnn:: common.TfVisionTest + coco {
     modelName: 'vision-maskrcnn',
     scriptConfig+: {
       experiment: 'maskrcnn_resnetfpn_coco',
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer+: {
@@ -67,7 +72,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local convergence = common.Convergence,
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -79,19 +85,24 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v3_8 = tpu_common {
+  local v3_8 = self.v3_8,
+  v3_8:: tpu_common {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = tpu_common {
+  local v2_32 = self.v2_32,
+  v2_32:: tpu_common {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = tpu_common {
+  local v3_32 = self.v3_32,
+  v3_32:: tpu_common {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = tpu_common {
+  local v4_8 = self.v4_8,
+  v4_8:: tpu_common {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = tpu_common {
+  local v4_32 = self.v4_32,
+  v4_32:: tpu_common {
     accelerator: tpus.v4_32,
   },
   local tpuVm = common.tpuVm,

--- a/tests/tensorflow/r2.11/vision-imagenet.libsonnet
+++ b/tests/tensorflow/r2.11/vision-imagenet.libsonnet
@@ -20,26 +20,30 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local imagenet = {
+  local imagenet = self.imagenet,
+  imagenet:: {
     scriptConfig+: {
       trainFilePattern: '$(IMAGENET_DIR)/train*',
       evalFilePattern: '$(IMAGENET_DIR)/valid*',
     },
   },
-  local resnet = common.TfVisionTest + imagenet {
+  local resnet = self.resnet,
+  resnet:: common.TfVisionTest + imagenet {
     modelName: 'vision-resnet',
     scriptConfig+: {
       experiment: 'resnet_imagenet',
     },
   },
-  local resnet_rs = common.TfVisionTest + imagenet {
+  local resnet_rs = self.resnet_rs,
+  resnet_rs:: common.TfVisionTest + imagenet {
     modelName: 'vision-resnetrs',
     scriptConfig+: {
       experiment: 'resnet_rs_imagenet',
       configFiles: ['official/vision/configs/experiments/image_classification/imagenet_resnetrs50_i160.yaml'],
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer: {
@@ -50,7 +54,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local convergence = common.Convergence,
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -65,19 +70,24 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
   },
   local tpuVm = common.tpuVm,

--- a/tests/tensorflow/r2.11/vision-imagenet.libsonnet
+++ b/tests/tensorflow/r2.11/vision-imagenet.libsonnet
@@ -53,7 +53,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
   local v2_8 = self.v2_8,
   v2_8:: {
     accelerator: tpus.v2_8,
@@ -90,7 +91,8 @@ local utils = import 'templates/utils.libsonnet';
   v4_32:: {
     accelerator: tpus.v4_32,
   },
-  local tpuVm = common.tpuVm,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   local functionalTests = [
     benchmark + accelerator + functional

--- a/tests/tensorflow/r2.12/dlrm.libsonnet
+++ b/tests/tensorflow/r2.12/dlrm.libsonnet
@@ -250,7 +250,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local tpuVm = common.tpuVm,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   configs: [
     dlrm + functional + v3_8,

--- a/tests/tensorflow/r2.12/dlrm.libsonnet
+++ b/tests/tensorflow/r2.12/dlrm.libsonnet
@@ -20,7 +20,8 @@ local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local dlrm = common.ModelGardenTest {
+  local dlrm = self.dlrm,
+  dlrm:: common.ModelGardenTest {
     modelName: 'ranking-dlrm',
     paramsOverride:: {
       runtime: {
@@ -97,7 +98,8 @@ local tpus = import 'templates/tpus.libsonnet';
       '--model_dir=$(MODEL_DIR)',
     ],
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     command+: [
       '--mode=train',
     ],
@@ -107,7 +109,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
 
     command+: [
@@ -120,7 +123,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local gpu_common = {
+  local gpu_common = self.gpu_common,
+  gpu_common:: {
     local config = self,
 
     paramsOverride+:: {
@@ -137,7 +141,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local cross_interaction = {
+  local cross_interaction = self.cross_interaction,
+  cross_interaction:: {
     modelName: 'ranking-dcn',
     local config = self,
 
@@ -150,14 +155,17 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v100 = gpu_common {
+  local v100 = self.v100,
+  v100:: gpu_common {
     accelerator: gpus.teslaV100,
   },
-  local v100x4 = v100 {
+  local v100x4 = self.v100x4,
+  v100x4:: v100 {
     accelerator: gpus.teslaV100 { count: 4 },
   },
 
-  local tpu_common = {
+  local tpu_common = self.tpu_common,
+  tpu_common:: {
     paramsOverride+:: {
       runtime+: {
         distribution_strategy: 'tpu',
@@ -166,7 +174,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_8 = tpu_common {
+  local v2_8 = self.v2_8,
+  v2_8:: tpu_common {
     accelerator: tpus.v2_8,
     paramsOverride+:: {
       task+: {
@@ -178,7 +187,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_32 = tpu_common {
+  local v2_32 = self.v2_32,
+  v2_32:: tpu_common {
     accelerator: tpus.v2_32,
     paramsOverride+:: {
       task+: {
@@ -190,7 +200,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_8 = tpu_common {
+  local v3_8 = self.v3_8,
+  v3_8:: tpu_common {
     accelerator: tpus.v3_8,
     paramsOverride+:: {
       task+: {
@@ -202,7 +213,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_32 = tpu_common {
+  local v3_32 = self.v3_32,
+  v3_32:: tpu_common {
     accelerator: tpus.v3_32,
     paramsOverride+:: {
       task+: {
@@ -214,7 +226,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v4_8 = tpu_common {
+  local v4_8 = self.v4_8,
+  v4_8:: tpu_common {
     accelerator: tpus.v4_8,
     paramsOverride+:: {
       task+: {
@@ -225,7 +238,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local v4_32 = tpu_common {
+  local v4_32 = self.v4_32,
+  v4_32:: tpu_common {
     accelerator: tpus.v4_32,
     paramsOverride+:: {
       task+: {

--- a/tests/tensorflow/r2.12/keras-api.libsonnet
+++ b/tests/tensorflow/r2.12/keras-api.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local keras_test = common.ModelGardenTest {
+  local keras_test = self.keras_test,
+  keras_test:: common.ModelGardenTest {
     testFeature:: error 'Must override `testFeature`',
     modelName: 'keras-api',
     isTPUPod:: error 'Must set `isTPUPod`',
@@ -38,7 +39,8 @@ local utils = import 'templates/utils.libsonnet';
     ),
   },
 
-  local API = common.RunNightly {
+  local API = self.API,
+  API:: common.RunNightly {
     mode: 'api',
     timeout: timeouts.one_hour,
     tpuSettings+: {
@@ -46,72 +48,86 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
 
-  local connection = API {
+  local connection = self.connection,
+  connection:: API {
     mode: 'connection',
     testFeature:: 'aaa_connection',
   },
 
-  local custom_layers = API {
+  local custom_layers = self.custom_layers,
+  custom_layers:: API {
     mode: 'custom-layers',
     testFeature:: 'custom_layers_model',
   },
 
-  local custom_training_loop = API {
+  local custom_training_loop = self.custom_training_loop,
+  custom_training_loop:: API {
     mode: 'ctl',
     testFeature:: 'custom_training_loop',
   },
 
-  local feature_column = API {
+  local feature_column = self.feature_column,
+  feature_column:: API {
     mode: 'feature-column',
     testFeature:: 'feature_column',
   },
 
-  local rnn = API {
+  local rnn = self.rnn,
+  rnn:: API {
     mode: 'rnn',
     testFeature:: 'rnn',
   },
 
-  local preprocessing_layers = API {
+  local preprocessing_layers = self.preprocessing_layers,
+  preprocessing_layers:: API {
     mode: 'preprocess-layers',
     testFeature:: 'preprocessing_layers',
   },
 
-  local upsample = API {
+  local upsample = self.upsample,
+  upsample:: API {
     mode: 'upsample',
     testFeature:: 'upsample',
   },
 
-  local save_load_io_device_local = API {
+  local save_load_io_device_local = self.save_load_io_device_local,
+  save_load_io_device_local:: API {
     mode: 'save-load-localhost',
     testFeature:: 'save_and_load_io_device_local_drive',
   },
 
-  local save_and_load = API {
+  local save_and_load = self.save_and_load,
+  save_and_load:: API {
     mode: 'save-and-load',
     testFeature:: 'save_and_load.feature',
   },
 
-  local train_and_evaluate = API {
+  local train_and_evaluate = self.train_and_evaluate,
+  train_and_evaluate:: API {
     mode: 'train-and-evaluate',
     testFeature:: 'train_and_evaluate',
   },
 
-  local train_validation_dataset = API {
+  local train_validation_dataset = self.train_validation_dataset,
+  train_validation_dataset:: API {
     mode: 'train-eval-dataset',
     testFeature:: 'train_validation_dataset',
   },
 
-  local transfer_learning = API {
+  local transfer_learning = self.transfer_learning,
+  transfer_learning:: API {
     mode: 'transfer-learning',
     testFeature:: 'transfer_learning',
   },
 
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     isTPUPod: false,
   },
 
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
     isTPUPod: true,
   },

--- a/tests/tensorflow/r2.12/keras-api.libsonnet
+++ b/tests/tensorflow/r2.12/keras-api.libsonnet
@@ -132,7 +132,8 @@ local utils = import 'templates/utils.libsonnet';
     isTPUPod: true,
   },
 
-  local tpuVm = common.tpuVm,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   configs: [
     keras_test + v2_8 + connection,

--- a/tests/tensorflow/r2.12/nlp-mnli.libsonnet
+++ b/tests/tensorflow/r2.12/nlp-mnli.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local bert = common.TfNlpTest {
+  local bert = self.bert,
+  bert:: common.TfNlpTest {
     modelName: 'nlp-bert-mnli',
     scriptConfig+: {
       experiment: 'bert/sentence_prediction_text',
@@ -40,7 +41,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer+: {
@@ -51,16 +53,20 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local convergence = common.Convergence,
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
   configs: [

--- a/tests/tensorflow/r2.12/nlp-mnli.libsonnet
+++ b/tests/tensorflow/r2.12/nlp-mnli.libsonnet
@@ -52,7 +52,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
   local v2_8 = self.v2_8,
   v2_8:: {
     accelerator: tpus.v2_8,

--- a/tests/tensorflow/r2.12/nlp-wmt.libsonnet
+++ b/tests/tensorflow/r2.12/nlp-wmt.libsonnet
@@ -17,7 +17,8 @@ local timeouts = import 'templates/timeouts.libsonnet';
 local tpus = import 'templates/tpus.libsonnet';
 
 {
-  local transformer = common.TfNlpTest {
+  local transformer = self.transformer,
+  transformer:: common.TfNlpTest {
     modelName: 'nlp-wmt-transformer',
     scriptConfig+: {
       experiment: 'wmt_transformer/large',
@@ -28,7 +29,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer+: {
@@ -38,7 +40,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence {
+  local convergence = self.convergence,
+  convergence:: common.Convergence {
     local config = self,
     scriptConfig+: {
       paramsOverride+: {
@@ -49,7 +52,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -62,7 +66,8 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -74,7 +79,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
     scriptConfig+: {
       paramsOverride+: {
@@ -86,7 +92,8 @@ local tpus = import 'templates/tpus.libsonnet';
       },
     },
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
     scriptConfig+: {
       paramsOverride+: {

--- a/tests/tensorflow/r2.12/vision-coco.libsonnet
+++ b/tests/tensorflow/r2.12/vision-coco.libsonnet
@@ -71,7 +71,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
   local v2_8 = self.v2_8,
   v2_8:: {
     accelerator: tpus.v2_8,
@@ -105,7 +106,8 @@ local utils = import 'templates/utils.libsonnet';
   v4_32:: tpu_common {
     accelerator: tpus.v4_32,
   },
-  local tpuVm = common.tpuVm,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   local functionalTests = [
     benchmark + accelerator + functional

--- a/tests/tensorflow/r2.12/vision-coco.libsonnet
+++ b/tests/tensorflow/r2.12/vision-coco.libsonnet
@@ -20,7 +20,8 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local coco = {
+  local coco = self.coco,
+  coco:: {
     scriptConfig+: {
       trainFilePattern: '$(COCO_DIR)/train*',
       evalFilePattern: '$(COCO_DIR)/val*',
@@ -31,7 +32,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local tpu_common = {
+  local tpu_common = self.tpu_common,
+  tpu_common:: {
     local config = self,
     scriptConfig+: {
       paramsOverride+: {
@@ -43,19 +45,22 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local retinanet = common.TfVisionTest + coco {
+  local retinanet = self.retinanet,
+  retinanet:: common.TfVisionTest + coco {
     modelName: 'vision-retinanet',
     scriptConfig+: {
       experiment: 'retinanet_resnetfpn_coco',
     },
   },
-  local maskrcnn = common.TfVisionTest + coco {
+  local maskrcnn = self.maskrcnn,
+  maskrcnn:: common.TfVisionTest + coco {
     modelName: 'vision-maskrcnn',
     scriptConfig+: {
       experiment: 'maskrcnn_resnetfpn_coco',
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer+: {
@@ -67,7 +72,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local convergence = common.Convergence,
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -79,19 +85,24 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v3_8 = tpu_common {
+  local v3_8 = self.v3_8,
+  v3_8:: tpu_common {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = tpu_common {
+  local v2_32 = self.v2_32,
+  v2_32:: tpu_common {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = tpu_common {
+  local v3_32 = self.v3_32,
+  v3_32:: tpu_common {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = tpu_common {
+  local v4_8 = self.v4_8,
+  v4_8:: tpu_common {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = tpu_common {
+  local v4_32 = self.v4_32,
+  v4_32:: tpu_common {
     accelerator: tpus.v4_32,
   },
   local tpuVm = common.tpuVm,

--- a/tests/tensorflow/r2.12/vision-imagenet.libsonnet
+++ b/tests/tensorflow/r2.12/vision-imagenet.libsonnet
@@ -20,26 +20,30 @@ local tpus = import 'templates/tpus.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 
 {
-  local imagenet = {
+  local imagenet = self.imagenet,
+  imagenet:: {
     scriptConfig+: {
       trainFilePattern: '$(IMAGENET_DIR)/train*',
       evalFilePattern: '$(IMAGENET_DIR)/valid*',
     },
   },
-  local resnet = common.TfVisionTest + imagenet {
+  local resnet = self.resnet,
+  resnet:: common.TfVisionTest + imagenet {
     modelName: 'vision-resnet',
     scriptConfig+: {
       experiment: 'resnet_imagenet',
     },
   },
-  local resnet_rs = common.TfVisionTest + imagenet {
+  local resnet_rs = self.resnet_rs,
+  resnet_rs:: common.TfVisionTest + imagenet {
     modelName: 'vision-resnetrs',
     scriptConfig+: {
       experiment: 'resnet_rs_imagenet',
       configFiles: ['official/vision/configs/experiments/image_classification/imagenet_resnetrs50_i160.yaml'],
     },
   },
-  local functional = common.Functional {
+  local functional = self.functional,
+  functional:: common.Functional {
     scriptConfig+: {
       paramsOverride+: {
         trainer: {
@@ -50,7 +54,8 @@ local utils = import 'templates/utils.libsonnet';
     },
   },
   local convergence = common.Convergence,
-  local v2_8 = {
+  local v2_8 = self.v2_8,
+  v2_8:: {
     accelerator: tpus.v2_8,
     scriptConfig+: {
       paramsOverride+: {
@@ -65,19 +70,24 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local v3_8 = {
+  local v3_8 = self.v3_8,
+  v3_8:: {
     accelerator: tpus.v3_8,
   },
-  local v2_32 = {
+  local v2_32 = self.v2_32,
+  v2_32:: {
     accelerator: tpus.v2_32,
   },
-  local v3_32 = {
+  local v3_32 = self.v3_32,
+  v3_32:: {
     accelerator: tpus.v3_32,
   },
-  local v4_8 = {
+  local v4_8 = self.v4_8,
+  v4_8:: {
     accelerator: tpus.v4_8,
   },
-  local v4_32 = {
+  local v4_32 = self.v4_32,
+  v4_32:: {
     accelerator: tpus.v4_32,
   },
   local tpuVm = common.tpuVm,

--- a/tests/tensorflow/r2.12/vision-imagenet.libsonnet
+++ b/tests/tensorflow/r2.12/vision-imagenet.libsonnet
@@ -53,7 +53,8 @@ local utils = import 'templates/utils.libsonnet';
       },
     },
   },
-  local convergence = common.Convergence,
+  local convergence = self.convergence,
+  convergence:: common.Convergence,
   local v2_8 = self.v2_8,
   v2_8:: {
     accelerator: tpus.v2_8,
@@ -90,7 +91,8 @@ local utils = import 'templates/utils.libsonnet';
   v4_32:: {
     accelerator: tpus.v4_32,
   },
-  local tpuVm = common.tpuVm,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   local functionalTests = [
     benchmark + accelerator + functional


### PR DESCRIPTION
# Description

Make it easier to import this repository as a submodule and add new test variants. Expose most test configuration as fields (rather than locals) to make them accessible from other files. I left the existing `local`s in place to make the `configs` section less verbose (e.g. `mnist + funtional` vs `self.mnist + self.functional`).

# Tests

Test run with PT/XLA MNIST example: http://shortn/_lFUC1nIJZJ
Test run with TF example (currently failing on dashboard too): http://shortn/_I1A8T3wAbW

Diffs have no changes except for whitespace.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.