### PR TITLE
Add JAX GPT2 test

### DIFF
--- a/tests/jax/latest/flax-gpt2-oscar.libsonnet
+++ b/tests/jax/latest/flax-gpt2-oscar.libsonnet
@@ -1,0 +1,73 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local common = import '../common.libsonnet';
+local mixins = import 'templates/mixins.libsonnet';
+local timeouts = import 'templates/timeouts.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+
+{
+  local hf_gpt2_common = self.hf_gpt2_common,
+  hf_gpt2_common:: common.JaxTest + common.huggingFace {
+    local config = self,
+    frameworkPrefix: 'flax.latest',
+    modelName:: 'gpt2-oscar',
+    extraFlags:: [],
+    testScript:: |||
+      %(installPackages)s
+      pip install -r examples/flax/language-modeling/requirements.txt
+      %(verifySetup)s
+
+      cd examples/flax/language-modeling
+      gsutil cp -r gs://cloud-tpu-tpuvm-artifacts/config/xl-ml-test/jax/gpt2 .
+
+      python3 run_clm_flax.py \
+        --output_dir=./gpt2 \
+        --model_type=gpt2 \
+        --config_name=./gpt2 \
+        --tokenizer_name=./gpt2 \
+        --dataset_name=oscar \
+        --dataset_config_name=unshuffled_deduplicated_no \
+        --do_train \
+        --do_eval \
+        --block_size=512 \
+        --learning_rate=5e-3 \
+        --warmup_steps=1000 \
+        --adam_beta1=0.9 \
+        --adam_beta2=0.98 \
+        --weight_decay=0.01 \
+        --overwrite_output_dir \
+        --num_train_epochs=1 \
+        --logging_steps=500 \
+        --eval_steps=2500 \
+         %(extraFlags)s
+
+    ||| % (self.scriptConfig { extraFlags: std.join(' ', config.extraFlags) }),
+  },
+
+  local func = self.func,
+  func:: mixins.Functional,
+
+  local v4 = self.v4,
+  v4:: common.tpuVmV4Base {
+    extraFlags+:: ['--per_device_train_batch_size=64', '--per_device_eval_batch_size=64'],
+  },
+
+  local v4_8 = self.v4_8,
+  v4_8:: v4 {
+    accelerator: tpus.v4_8,
+  },
+
+  configs: [hf_gpt2_common + func + v4_8 + timeouts.Hours(2)],
+}

--- a/tests/jax/latest/targets.jsonnet
+++ b/tests/jax/latest/targets.jsonnet
@@ -15,6 +15,7 @@
 local hf_bart = import 'flax-bart-wiki_summary.libsonnet';
 local hf_bert_mnli = import 'flax-bert-glue_mnli.libsonnet';
 local hf_bert_mrpc = import 'flax-bert-glue_mrpc.libsonnet';
+local hf_gpt2 = import 'flax-gpt2-oscar.libsonnet';
 local resnet = import 'flax-resnet-imagenet.libsonnet';
 local hf_vit = import 'flax-vit-imagenette.libsonnet';
 local wmt = import 'flax-wmt-wmt17_translate.libsonnet';
@@ -25,6 +26,7 @@ std.flattenArrays([
   hf_vit.configs,
   hf_bert_mnli.configs,
   hf_bert_mrpc.configs,
+  hf_gpt2.configs,
   resnet.configs,
   wmt.configs,
 ])


### PR DESCRIPTION
# Description

Add func JAX GPT2 test for V4 with tiny model size (ref [configs](https://huggingface.co/hf-tiny-model-private/tiny-random-GPT2LMHeadModel/blob/main/config.json)). It still passes 1 hour default limit for func test (even with 1 training epoch), so extend the time-out to 2 hours (with some buffer).

Model config:

```
{
  "activation_function": "gelu_new",
  "architectures": [
    "GPT2LMHeadModel"
  ],
  "attn_pdrop": 0.0,
  "bos_token_id": 0,
  "embd_pdrop": 0.0,
  "eos_token_id": 0,
  "initializer_range": 0.02,
  "layer_norm_epsilon": 1e-05,
  "model_type": "gpt2",
  "n_ctx": 512,
  "n_embd": 32,
  "n_head": 4,
  "n_inner": null,
  "n_layer": 3,
  "n_positions": 512,
  "reorder_and_upcast_attn": false,
  "resid_pdrop": 0.0,
  "scale_attn_by_inverse_layer_idx": false,
  "scale_attn_weights": true,
  "summary_activation": null,
  "summary_first_dropout": 0.1,
  "summary_proj_to_labels": true,
  "summary_type": "cls_index",
  "summary_use_proj": true,
  "task_specific_params": {
    "text-generation": {
      "do_sample": true,
      "max_length": 50
    }
  },
  "transformers_version": "4.27.0.dev0",
  "use_cache": true,
  "vocab_size": 1024
}
```

# Tests

**Instruction and/or command lines to reproduce your tests:** ...

```
./scripts/run-oneshot.sh -t flax.latest-gpt2-oscar-func-v4-8
```

**List links for your tests (use go/shortn-gen for any internal link):** ...

The test passed: [link](http://shortn/_WCjFF688oK).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.