### PR TITLE
Move timeout to pod for TPU VM tests

### DIFF
--- a/tests/experimental.libsonnet
+++ b/tests/experimental.libsonnet
@@ -14,6 +14,7 @@
 
 local utils = import 'templates/utils.libsonnet';
 local volumes = import 'templates/volumes.libsonnet';
+local timeouts = import 'templates/timeouts.libsonnet';
 
 {
   BaseTpuVmTest:: {
@@ -157,6 +158,7 @@ local volumes = import 'templates/volumes.libsonnet';
     // Disable retries
     jobTemplate+:: {
       spec+: {
+        activeDeadlineSeconds: std.max(2 * config.timeout, 24 * timeouts.one_hour),
         backoffLimit: 0,
       },
     },
@@ -168,6 +170,7 @@ local volumes = import 'templates/volumes.libsonnet';
     // Pass TPU VM name to test container
     podTemplate+:: {
       spec+: {
+        activeDeadlineSeconds: config.timeout,
         containerMap+:: {
           train+: {
             image: 'google/cloud-sdk',

--- a/tests/experimental.libsonnet
+++ b/tests/experimental.libsonnet
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local timeouts = import 'templates/timeouts.libsonnet';
 local utils = import 'templates/utils.libsonnet';
 local volumes = import 'templates/volumes.libsonnet';
-local timeouts = import 'templates/timeouts.libsonnet';
 
 {
   BaseTpuVmTest:: {


### PR DESCRIPTION
# Description

Jobs are current timing out before any pod has been created. For TPU VM tests, move the primary timeout to the pod so it starts when the test begins.

To prevent jobs from hanging around forever, give the parent job a timeout of 24 hours (or 2 times the expected pod timeout for very long jobs). These values are totally arbitrary, and we can update them later based on feedback.

This doesn't play nice with retries, since the workload timer will essentially reset every time we restart the pod. However, the TPU VM tests do not actually attempt retries.

# Tests

Smoke test: http://shortn/_i3bf5u3pFF

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.