### PR TITLE
[PT/XLA] Disable `unattended-upgrades`

### DIFF
--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -92,6 +92,8 @@ local volumes = import 'templates/volumes.libsonnet';
       softwareVersion: 'tpu-ubuntu2204-base',
       tpuVmPytorchSetup: |||
         pip3 install -U setuptools
+        # `unattended-upgr` blocks us from installing apt dependencies
+        systemctl stop unattended-upgrades
         sudo apt install -y libopenblas-base
         pip install --user \
           https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch-nightly-cp310-cp310-linux_x86_64.whl \


### PR DESCRIPTION
# Description

See https://askubuntu.com/questions/1186492/terminate-unattended-upgrades-or-whatever-is-using-apt-in-ubuntu-18-04-or-later

This is intermittently preventing us from installing apt dependencies like `openblas`.

# Tests

smoke test: http://shortn/_hiDPwYjcXR

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.