### PR TITLE
Fixed TF resnetrs TPU VM startup script

### DIFF
--- a/tests/tensorflow/nightly/tf-resnetrs-imagenet.libsonnet
+++ b/tests/tensorflow/nightly/tf-resnetrs-imagenet.libsonnet
@@ -62,7 +62,8 @@ local utils = import 'templates/utils.libsonnet';
   local v3_32 = {
     accelerator: tpus.v3_32,
   },
-  local tpuVm = experimental.TensorFlowTpuVmMixin,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   local functionalTests = [
     resnet_rs + v2_8 + functional,

--- a/tests/tensorflow/r2.12/tf-resnetrs-imagenet.libsonnet
+++ b/tests/tensorflow/r2.12/tf-resnetrs-imagenet.libsonnet
@@ -62,7 +62,8 @@ local utils = import 'templates/utils.libsonnet';
   local v3_32 = {
     accelerator: tpus.v3_32,
   },
-  local tpuVm = experimental.TensorFlowTpuVmMixin,
+  local tpuVm = self.tpuVm,
+  tpuVm:: common.tpuVm,
 
   local functionalTests = [
     resnet_rs + v2_8 + functional,


### PR DESCRIPTION
# Description
The tensorflow resnetrs TPU VM tests were using an out-of-date TPU VM startup script, resulting in an import issue with tensorflow. This PR updates their startup script.
# Tests
Ran oneshot test for `tf.nightly-resnetrs-imagenet-conv-v3-32-1vm`, no longer runs into tensorflow importing issues.
**Instruction and/or command lines to reproduce your tests:** ...
`./scripts/run-oneshot.sh -t tf.nightly-resnetrs-imagenet-conv-v3-32-1vm`
**List links for your tests (use go/shortn-gen for any internal link):** ...
http://shortn/_0Y05OgaYIm
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.