### PR TITLE
Extending .gitignore to ignore generated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bazel-*
 **/__pycache__
+
+k8s/*/gen/*.yaml


### PR DESCRIPTION
# Description

Adds a .gitignore line for the generated tests. They aren't committed anyway and are quite distracting when working through diffs.

E.g. this is what those directories look like [in the repo](https://github.com/GoogleCloudPlatform/ml-testing-accelerators/tree/master/k8s/europe-west4/gen)

# Tests

N/A, no changes to the tests

**Instruction and/or command lines to reproduce your tests:** N/A

**List links for your tests (use go/shortn-gen for any internal link):** N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.