### PR TITLE
migrate jax tests to use Ubuntu 22.04 base vm image

### DIFF
--- a/tests/jax/common.libsonnet
+++ b/tests/jax/common.libsonnet
@@ -114,10 +114,6 @@ local utils = import 'templates/utils.libsonnet';
               sleep %(sleepTime)d
             ||| % tpuCreateSettings),
           },
-          'tpu-version': {
-            image: 'google/cloud-sdk',
-            command: null,
-          },
         },
       },
     },

--- a/tests/jax/latest/flax-bart-wiki_summary.libsonnet
+++ b/tests/jax/latest/flax-bart-wiki_summary.libsonnet
@@ -98,12 +98,12 @@ local tpus = import 'templates/tpus.libsonnet';
     extraFlags+:: ['--per_device_train_batch_size 16', '--per_device_eval_batch_size 16'],
   },
   local v4_8 = self.v4_8,
-  v4_8:: common.tpuVmV4Base {
+  v4_8:: common.tpuVmBaseImage {
     accelerator: tpus.v4_8,
     extraFlags+:: ['--per_device_train_batch_size 64', '--per_device_eval_batch_size 64'],
   },
   local v4_32 = self.v4_32,
-  v4_32:: common.tpuVmV4Base {
+  v4_32:: common.tpuVmBaseImage {
     accelerator: tpus.v4_32,
     extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },

--- a/tests/jax/latest/flax-bert-glue_mnli.libsonnet
+++ b/tests/jax/latest/flax-bert-glue_mnli.libsonnet
@@ -63,7 +63,7 @@ local tpus = import 'templates/tpus.libsonnet';
     extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
   },
   local v4 = self.v4,
-  v4:: common.tpuVmV4Base {
+  v4:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size 8', '--per_device_eval_batch_size 8'],
   },
 

--- a/tests/jax/latest/flax-bert-glue_mrpc.libsonnet
+++ b/tests/jax/latest/flax-bert-glue_mrpc.libsonnet
@@ -62,7 +62,7 @@ local tpus = import 'templates/tpus.libsonnet';
     extraFlags+:: ['--per_device_train_batch_size 4', '--per_device_eval_batch_size 4'],
   },
   local v4 = self.v4,
-  v4:: common.tpuVmV4Base {
+  v4:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size 8', '--per_device_eval_batch_size 8'],
   },
 

--- a/tests/jax/latest/flax-gpt2-oscar.libsonnet
+++ b/tests/jax/latest/flax-gpt2-oscar.libsonnet
@@ -60,7 +60,7 @@ local tpus = import 'templates/tpus.libsonnet';
   func:: mixins.Functional,
 
   local v4 = self.v4,
-  v4:: common.tpuVmV4Base {
+  v4:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size=64', '--per_device_eval_batch_size=64'],
   },
 

--- a/tests/jax/latest/flax-vit-imagenette.libsonnet
+++ b/tests/jax/latest/flax-vit-imagenette.libsonnet
@@ -82,7 +82,7 @@ local tpus = import 'templates/tpus.libsonnet';
     extraFlags+:: ['--per_device_train_batch_size 32', '--per_device_eval_batch_size 32'],
   },
   local v4 = self.v4,
-  v4:: common.tpuVmV4Base {
+  v4:: common.tpuVmBaseImage {
     extraFlags+:: ['--per_device_train_batch_size 64', '--per_device_eval_batch_size 64'],
   },
 

--- a/tests/jax/tpu-embedding.libsonnet
+++ b/tests/jax/tpu-embedding.libsonnet
@@ -26,8 +26,8 @@ local tpus = import 'templates/tpus.libsonnet';
     testScript:: |||
       pip install --upgrade 'jax[tpu]==0.4.4' -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
       pip install flax==0.6.7
-      gsutil cp gs://cloud-tpu-tpuvm-artifacts/tensorflow/20230214/tf_nightly-2.13.0-cp38-cp38-linux_x86_64.whl .
-      pip install tf_nightly-2.13.0-cp38-cp38-linux_x86_64.whl
+      gsutil cp gs://cloud-tpu-v2-images-dev-artifacts/tensorflow/tf-nightly/latest/tf_nightly-*.whl .
+      pip install tf_nightly-*.whl
       git clone https://github.com/jax-ml/jax-tpu-embedding.git
       %(testCommand)s
     ||| % config.testCommand,


### PR DESCRIPTION
# Description

Migrate JAX tests to use new TPU VM base image 

# Tests

Please describe the tests that you ran on TPUs to verify changes.

JAX compilation cache test - http://shortn/_z3ODv37qyf
JAX embedding pmap test - http://shortn/_PUYPqoa0zw

**Instruction and/or command lines to reproduce your tests:** ...

`./scripts/run-oneshot.sh -t jax-compilation-cache-test-func-v2-8-1vm`

**List links for your tests (use go/shortn-gen for any internal link):** ...

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.