### PR TITLE
Find logs based on job name instead of pod name

### DIFF
--- a/metrics/publisher/event_publisher.py
+++ b/metrics/publisher/event_publisher.py
@@ -119,7 +119,7 @@ def create_test_completed_event(
     resource.labels.project_id={project}
     resource.labels.cluster_name={cluster_name}
     resource.labels.namespace_name={job.metadata.namespace}
-    resource.labels.pod_name:{job.metadata.name}
+    labels.k8s-pod/job-name:{job.metadata.name}
     resource.labels.location:{cluster_location}
   """)
   stackdriver_link = "https://console.cloud.google.com/logs?{}".format(


### PR DESCRIPTION
# Description

Workload names are twice-generated, once when creating the Job name and once when creating the Pod. When the pod's generated name length would exceed the limit of 64 characters, the random characters from the generation replace the last few characters of the Job name, breaking the existing query by pod name in `resource.labels.pod_name:{job.metadata.name }`.

This change will filter logs based on the job's name using `labels.k8s-pod/job-name` instead.

# Tests

Example stackdriver logs with the old query: http://shortn/_IP8kyAYzbe 
- Note that nothing is found because the name is too long

Example stackdriver logs with the updated query: http://shortn/_F444SRdUBC
- Logs are now correctly found based on the Job name

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.