### PR TITLE
Bugfix: removing -N flag from git commands in generate.yaml

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -37,8 +37,8 @@ jobs:
         # Add the generated tests using the most recent authors name/email
         git config --global user.name "`git log -1 --pretty=format:'%an'`"
         git config --global user.email "`git log -1 --pretty=format:'%ae'`"
-        git add --force -N k8s/*/gen/*.yaml
-        git add -N k8s/
+        git add --force k8s/*/gen/*.yaml
+        git add k8s/
         git commit -m "Automatically updated using GitHub Actions"
         git push -f origin gen
 


### PR DESCRIPTION
# Description

The `-N` flag adds the files to the diff but doesn't actually add them to be committed, this is not what we want here.

# Tests

N/A

**Instruction and/or command lines to reproduce your tests:** N/A

**List links for your tests (use go/shortn-gen for any internal link):** N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.