### PR TITLE
Add script to clean up unused TPU VMs

### DIFF
--- a/scripts/run-oneshot.sh
+++ b/scripts/run-oneshot.sh
@@ -69,12 +69,7 @@ run()
   set -x
   cd -
 
-  if [ $region == "us-central2" ]
-  then
-    CLUSTER="xl-ml-test-$region"
-  else
-    CLUSTER="oneshots-$region"
-  fi
+  CLUSTER="xl-ml-test-$region"
 
   which jsonnet &> /dev/null
   if [ -z "$dryrun" ]

--- a/scripts/tpu-cleanup.sh
+++ b/scripts/tpu-cleanup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -x
+set -u
+
+zones=("us-central1-b" "us-central2-b" "europe-west4-a")
+
+for zone in ${zones[@]}; do
+  region=${zone%-*}
+  cluster=xl-ml-test-$region
+  gcloud container clusters get-credentials $cluster --region $region --project xl-ml-test
+
+  # Don't delete any TPUs for pods that are currently running
+  pods_to_save=$(mktemp)
+  for namespace in default automated; do
+    for status in Running Pending; do
+      kubectl get pods -n $namespace --field-selector status.phase=$status -o jsonpath='{.items[*].metadata.uid}' \
+        | tr ' ' '\n' \
+          >> $pods_to_save
+      # Ensure there is a newline between outputs
+      echo "" >> $pods_to_save
+    done
+  done
+
+  # Strip empty lines that could confuse grep
+  sed -i -ne/./p $pods_to_save
+
+  leaks=$(
+    gcloud compute tpus tpu-vm list --zone $zone --project=xl-ml-test --format="value(name)" \
+      | grep "^tpu-" \
+      | grep -v -f $pods_to_save)
+  for leak in $leaks; do
+    gcloud compute tpus tpu-vm delete --quiet --async --zone $zone --project=xl-ml-test $leak
+  done
+done


### PR DESCRIPTION
# Description

Hacky script that deletes any TPU that does not correspond to a running Pod in a known cluster/namespace.

Move the run-oneshots.sh script off of the oneshots-* clusters. It makes this sort of management easier, and the deployment triggers already update the `default` namespace in those clusters.

Once submitted, I can add a trigger to run this every ~15 minutes to clean up any unowned TPUs automatically.

# Tests

With updated oneshot script: http://shortn/_T3g1OeS8t7

Ran `tpu-cleanup.sh` manually. It found a leaked TPU and ignored currently used and non-test TPU VMs.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.