### PR TITLE
Adds lite TPU support

### DIFF
--- a/templates/tpus.libsonnet
+++ b/templates/tpus.libsonnet
@@ -18,10 +18,14 @@ local base = import 'base.libsonnet';
   TpuSpec:: base.BaseAccelerator {
     local tpu = self,
 
-    name: 'v%(version)d-%(size)d' % tpu,
+    name: if self.isLite then
+      'v%(version)dlite-%(size)d' % tpu
+    else
+      'v%(version)d-%(size)d' % tpu,
     type: 'tpu',
     version: error 'Must override `version`',
     size: error 'Must override `size`',
+    isLite: error 'Must override `isLite`',
     numCores: if tpu.version <= 3 then 8 else 4,
     replicas: tpu.size / 8,  // Each TPU replica has 8 cores
 
@@ -63,11 +67,11 @@ local base = import 'base.libsonnet';
     },
   },
 
-  v2_8: self.TpuSpec { version: 2, size: 8 },
-  v3_8: self.TpuSpec { version: 3, size: 8 },
-  v2_32: self.TpuSpec { version: 2, size: 32 },
-  v3_32: self.TpuSpec { version: 3, size: 32 },
-  v4_8: self.TpuSpec { version: 4, size: 8 },
-  v4_16: self.TpuSpec { version: 4, size: 16 },
-  v4_32: self.TpuSpec { version: 4, size: 32 },
+  v2_8: self.TpuSpec { version: 2, size: 8, isLite: false },
+  v3_8: self.TpuSpec { version: 3, size: 8, isLite: false },
+  v2_32: self.TpuSpec { version: 2, size: 32, isLite: false },
+  v3_32: self.TpuSpec { version: 3, size: 32, isLite: false },
+  v4_8: self.TpuSpec { version: 4, size: 8, isLite: false },
+  v4_16: self.TpuSpec { version: 4, size: 16, isLite: false },
+  v4_32: self.TpuSpec { version: 4, size: 32, isLite: false },
 }


### PR DESCRIPTION
# Description

Adds support for lite TPUs. Also adds the first example of a lite TPU: `v4lite_4`.

# Tests

I ran a random nightly test to sanity check that existing tests are intact. No tests are expected to be affected by this change.

**Instruction and/or command lines to reproduce your tests:**
```
export TEST_NAME=pt-nightly-hf-fsmt-pjrt-func-v4-8-1vm
./scripts/gen-tests.sh
gcloud container clusters get-credentials xl-ml-test-us-central2 --region us-central2 --project xl-ml-test
./scripts/run-oneshot.sh -t $TEST_NAME
```

**List links for your tests (use go/shortn-gen for any internal link):**
http://shortn/_iJoaMzX17D

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.