### PR TITLE
changed python version in script path for Pax nightly tests

### DIFF
--- a/tests/pax/nightly/common.libsonnet
+++ b/tests/pax/nightly/common.libsonnet
@@ -54,7 +54,7 @@ local mixins = import 'templates/mixins.libsonnet';
           exit 1
       fi
 
-      python3 .local/lib/python3.8/site-packages/paxml/main.py --exp=%(expPath)s --job_log_dir=$(MODEL_DIR) %(extraFlags)s
+      python3 .local/lib/python3.10/site-packages/paxml/main.py --exp=%(expPath)s --job_log_dir=$(MODEL_DIR) %(extraFlags)s
     ||| % { buildDate: config.buildDate, expPath: config.expPath, extraFlags: std.join(' ', config.extraFlags) },
   },
   Convergence:: mixins.Convergence {

--- a/tests/pax/nightly/lmspmd2b.libsonnet
+++ b/tests/pax/nightly/lmspmd2b.libsonnet
@@ -42,7 +42,7 @@ local tpus = import 'templates/tpus.libsonnet';
           echo "No TPU devices detected"
           exit 1
       fi
-      python3 .local/lib/python3.8/site-packages/paxml/main.py --exp=%(expPath)s --job_log_dir=$(MODEL_DIR) %(extraFlags)s
+      python3 .local/lib/python3.10/site-packages/paxml/main.py --exp=%(expPath)s --job_log_dir=$(MODEL_DIR) %(extraFlags)s
     ||| % { buildDate: config.buildDate, expPath: config.expPath, extraFlags: std.join(' ', config.extraFlags) },
   },
 


### PR DESCRIPTION
# Description
Changed python version from 3.8 to 3.10 in the python script's path for Pax nightly tests

# Tests
http://shortn/_eTii9dFad5

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.