### PR TITLE
[PT/XLA] Update TPU metrics debug argument

### DIFF
--- a/tests/pytorch/nightly/hf-glue.libsonnet
+++ b/tests/pytorch/nightly/hf-glue.libsonnet
@@ -83,7 +83,7 @@ local utils = import 'templates/utils.libsonnet';
         '--logging_steps=30',
         '--save_steps=3000',
         '--overwrite_cache=true',
-        '--tpu_metrics_debug=true',
+        '--debug=tpu_metrics_debug',
         '--per_device_train_batch_size=%d ' % config.paramsOverride.per_device_train_batch_size,
         '--per_device_eval_batch_size=%d ' % config.paramsOverride.per_device_eval_batch_size,
       ],

--- a/tests/pytorch/nightly/hf-lm.libsonnet
+++ b/tests/pytorch/nightly/hf-lm.libsonnet
@@ -37,7 +37,7 @@ local utils = import 'templates/utils.libsonnet';
       --logging_steps 30 \
       --save_steps 3000 \
       --overwrite_cache \
-      --tpu_metrics_debug \
+      --debug tpu_metrics_debug \
   |||,
   local command_copy_metrics = |||
     gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)

--- a/tests/pytorch/nightly/hf-mae.libsonnet
+++ b/tests/pytorch/nightly/hf-mae.libsonnet
@@ -66,7 +66,7 @@ local utils = import 'templates/utils.libsonnet';
         '--output_dir=MAE',
         '--overwrite_output_dir=true',
         '--logging_dir=./tensorboard-metrics',
-        '--tpu_metrics_debug=true',
+        '--debug=tpu_metrics_debug',
       ],
     },
     command: utils.scriptCommand(

--- a/tests/pytorch/r2.0/hf-glue.libsonnet
+++ b/tests/pytorch/r2.0/hf-glue.libsonnet
@@ -82,7 +82,7 @@ local utils = import 'templates/utils.libsonnet';
         '--logging_steps=30',
         '--save_steps=3000',
         '--overwrite_cache=true',
-        '--tpu_metrics_debug=true',
+        '--debug=tpu_metrics_debug',
         '--per_device_train_batch_size=%d ' % config.paramsOverride.per_device_train_batch_size,
         '--per_device_eval_batch_size=%d ' % config.paramsOverride.per_device_eval_batch_size,
       ],

--- a/tests/pytorch/r2.0/hf-lm.libsonnet
+++ b/tests/pytorch/r2.0/hf-lm.libsonnet
@@ -37,7 +37,7 @@ local utils = import 'templates/utils.libsonnet';
       --logging_steps 30 \
       --save_steps 3000 \
       --overwrite_cache \
-      --tpu_metrics_debug \
+      --debug tpu_metrics_debug \
   |||,
   local command_copy_metrics = |||
     gsutil -m cp -r ./tensorboard-metrics/* $(MODEL_DIR)

--- a/tests/pytorch/r2.0/hf-mae.libsonnet
+++ b/tests/pytorch/r2.0/hf-mae.libsonnet
@@ -65,7 +65,7 @@ local utils = import 'templates/utils.libsonnet';
         '--output_dir=MAE',
         '--overwrite_output_dir=true',
         '--logging_dir=./tensorboard-metrics',
-        '--tpu_metrics_debug=true',
+        '--debug=tpu_metrics_debug',
       ],
     },
     command: utils.scriptCommand(


### PR DESCRIPTION
# Description
Change `--tpu_metrics_debug` argument to `--debug tpu_metrics_debug` for hugging face tests.
Note: `--tpu_metrics_debug` flag will be deprecated in version 5 of transformers. https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py#L1560

Fixes failures on pytorch huggingface tests from 
` "    self.debug += " tpu_metrics_debug""` that caused
`TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'`

# Tests

Successfully ran the following one shot tests:
./scripts/run-oneshot.sh -t  pt-nightly-hf-vit-mae-conv-v4-8-1vm
./scripts/run-oneshot.sh -t  pt-nightly-hf-glue-roberta-l-conv-v4-8-1vm
./scripts/run-oneshot.sh -t  pt-nightly-hf-glue-bert-b-c-conv-v2-8-1vm

Could not verify this fixed v3 tests because of capacity.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [~] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.