### PR TITLE
fix old architecture donut tests for 2.12.1

### DIFF
--- a/tests/tensorflow/r2.12/common.libsonnet
+++ b/tests/tensorflow/r2.12/common.libsonnet
@@ -65,6 +65,7 @@ local mixins = import 'templates/mixins.libsonnet';
                   import tensorflow as tf
                   import urllib
                   import json
+                  os.system('pip3 install cloud_tpu_client')
                   import cloud_tpu_client
                   import sys
                   print('python version: ' + str(sys.version))


### PR DESCRIPTION
# Description

fix old architecture donut tests for 2.12.1

Please include a summary of relevant context/issue and your changes.

# Tests

Please describe the tests that you ran on TPUs to verify changes.

http://shortn/_fI8gnHklrz

**Instruction and/or command lines to reproduce your tests:** ...

./scripts/run-oneshot.sh -t <test_name>

**List links for your tests (use go/shortn-gen for any internal link):** ...

N/A

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.