### PR TITLE
Updates to Lightning SD test scripts

### DIFF
--- a/tests/pytorch/nightly/sd-model.libsonnet
+++ b/tests/pytorch/nightly/sd-model.libsonnet
@@ -36,6 +36,7 @@ local utils = import 'templates/utils.libsonnet';
         'lightning.trainer.max_epochs=5',
         'model.params.first_stage_config.params.ckpt_path=stable-diffusion/models/first_stage_models/vq-f8/model.ckpt',
         'lightning.trainer.enable_checkpointing=False',
+        'lightning.strategy.sync_module_states=False',
       ],
     },
     command: self.paramsOverride.trainCommand,
@@ -47,7 +48,7 @@ local utils = import 'templates/utils.libsonnet';
         cd stable-diffusion/
       |||,
       tpuVmExtraSetup: |||
-        git clone https://github.com/gkroiz/stable-diffusion.git
+        git clone https://github.com/pytorch-tpu/stable-diffusion.git
         cd stable-diffusion
         pip install transformers==4.19.2 diffusers invisible-watermark
         pip install -e .

--- a/tests/pytorch/r2.0/sd-model.libsonnet
+++ b/tests/pytorch/r2.0/sd-model.libsonnet
@@ -36,6 +36,7 @@ local utils = import 'templates/utils.libsonnet';
         'lightning.trainer.max_epochs=5',
         'model.params.first_stage_config.params.ckpt_path=stable-diffusion/models/first_stage_models/vq-f8/model.ckpt',
         'lightning.trainer.enable_checkpointing=False',
+        'lightning.strategy.sync_module_states=False',
       ],
     },
     command: self.paramsOverride.trainCommand,
@@ -47,7 +48,7 @@ local utils = import 'templates/utils.libsonnet';
         cd stable-diffusion/
       |||,
       tpuVmExtraSetup: |||
-        git clone https://github.com/gkroiz/stable-diffusion.git
+        git clone https://github.com/pytorch-tpu/stable-diffusion.git
         cd stable-diffusion
         pip install transformers==4.19.2 diffusers invisible-watermark
         pip install -e .


### PR DESCRIPTION
This PR updates Lightning SD in 2 ways:
1) The Lightning SD tests are currently taking longer than expected since they are unnecessarily synchronizing model weights. There was a recent change made to the Lightning src code ([here](https://github.com/Lightning-AI/lightning/pull/17522)) to allow users to skip the synchronization if need be. The synchronization will be skipped with this PR. 
2) We changed the location of the Lightning SD code to a more permanent repo.

# Tests
Ran oneshot nightly test: http://shortn/_aHSGqjAg7w (that no longer has the synchronization delay)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.