### PR TITLE
Add ttlSecondsAfterFinished field to all jobs

### DIFF
--- a/templates/base.libsonnet
+++ b/templates/base.libsonnet
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+local timeouts = import 'timeouts.libsonnet';
 local volumes = import 'volumes.libsonnet';
 
 {
@@ -225,6 +226,7 @@ local volumes = import 'volumes.libsonnet';
         // Try 2 times before giving up.
         backoffLimit: 1,
         activeDeadlineSeconds: config.timeout,
+        ttlSecondsAfterFinished: timeouts.one_hour * 24 * 7,
         template: config.podTemplate,
       },
     },

--- a/templates/base.libsonnet
+++ b/templates/base.libsonnet
@@ -226,7 +226,6 @@ local volumes = import 'volumes.libsonnet';
         // Try 2 times before giving up.
         backoffLimit: 1,
         activeDeadlineSeconds: config.timeout,
-        ttlSecondsAfterFinished: timeouts.one_hour * 24 * 7,
         template: config.podTemplate,
       },
     },
@@ -237,6 +236,7 @@ local volumes = import 'volumes.libsonnet';
           spec+: {
             // Don't retry oneshot jobs.
             backoffLimit: 0,
+            ttlSecondsAfterFinished: timeouts.one_hour * 24 * 7,
           },
         },
       },


### PR DESCRIPTION
# Description

Added ttlSecondsAfterFinished to all jobs. This will ensure that after running a one-shot test, the corresponding job will be deleted after 1 week.

# Tests

Please describe the tests that you ran on TPUs to verify changes.

Ran a one-shot test to ensure that `ttlSecondsAfterFinished` was in the job yaml: http://shortn/_Gb0g5DvIT6

Also ran a bash script locally to ensure that all generated tests had the new field:

```
list1=$(./scripts/list-tests.sh)
list2=$(grep -R ttlSecondsAfterFinished .)
for string in "${list1[@]}"; do 
  if [[ -z $(grep "$string" <<< $list2) ]]; then
    echo $string;
  fi;
done
```

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.