### PR TITLE
Adding tf. prefix to SE tests

### DIFF
--- a/dashboard/app.yaml
+++ b/dashboard/app.yaml
@@ -33,7 +33,7 @@ resources:
 env_variables:
   REDISHOST: '10.25.27.107'
   REDISPORT: '6379'
-  TEST_NAME_PREFIXES: 'pt-nightly,pt-2.0,tf.nightly,nightly-se,tf.exp,tf.r2.12.1,tf-r2.13.0,%-1vm,jax,flax,pax,mp-jax,mp-pax,mp-pt'
+  TEST_NAME_PREFIXES: 'pt-nightly,pt-2.0,tf.nightly,tf.nightly-se,tf.exp,tf.r2.12.1,tf-r2.13.0,%-1vm,jax,flax,pax,mp-jax,mp-pax,mp-pt'
   JOB_HISTORY_TABLE_NAME: 'xl-ml-test.metrics_handler_dataset.job_history'
   METRIC_HISTORY_TABLE_NAME: 'xl-ml-test.metrics_handler_dataset.metric_history'
 

--- a/tests/tensorflow/nightly-se/common.libsonnet
+++ b/tests/tensorflow/nightly-se/common.libsonnet
@@ -23,7 +23,7 @@ local volumes = import 'templates/volumes.libsonnet';
   HuggingFaceTransformer:: common.ModelGardenTest {
     local config = self,
 
-    frameworkPrefix: 'nightly-se',
+    frameworkPrefix: 'tf.nightly-se',
     tpuSettings+: {
       softwareVersion: 'nightly',
     },
@@ -42,7 +42,7 @@ local volumes = import 'templates/volumes.libsonnet';
   ModelGardenTest:: common.ModelGardenTest {
     local config = self,
 
-    frameworkPrefix: 'nightly-se',
+    frameworkPrefix: 'tf.nightly-se',
     tpuSettings+: {
       softwareVersion: 'nightly',
     },

--- a/tests/tensorflow/nightly-se/tf-keras-api.libsonnet
+++ b/tests/tensorflow/nightly-se/tf-keras-api.libsonnet
@@ -86,7 +86,7 @@ local utils = import 'templates/utils.libsonnet';
 
   local save_load_io_device_local = self.save_load_io_device_local,
   save_load_io_device_local:: API {
-    mode: 'save-load-localhost',
+    mode: 'save-load-local',
     testFeature:: 'save_and_load_io_device_local_drive',
   },
 
@@ -98,7 +98,7 @@ local utils = import 'templates/utils.libsonnet';
 
   local train_and_evaluate = self.train_and_evaluate,
   train_and_evaluate:: API {
-    mode: 'train-and-evaluate',
+    mode: 'train-and-eval',
     testFeature:: 'train_and_evaluate',
   },
 


### PR DESCRIPTION
# Description

Adds the framework to the prefix to keep parity with other test names.
Had to shorten a couple tests that had exceeded the max name length.

# Tests

**Instruction and/or command lines to reproduce your tests:**
`./scripts/run-oneshot.sh -t tf.nightly-se-dlrm-criteo-func-v100-x1`

**List links for your tests (use go/shortn-gen for any internal link):**
http://shortn/_wsQ5o2OzWF

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.