### PR TITLE
Use .* instead of explicit .py to run tensorboard_plugin_profiler integration test

### DIFF
--- a/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
+++ b/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
@@ -58,9 +58,11 @@ local tpus = import 'templates/tpus.libsonnet';
     testScript+:: |||
       gsutil -q stat $(MODEL_DIR)/plugins/profile/*/*.xplane.pb
       gsutil cp -r $(MODEL_DIR)/plugins /tmp/
-      pip uninstall tensorboard_plugin_profile
-      pip install tbp-nightly
-      python3 ~/.local/lib/python3.*/site-packages/tensorboard_plugin_profile/integration_tests/tpu/tensorflow/tpu_tf2_keras_test.py --log_directory=/tmp/
+      python3 -m pip uninstall tensorboard_plugin_profile
+      python3 -m pip install tbp-nightly
+      git clone https://github.com/tensorflow/profiler.git
+      python3 profiler/plugin/tensorboard_plugin_profile/integration_tests/tpu/tensorflow/tpu_tf2_keras_test.py --log_directory=/tmp/
+      rm -rf profiler
     ||| % (self.scriptConfig {}),
   },
   configs: [

--- a/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
+++ b/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
@@ -60,9 +60,7 @@ local tpus = import 'templates/tpus.libsonnet';
       gsutil cp -r $(MODEL_DIR)/plugins /tmp/
       python3 -m pip uninstall tensorboard_plugin_profile
       python3 -m pip install tbp-nightly
-      git clone https://github.com/tensorflow/profiler.git
-      python3 profiler/plugin/tensorboard_plugin_profile/integration_tests/tpu/tensorflow/tpu_tf2_keras_test.py --log_directory=/tmp/
-      rm -rf profiler
+      python3 ~/.local/lib/python3.*/site-packages/tensorboard_plugin_profile/integration_tests/tpu/tensorflow/tpu_tf2_keras_test.* --log_directory=/tmp/
     ||| % (self.scriptConfig {}),
   },
   configs: [


### PR DESCRIPTION
Use .* instead of explicit .py to run tensorboard_plugin_profiler integration test

pip installs .pyc files sometimes so ~/.local/lib/python3.*/site-packages/tensorboard_plugin_profile/integration_tests/tpu/tensorflow/tpu_tf2_keras_test.py may not exist.

This change uses .* instead of .py so both .pyc and .py files can be run

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.