### PR TITLE
Use async delete for TPU VM tests

### DIFF
--- a/tests/experimental.libsonnet
+++ b/tests/experimental.libsonnet
@@ -91,7 +91,8 @@ local volumes = import 'templates/volumes.libsonnet';
               ssh-keygen -t rsa -f /scripts/id_rsa -q -N ""
 
               echo "
-              gcloud alpha compute tpus tpu-vm delete -q ${tpu_name} --zone=${zone}
+              gcloud alpha compute tpus tpu-vm delete -q --async ${tpu_name} --zone=${zone}
+              sleep 60
               " > /scripts/cleanup.sh
 
               echo "xl-ml-test:$(cat /scripts/id_rsa.pub)" > ssh-keys.txt
@@ -115,7 +116,7 @@ local volumes = import 'templates/volumes.libsonnet';
                 elapsed_seconds=$(($current_time-$start_time))
                 # Break if command passed or 10-minute limit reached
                 test $exit_code = 0 && break
-                test "$elapsed_seconds > 600" && break
+                test $elapsed_seconds -gt 600 && break
                 sleep 30
               done
 


### PR DESCRIPTION
# Description

Some tests are timing out due to slow delete operations. This PR makes an asynchronous call to delete the TPU and waits for a fixed time to reduce the variance in test duration.

Fix retry logic. We'll need this because tests may slightly overlap each other now. (ie another test may start while delete is running. 

# Tests

http://shortn/_PH4u6wV3pE

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.