### PR TITLE
Use virtual device in SPMD tests

### DIFF
--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -197,6 +197,11 @@ local tpus = import 'templates/tpus.libsonnet';
     // Keep the same global batch size. In SPMD, the global batch size is
     // divided across all devices.
     batch_size: self.accelerator.size * 128,
+    tpuSettings+: {
+      tpuVmExports+: |||
+        export XLA_USE_SPMD=1
+      |||,
+    },
   },
 
   configs: [


### PR DESCRIPTION
# Description

Use virtual device in SPMD resnet50 tests. Currently, the tests are failing because the MpDeviceLoader requires virtual device usage when using sharded data loading.

# Tests

Please describe the tests that you ran on TPUs to verify changes.

`scripts/run-oneshot.sh -t pt-nightly-resnet50-spmd-batch-func-v4-8-1vm`: http://shortn/_E8LhRJtrJV
`scripts/run-oneshot.sh -t pt-nightly-resnet50-spmd-spatial-func-v4-8-1vm`: http://shortn/_57yqlRJvd9

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.