### PR TITLE
Fixes bug in tensorflow Dockerfile

### DIFF
--- a/images/tensorflow/Dockerfile
+++ b/images/tensorflow/Dockerfile
@@ -12,23 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG image_version=nightly
+ARG image_version="nightly"
+
 FROM tensorflow/tensorflow:${image_version}-gpu
 
-ARG model_garden_branch=master
+ARG image_version
+ARG model_garden_branch="master"
+ARG tensorflow_text_version="nightly"
 
 RUN apt-get update && apt-get install -y --no-install-recommends git
-
 RUN pip3 install cloud-tpu-client pyyaml
-
-ARG tensorflow_text_version=nightly
 
 # HACKs: Remove this once they are added to the Model Garden requirements
 RUN pip3 install tensorflow-recommenders --no-deps
-RUN if [[ "${image_version}" == "nightly" || "${tensorflow_text_version}" == "nightly" || "${tensorflow_text_version}" == *"dev"* ]]; then \
-    pip3 install tensorflow-text-nightly --no-deps; \
+RUN if [ ${image_version} = "nightly" ] \
+    || [ ${tensorflow_text_version} = "nightly" ] \
+    || [ echo ${tensorflow_text_version} | grep -q "dev" ]; then \
+        pip3 install tensorflow-text-nightly --no-deps; \
     else \
-    pip3 install tensorflow-text==${tensorflow_text_version} --no-deps; \
+        pip3 install tensorflow-text==${tensorflow_text_version} --no-deps; \
     fi
 
 # Checkout tensorflow/models at HEAD
@@ -50,3 +52,4 @@ ENV PATH "/google-cloud-sdk/bin/:${PATH}"
 
 WORKDIR /garden
 ENTRYPOINT ["/entrypoint.sh"]
+


### PR DESCRIPTION
# Description

This fixes a bug in the TensorFlow Dockerfile. The file is currently throwing exceptions because it does not have valid `/bin/sh` syntax and because variables were out of scope in places they were being used. This change fixes both issues.

# Tests

This doesn't affect tests, just the image generation script used to run them. I ran the image generation script locally using:
```
sudo docker build . \
-f images/tensorflow/Dockerfile \
--build-arg image_version=${_BASE_IMAGE_VERSION} \
--build-arg model_garden_branch=${_MODEL_GARDEN_BRANCH} \
--build-arg tensorflow_text_version=${_TENSORFLOW_TEXT_VERSION}
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.