### PR TITLE
Add TensorFlow ViT test

### DIFF
--- a/tests/tensorflow/nightly/common.libsonnet
+++ b/tests/tensorflow/nightly/common.libsonnet
@@ -20,6 +20,25 @@ local utils = import 'templates/utils.libsonnet';
 local volumes = import 'templates/volumes.libsonnet';
 
 {
+  HuggingFaceTransformer:: common.ModelGardenTest {
+    local config = self,
+
+    frameworkPrefix: 'tf.nightly',
+    tpuSettings+: {
+      softwareVersion: 'nightly',
+    },
+    imageTag: 'nightly',
+    script: {
+      initialSetup:
+        |||
+          cd /tmp
+          git clone https://github.com/huggingface/transformers.git
+          cd transformers
+          pip install .
+          pip install -r examples/tensorflow/_tests_requirements.txt
+        |||,
+    },
+  },
   ModelGardenTest:: common.ModelGardenTest {
     local config = self,
 

--- a/tests/tensorflow/nightly/targets.jsonnet
+++ b/tests/tensorflow/nightly/targets.jsonnet
@@ -20,6 +20,7 @@ local maskrcnn = import 'tf-maskrcnn-coco.libsonnet';
 local resnet = import 'tf-resnet-imagenet.libsonnet';
 local resnetrs = import 'tf-resnetrs-imagenet.libsonnet';
 local retinanet = import 'tf-retinanet-coco.libsonnet';
+local vit = import 'tf-vit-beans.libsonnet';
 local wmt = import 'tf-wmt-wmt14_translate.libsonnet';
 
 // Add new models here
@@ -33,4 +34,5 @@ std.flattenArrays([
   retinanet.configs,
   resnet.configs,
   resnetrs.configs,
+  vit.configs,
 ])

--- a/tests/tensorflow/nightly/tf-vit-beans.libsonnet
+++ b/tests/tensorflow/nightly/tf-vit-beans.libsonnet
@@ -1,0 +1,63 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+local common = import 'common.libsonnet';
+local tpus = import 'templates/tpus.libsonnet';
+local utils = import 'templates/utils.libsonnet';
+
+{
+  local vit = common.HuggingFaceTransformer {
+    modelName: 'vit-beans',
+    command: utils.scriptCommand(
+      |||
+        %(initialSetup)s
+        cd /tmp/transformers/examples/tensorflow/image-classification
+        pip install -r requirements.txt
+        python3 run_image_classification.py \
+            --dataset_name beans \
+            --output_dir ./beans_outputs/ \
+            --remove_unused_columns False \
+            --do_train \
+            --do_eval \
+            --learning_rate 2e-5 \
+            --num_train_epochs 3 \
+            --per_device_train_batch_size 8 \
+            --per_device_eval_batch_size 8 \
+            --logging_strategy steps \
+            --logging_steps 10 \
+            --evaluation_strategy epoch \
+            --save_strategy epoch \
+            --save_total_limit 3 
+      ||| % self.script,
+    ),
+  },
+
+  local v2_8 = self.v2_8,
+  v2_8:: {
+    accelerator: tpus.v2_8,
+  },
+  local v3_8 = self.v3_8,
+  v3_8:: {
+    accelerator: tpus.v3_8,
+  },
+  local v4_8 = self.v4_8,
+  v4_8:: {
+    accelerator: tpus.v4_8,
+  },
+
+  configs: [
+    vit + accelerator + common.Functional + common.tpuVm
+    for accelerator in [v2_8, v3_8, v4_8]
+  ],
+}


### PR DESCRIPTION
# Description

Based on the [plan](http://shortn/_c0Mhjnub35), add TF ViT test from HuggingFace to nightly version (as SoT for future version releases).

# Tests

**Instruction and/or command lines to reproduce your tests:** 

Run one-shot on v2-8 and v4-8 (no capacity for v3-8).

**List links for your tests (use go/shortn-gen for any internal link):** 

* v2-8 test [link](http://shortn/_2cegvhhdhg)
* v4-8 test [link](http://shortn/_wFTYyAaVfa)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.