### PR TITLE
Extend timeout of hf-fsmt-pjrt-func test.

### DIFF
--- a/tests/pytorch/nightly/hf-fsmt.libsonnet
+++ b/tests/pytorch/nightly/hf-fsmt.libsonnet
@@ -58,7 +58,7 @@ local tpus = import 'templates/tpus.libsonnet';
   },
 
   configs: [
-    fsmt + functional + v4_8 + pjrt + timeouts.Hours(1),
+    fsmt + functional + v4_8 + pjrt + timeouts.Hours(2),
     fsmt + convergence + v4_8 + pjrt + timeouts.Hours(12),
   ],
 }


### PR DESCRIPTION
# Description

This PR is intended to extend the timeout of hf-fsmt-pjrt-func test.

hf-fsmt-pjrt-conv test has been successful consistently so it shouldn't a problem of the model code since func is a short version of conv test.

The test has been passing until 05/25. On 05/24, it succeeded with [log](https://pantheon.corp.google.com/kubernetes/job/us-central2/xl-ml-test-us-central2/automated/pt-nightly-hf-fsmt-pjrt-func-v4-8-1vm-28081860/logs?project=xl-ml-test). On 05/25, it failed with [log](https://cloudlogging.app.goo.gl/XB4a37evMvLDrMRw7). Both runs started at 12am and have timeout of 1h. The successful run (05/24) finishes at around 12:40am. The failing one is different in such ways:
- The job starting time got delay by 10min while the successful job started at 12am:
![image](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/assets/5279639/442374f2-5325-4986-b944-55d7c3666390)
- There is a gap between when we spawn the thread and when we start training (12min gap):
![image](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/assets/5279639/19150bb2-1c4e-439b-ae2d-2b6db1990802)
- There is a gap between epoch1 step=0 and epoch1 step=20 (17min gap):
![image](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/assets/5279639/3d81fdf2-dcc8-43db-818a-c62c1c13cff3)
However, in the successful run, the gap is much shorter:
![image](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/assets/5279639/63a0a748-dbef-42e3-bd6c-dddfdbb12300)
I am not sure how to explain the gap though.



# Tests

Please describe the tests that you ran on TPUs to verify changes.

**Instruction and/or command lines to reproduce your tests:** 
```
$ TEST_NAME=pt-nightly-hf-fsmt-pjrt-func-v4-8-1vm
$ gcloud container clusters get-credentials xl-ml-test-us-central2 --region us-central2 --project xl-ml-test
$ jsonnet tests/oneshot.jsonnet -J . -S --tla-str test=$TEST_NAME | kubectl create -f -
```

**List links for your tests (use go/shortn-gen for any internal link):** [test](https://pantheon.corp.google.com/kubernetes/job/us-central2/xl-ml-test-us-central2/default/pt-nightly-hf-fsmt-pjrt-func-v4-8-1vm-cqm5p/details?mods=allow_workbench_image_override&project=xl-ml-test)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.