### PR TITLE
[PT/XLA] Add v2-8 resnet test

### DIFF
--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -115,7 +115,10 @@ local tpus = import 'templates/tpus.libsonnet';
     },
   },
 
-
+  local v2_8 = self.v2_8,
+  v2_8:: {
+    accelerator: tpus.v2_8,
+  },
   local v3_8 = self.v3_8,
   v3_8:: {
     accelerator: tpus.v3_8,
@@ -219,6 +222,7 @@ local tpus = import 'templates/tpus.libsonnet';
     resnet50 + convergence + v4_8 + timeouts.Hours(24) + tpuVm + mixins.Experimental,
     resnet50 + convergence + v4_32 + timeouts.Hours(24) + tpuVm + mixins.Experimental,
     // PJRT
+    resnet50 + fake_data + v2_8 + timeouts.Hours(2) + pjrt,
     resnet50 + fake_data + v3_8 + timeouts.Hours(2) + pjrt,
     resnet50 + convergence + v3_8 + timeouts.Hours(24) + pjrt,
     resnet50 + fake_data + v3_8 + timeouts.Hours(2) + pjrt + pjrt_ddp,

--- a/tests/pytorch/nightly/resnet50-mp.libsonnet
+++ b/tests/pytorch/nightly/resnet50-mp.libsonnet
@@ -222,7 +222,7 @@ local tpus = import 'templates/tpus.libsonnet';
     resnet50 + convergence + v4_8 + timeouts.Hours(24) + tpuVm + mixins.Experimental,
     resnet50 + convergence + v4_32 + timeouts.Hours(24) + tpuVm + mixins.Experimental,
     // PJRT
-    resnet50 + fake_data + v2_8 + timeouts.Hours(2) + pjrt,
+    resnet50 + fake_data + v2_8 + timeouts.Hours(3) + pjrt,
     resnet50 + fake_data + v3_8 + timeouts.Hours(2) + pjrt,
     resnet50 + convergence + v3_8 + timeouts.Hours(24) + pjrt,
     resnet50 + fake_data + v3_8 + timeouts.Hours(2) + pjrt + pjrt_ddp,


### PR DESCRIPTION
# Description

Adding a v2-8 version sinc thee v3-8 version mostly stocks out. We still should collect performance data on v3 when we can, but this test will give us some functional coverage for PJRT with multithreading.

# Tests

- http://shortn/_d4OYLq7M1F

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.