### PR TITLE
[PT/XLA] Update `apt` after stopping `unattended-upgrades`

### DIFF
--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -124,6 +124,7 @@ local volumes = import 'templates/volumes.libsonnet';
         pip3 install -U setuptools
         # `unattended-upgr` blocks us from installing apt dependencies
         sudo systemctl stop unattended-upgrades
+        sudo apt-get -y update
         sudo apt install -y libopenblas-base
         # for huggingface tests
         sudo apt install -y libsndfile-dev


### PR DESCRIPTION
# Description

Fixes edge case where we try to install packages before `unattended-upgrades` do it for us.

# Tests

n/a

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.