### PR TITLE
Install pillow in common.libsonnet

### DIFF
--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -100,6 +100,7 @@ local volumes = import 'templates/volumes.libsonnet';
           https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch-nightly-cp38-cp38-linux_x86_64.whl \
           'torch_xla[tpuvm] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp38-cp38-linux_x86_64.whl'
         pip3 install --user --pre --no-deps torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+        pip3 install pillow
         git clone --depth=1 https://github.com/pytorch/pytorch.git
         cd pytorch
         git clone https://github.com/pytorch/xla.git


### PR DESCRIPTION
Install pillow in common.libsonnet

# Description

We now install `torchvision` with `--no-deps`, hence one of its dependencies `pillow` is not installed. We can see all the dependencies of `torchvision`:
```
wonjoo@t1v-n-c547f49b-w-0:~$ pip show torchvision
Name: torchvision
Version: 0.16.0.dev20230612+cpu
Summary: image and video datasets and models for torch deep learning
Home-page: https://github.com/pytorch/vision
Author: PyTorch Core Team
Author-email: soumith@pytorch.org
License: BSD
Location: /usr/local/lib/python3.8/dist-packages
Requires: numpy, requests, torch, pillow
Required-by: 
```
Packages `numpy`, `requests`, and `torch` are already installed. The only remaining package is `pillow`.

# Tests

`python pytorch/xla/test/test_train_mp_mnist.py`

Locally in a TPUv3-8, with command `sudo pip install pillow`, I can see the tests are passing.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.