### PR TITLE
Removes hacky Python 3.10 upgrade from TF image build

### DIFF
--- a/images/tensorflow/Dockerfile
+++ b/images/tensorflow/Dockerfile
@@ -20,18 +20,6 @@ ARG image_version
 ARG model_garden_branch="master"
 ARG tensorflow_text_version="nightly"
 
-# TODO (ericlefort) remove this once the base image gets updated to 22.04
-# Keep track of the full set of dependencies in 3.8 and reinstall them on 3.10
-RUN pip3 freeze > requirements.txt
-RUN apt-get install software-properties-common && apt-get update && add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update && apt-get install -y --no-install-recommends git python3.10 python3.10-distutils python3.10-dev libcairo2-dev
-RUN cd /usr/bin &&  unlink python3 && ln -s /usr/bin/python3.10 python3
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
-RUN cat requirements.txt | xargs -n 1 pip3 install
-RUN rm requirements.txt
-
-RUN pip3 install cloud-tpu-client pyyaml
-
 # HACKs: Remove this once they are added to the Model Garden requirements
 RUN pip3 install tensorflow-recommenders --no-deps
 RUN if [ ${image_version} = "nightly" ] \
@@ -47,6 +35,8 @@ WORKDIR /
 RUN curl -L https://github.com/tensorflow/models/archive/${model_garden_branch}.tar.gz | tar zx
 RUN mv models-${model_garden_branch} garden/
 
+RUN pip3 install cloud-tpu-client
+RUN pip3 install "Cython<3.0" "pyyaml<6" --no-build-isolation
 RUN pip3 install -r /garden/official/requirements.txt
 ENV PYTHONPATH /garden
 

--- a/images/tensorflow/cloudbuild.yaml
+++ b/images/tensorflow/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/tensorflow:$_VERSION']
 images: ['gcr.io/$PROJECT_ID/tensorflow:$_VERSION']
-timeout: 2400s  # 40 minutes TODO (ericlefort) revert this back to 20 minutes once TF team updates the base image to Ubuntu 22.04
+timeout: 1200s  # 20 minutes
 substitutions:
   _VERSION: 'latest'
   _BASE_IMAGE_VERSION: 'nightly'


### PR DESCRIPTION
# Description

Removes the Python 3.10 upgrade hack.
Fixes a new pyyaml related bug caused by the upgrade of the base image to Python 3.11 (pyyaml>=6.0 would also fix it but model garden has a requirement of <6.0)

# Tests

**Instruction and/or command lines to reproduce your tests:**
`./scripts/run-oneshot.sh -t tf.nightly-se-dlrm-criteo-func-v100-x1`
`./scripts/run-oneshot.sh -t tf.nightly-se-dlrm-criteo-conv-v100-x1`

**List links for your tests (use go/shortn-gen for any internal link):**
http://shortn/_wsQ5o2OzWF
http://shortn/_dACHPCU57K

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.