### PR TITLE
Extending .gitignore to ignore generated tests

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -38,6 +38,7 @@ jobs:
     - name: Show git diff summary
       run: |
         # New files need to be added before git diff will recognize them.
+        git add --force -N k8s/*/gen/*.yaml
         git add -N k8s/
         git fetch origin gen
         git diff origin/gen --compact-summary -- k8s/ || true

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -33,8 +33,9 @@ jobs:
         scripts/gen-tests.sh
     
     - name: Git Commit/Push Changes
-      uses: actions-x/commit@v5
-      with:
-        branch: gen
-        files: k8s/
-        force: true
+      run: |
+        git add --force -N k8s/*/gen/*.yaml
+        git add -N k8s/
+        git commit -m "Automatically updated using GitHub Actions"
+        git push -f origin gen
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bazel-*
 **/__pycache__
+
+k8s/*/gen/*.yaml


### PR DESCRIPTION
# Description

Adds a .gitignore line for the generated tests since they are quite distracting when working through diffs.

Since the workflow still needs those files, I also added a line to force add them there.

# Tests

N/A, no test changes. I will monitor the dashboard after merging to ensure nothing has been broken.

**Instruction and/or command lines to reproduce your tests:** N/A

**List links for your tests (use go/shortn-gen for any internal link):** N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.