### PR TITLE
Increase timeout for transformer conv test.

### DIFF
--- a/tests/pytorch/nightly/hf-fsmt.libsonnet
+++ b/tests/pytorch/nightly/hf-fsmt.libsonnet
@@ -59,6 +59,6 @@ local tpus = import 'templates/tpus.libsonnet';
 
   configs: [
     fsmt + functional + v4_8 + pjrt + timeouts.Hours(1),
-    fsmt + convergence + v4_8 + pjrt,
+    fsmt + convergence + v4_8 + pjrt + timeouts.Hours(12),
   ],
 }


### PR DESCRIPTION
# Description

Today, the huggingface fsmt conv test runs for 3 epochs and times out after 10h ("activeDeadlineSeconds": 36000). From the log, it seems each epoch runs for approximately 3h and 20min. So 10h timeout doesn't seem enough.

Per the [log](https://cloudlogging.app.goo.gl/8PMuZhBhasYgBLTb8), all 3 epochs have finished. The last exception before deleting the TPU VM:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/xl-ml-test/.local/lib/python3.8/site-packages/tensorboardX/event_file_writer.py", line 202, in run
    data = self._queue.get(True, queue_wait_duration)
  File "/usr/lib/python3.8/multiprocessing/queues.py", line 111, in get
    res = self._recv_bytes()
  File "/usr/lib/python3.8/multiprocessing/connection.py", line 216, in recv_bytes
    buf = self._recv_bytes(maxlength)
  File "/usr/lib/python3.8/multiprocessing/connection.py", line 414, in _recv_bytes
    buf = self._recv(4)
  File "/usr/lib/python3.8/multiprocessing/connection.py", line 383, in _recv
    raise EOFError
```
doesn't seem to be caused by this PR.

# Tests

Please describe the tests that you ran on TPUs to verify changes.

**Instruction and/or command lines to reproduce your tests:** 

```
$ export TEST_NAME=pt-nightly-hf-fsmt-pjrt-conv-v4-8-1vm
$ gcloud container clusters get-credentials xl-ml-test-us-central2 --region us-central2 --project xl-ml-test
$ jsonnet tests/oneshot.jsonnet -J . -S --tla-str test=$TEST_NAME | kubectl create -f -
```

**List links for your tests (use go/shortn-gen for any internal link):** 

https://cloudlogging.app.goo.gl/gXRmsiVb3HsiqBs26

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.