### PR TITLE
removing unused import that breaks the test

### DIFF
--- a/tests/jax/compilation-cache.libsonnet
+++ b/tests/jax/compilation-cache.libsonnet
@@ -48,7 +48,6 @@ local mixins = import 'templates/mixins.libsonnet';
       from jax.experimental.compilation_cache import compilation_cache as cc
       from jax import pmap, lax
       from jax._src.config import config
-      from jax._src.util import prod
       import numpy as np
 
       config.update('jax_persistent_cache_min_compile_time_secs', 0)


### PR DESCRIPTION
# Description

An unused import was causing the test to fail.

# Tests

I ran it locally to make sure the cache tests are written. 

And, here is the link to the one shot run I ran: http://shortn/_gKmaXWHuIV

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.