### PR TITLE
Changed TPU image for Pax nightly tests

### DIFF
--- a/tests/pax/nightly/common.libsonnet
+++ b/tests/pax/nightly/common.libsonnet
@@ -9,6 +9,10 @@ local mixins = import 'templates/mixins.libsonnet';
   NightlyPaxTest:: common.PaxTest {
     local config = self,
     frameworkPrefix: 'pax-nightly',
+    tpuSettings+: {
+      softwareVersion: 'tpu-ubuntu2204-base',
+      tpuVmCreateSleepSeconds: 60,
+    },
     expPath:: '',
     extraFlags:: [],
     buildDate:: '$(date +%Y%m%d)',


### PR DESCRIPTION
# Description
Current Pax Nightly tests are failing due to outdated python version (3.8). The new image uses python 3.10, which fixes the versioning issue.

# Tests

Oneshot of pax-nightly-lmtransformeradam v4-8 test: http://shortn/_v33ZuQGxcI
The test above does not pass, but that is due to an unrelated issue (jax nightly is failing on v4-8). Here is a log of building jax nightly manually on v4-8: http://shortn/_sU8yST0Zjo.


# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.