### PR TITLE
Automatically sync filestore instances

### DIFF
--- a/k8s/europe-west4/filestore.yaml
+++ b/k8s/europe-west4/filestore.yaml
@@ -1,0 +1,66 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: filestore-storage
+provisioner: filestore.csi.storage.gke.io
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  tier: standard
+  network: default
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.gke.io/zone
+    values:
+    - europe-west4-a
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: storage
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: filestore-datasets
+  namespace: storage
+spec:
+  accessModes:
+  - ReadWriteMany
+  storageClassName: filestore-storage
+  resources:
+    requests:
+      storage: 1Ti
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: filestore-sync
+  namespace: storage
+spec:
+  schedule: "5 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          containers:
+          - name: sync
+            image: google/cloud-sdk
+            command:
+            - gsutil
+            - -m
+            - rsync
+            - -d
+            - -r
+            - gs://xl-ml-test-filestore
+            - /filestore
+            volumeMounts:
+            - name: filestore
+              mountPath: /filestore
+          volumes:
+          - name: filestore
+            persistentVolumeClaim:
+              claimName: filestore-datasets
+          restartPolicy: Never

--- a/k8s/europe-west4/pytorch-data-ips.yaml
+++ b/k8s/europe-west4/pytorch-data-ips.yaml
@@ -17,4 +17,4 @@ kind: ConfigMap
 metadata:
   name: pytorch-nfs-ip
 data:
-  PYTORCH_DATA_LOCATION: 10.182.107.26:/pytorch_datasets
+  PYTORCH_DATA_LOCATION: 172.28.11.122:/vol1

--- a/k8s/us-central1/filestore.yaml
+++ b/k8s/us-central1/filestore.yaml
@@ -1,0 +1,66 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: filestore-storage
+provisioner: filestore.csi.storage.gke.io
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  tier: standard
+  network: default
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.gke.io/zone
+    values:
+    - us-central1-b
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: storage
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: filestore-datasets
+  namespace: storage
+spec:
+  accessModes:
+  - ReadWriteMany
+  storageClassName: filestore-storage
+  resources:
+    requests:
+      storage: 1Ti
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: filestore-sync
+  namespace: storage
+spec:
+  schedule: "5 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          containers:
+          - name: sync
+            image: google/cloud-sdk
+            command:
+            - gsutil
+            - -m
+            - rsync
+            - -d
+            - -r
+            - gs://xl-ml-test-filestore
+            - /filestore
+            volumeMounts:
+            - name: filestore
+              mountPath: /filestore
+          volumes:
+          - name: filestore
+            persistentVolumeClaim:
+              claimName: filestore-datasets
+          restartPolicy: Never

--- a/k8s/us-central1/pytorch-data-ips.yaml
+++ b/k8s/us-central1/pytorch-data-ips.yaml
@@ -17,4 +17,4 @@ kind: ConfigMap
 metadata:
   name: pytorch-nfs-ip
 data:
-  PYTORCH_DATA_LOCATION: 10.166.46.250:/pytorch_datasets
+  PYTORCH_DATA_LOCATION: 10.247.134.10:/vol1

--- a/k8s/us-central2/filestore.yaml
+++ b/k8s/us-central2/filestore.yaml
@@ -1,0 +1,89 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: filestore-storage
+provisioner: filestore.csi.storage.gke.io
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  tier: standard
+  network: default
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.gke.io/zone
+    values:
+    - us-central2-b
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: storage
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: filestore-datasets
+  namespace: storage
+  annotations:
+    pv.kubernetes.io/provisioned-by: filestore.csi.storage.gke.io
+spec:
+  storageClassName:  filestore-storage
+  capacity:
+    storage: 1Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Filesystem
+  csi:
+    driver: filestore.csi.storage.gke.io
+    volumeHandle: "modeInstance/us-central2-b/pytorch-datasets-us-central2-b/pytorch_datasets"
+    volumeAttributes:
+      ip: 10.61.8.66
+      volume: pytorch_datasets
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: filestore-datasets
+  namespace: storage
+spec:
+  accessModes:
+  - ReadWriteMany
+  storageClassName: filestore-storage
+  volumeName: filestore-datasets
+  resources:
+    requests:
+      storage: 1Ti
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: filestore-sync
+  namespace: storage
+spec:
+  schedule: "5 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          containers:
+          - name: sync
+            image: google/cloud-sdk
+            command:
+            - gsutil
+            - -m
+            - rsync
+            - -d
+            - -r
+            - gs://xl-ml-test-filestore
+            - /filestore
+            volumeMounts:
+            - name: filestore
+              mountPath: /filestore
+          volumes:
+          - name: filestore
+            persistentVolumeClaim:
+              claimName: filestore-datasets
+          restartPolicy: Never


### PR DESCRIPTION
# Description

Create filestore instances through the CSI driver and sync them from a GCS bucket using a CronJob. Reuse existing share in us-central2-b due to quota constraints.

# Tests

Tested with new instance IP and share location to confirm share is mounted correctly.

- http://shortn/_AbvVx95w0O
- http://shortn/_MoFFE5QbfS

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.