### PR TITLE
Upgrading Python version to 3.10 in tensorflow Dockerfile

### DIFF
--- a/images/tensorflow/Dockerfile
+++ b/images/tensorflow/Dockerfile
@@ -20,7 +20,16 @@ ARG image_version
 ARG model_garden_branch="master"
 ARG tensorflow_text_version="nightly"
 
-RUN apt-get update && apt-get install -y --no-install-recommends git
+# TODO (ericlefort) remove this once the base image gets updated to 22.04
+# Keep track of the full set of dependencies in 3.8 and reinstall them on 3.10
+RUN pip3 freeze > requirements.txt
+RUN apt-get install software-properties-common && apt-get update && add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get update && apt-get install -y --no-install-recommends git python3.10 python3.10-distutils python3.10-dev libcairo2-dev
+RUN cd /usr/bin &&  unlink python3 && ln -s /usr/bin/python3.10 python3
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+RUN cat requirements.txt | xargs -n 1 pip3 install
+RUN rm requirements.txt
+
 RUN pip3 install cloud-tpu-client pyyaml
 
 # HACKs: Remove this once they are added to the Model Garden requirements

--- a/images/tensorflow/cloudbuild.yaml
+++ b/images/tensorflow/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/tensorflow:$_VERSION']
 images: ['gcr.io/$PROJECT_ID/tensorflow:$_VERSION']
-timeout: 1200s  # 20 minutes
+timeout: 2400s  # 40 minutes TODO (ericlefort) revert this back to 20 minutes once TF team updates the base image to Ubuntu 22.04
 substitutions:
   _VERSION: 'latest'
   _BASE_IMAGE_VERSION: 'nightly'


### PR DESCRIPTION
# Description

Modified the tensorflow red VM image Dockerfile to upgrade the Python version from 3.8 to 3.10

This resolves a bug caused by [this line](https://github.com/tensorflow/models/blob/master/official/core/base_trainer.py#L457) which uses dict union syntax only available in Python 3.10+.

The plan will be to simply revert these changes once the TensorFlow team upgrades the base image to use 22.04 (which comes with Python 3.10).

# Tests

The following tests verify the fix. The convergence test is failing during eval using head, the functional test was already successful on head and still is.

**Instruction and/or command lines to reproduce your tests:**
```
./scripts/run-oneshot.sh -t tf.nightly-dlrm-criteo-func-v100-x1
./scripts/run-oneshot.sh -t tf.nightly-dlrm-criteo-conv-v100-x1
```

**List links for your tests (use go/shortn-gen for any internal link):**
Func results: http://shortn/_1slyPfh2iU
Conv results: http://shortn/_ONBuEpBvZT

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.