### PR TITLE
Add v4lite tests

### DIFF
--- a/templates/tpus.libsonnet
+++ b/templates/tpus.libsonnet
@@ -18,10 +18,14 @@ local base = import 'base.libsonnet';
   TpuSpec:: base.BaseAccelerator {
     local tpu = self,
 
-    name: 'v%(version)d-%(size)d' % tpu,
+    name: if self.isLite then
+      'v%(version)dlite-%(size)d' % tpu
+    else
+      'v%(version)d-%(size)d' % tpu,
     type: 'tpu',
     version: error 'Must override `version`',
     size: error 'Must override `size`',
+    isLite: error 'Must override `isLite`',
     numCores: if tpu.version <= 3 then 8 else 4,
     replicas: tpu.size / 8,  // Each TPU replica has 8 cores
 
@@ -63,11 +67,12 @@ local base = import 'base.libsonnet';
     },
   },
 
-  v2_8: self.TpuSpec { version: 2, size: 8 },
-  v3_8: self.TpuSpec { version: 3, size: 8 },
-  v2_32: self.TpuSpec { version: 2, size: 32 },
-  v3_32: self.TpuSpec { version: 3, size: 32 },
-  v4_8: self.TpuSpec { version: 4, size: 8 },
-  v4_16: self.TpuSpec { version: 4, size: 16 },
-  v4_32: self.TpuSpec { version: 4, size: 32 },
+  v2_8: self.TpuSpec { version: 2, size: 8, isLite: false },
+  v3_8: self.TpuSpec { version: 3, size: 8, isLite: false },
+  v2_32: self.TpuSpec { version: 2, size: 32, isLite: false },
+  v3_32: self.TpuSpec { version: 3, size: 32, isLite: false },
+  v4lite_4: self.TpuSpec { version: 4, size: 4, isLite: true },
+  v4_8: self.TpuSpec { version: 4, size: 8, isLite: false },
+  v4_16: self.TpuSpec { version: 4, size: 16, isLite: false },
+  v4_32: self.TpuSpec { version: 4, size: 32, isLite: false },
 }

--- a/tests/tensorflow/nightly/nlp-mnli.libsonnet
+++ b/tests/tensorflow/nightly/nlp-mnli.libsonnet
@@ -62,6 +62,10 @@ local utils = import 'templates/utils.libsonnet';
   v3_8:: {
     accelerator: tpus.v3_8,
   },
+  local v4lite_4 = self.v4lite_4,
+  v4lite_4:: {
+    accelerator: tpus.v4lite_4,
+  },
   local v2_32 = self.v2_32,
   v2_32:: {
     accelerator: tpus.v2_32,
@@ -70,11 +74,13 @@ local utils = import 'templates/utils.libsonnet';
   v3_32:: {
     accelerator: tpus.v3_32,
   },
+  local tpuVm = experimental.TensorFlowTpuVmMixin,
   configs: [
     bert + accelerator + functional
     for accelerator in [v2_8, v3_8]
   ] + [
     bert + v2_32 + convergence,
     bert + v3_32 + convergence,
+    bert + v4lite_4 + functional + tpuVm,
   ],
 }

--- a/tests/tensorflow/nightly/vision-imagenet.libsonnet
+++ b/tests/tensorflow/nightly/vision-imagenet.libsonnet
@@ -108,5 +108,6 @@ local utils = import 'templates/utils.libsonnet';
   configs: functionalTests + convergenceTests + [
     resnet + v4_8 + functional + tpuVm,
     resnet + v4_32 + convergence + tpuVm,
+    resnet_rs + v4lite_4 + functional + tpuVm,
   ],
 }


### PR DESCRIPTION
# Description
[DO NOT MERGE]
Adds v4lite tests for BERT and vision-resnet. A cluster with v4lite TPUs needs to be brought up before this change can be validated.

# Tests

These new tests will be run once the infrastructure to run them is properly setup.

**Instruction and/or command lines to reproduce your tests:**
N/A

**List links for your tests (use go/shortn-gen for any internal link):**
N/A 

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.