### PR TITLE
Use nightly version of tensorflow when running tests from tbp-nightly

### DIFF
--- a/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
+++ b/tests/jax/latest/flax-wmt-wmt17_translate.libsonnet
@@ -50,7 +50,7 @@ local tpus = import 'templates/tpus.libsonnet';
   wmt:: common.runFlaxLatest {
     folderName:: 'wmt',
     modelName:: 'wmt-wmt17.translate',
-    extraDeps+:: ['tensorflow-cpu tensorflow-datasets tensorflow_text sentencepiece'],
+    extraDeps+:: ['tf-nightly-cpu tensorflow-datasets tensorflow-text-nightly sentencepiece'],
   },
   local wmt_profiling = self.wmt_profiling,
   wmt_profiling:: wmt {


### PR DESCRIPTION
Use nightly version of tensorflow and tensorflow_text when running tests from nightly version of tensorboard_plugin_profile

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.