### PR TITLE
Remove default duration assertion

### DIFF
--- a/tests/common.libsonnet
+++ b/tests/common.libsonnet
@@ -42,18 +42,6 @@ local metrics = import 'templates/metrics.libsonnet';
           ],
           merge_runs: false,
         },
-        literals: {
-          assertions: {
-            duration: {
-              inclusive_bounds: false,
-              std_devs_from_mean: {
-                comparison: 'LESS',
-                std_devs: 5,
-              },
-              wait_for_n_data_points: 10,
-            },
-          },
-        },
       },
     },
 


### PR DESCRIPTION
# Description

After #884, `duration` is no longer a meaningful metric. The `Job`'s active time may be much longer than the test's actual duration.

# Tests

Will double-check diffs.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.