### PR TITLE
Don't require docker image in PAX tests

### DIFF
--- a/tests/pax/common.libsonnet
+++ b/tests/pax/common.libsonnet
@@ -21,6 +21,7 @@ local tpus = import 'templates/tpus.libsonnet';
     local config = self,
 
     frameworkPrefix: 'pax',
+    image: null,
     accelerator: tpus.v4_8,
     tpuSettings+: {
       softwareVersion: 'tpu-vm-v4-base',


### PR DESCRIPTION
Allows manifesting test configs directly for use in other systems, e.g. `jsonnet -J . -m configs tests/all_tests.jsonnet`

Otherwise, we get this error:

```
RUNTIME ERROR: Must specify mode `image`
        templates/base.libsonnet:36:12-45       object <anonymous>
        Field "image"
        Field "pax-nightly-c4spmd1b-pretraining-conv-v4-8-1vm"
        During manifestation
```

# Tests

n/a, no-op for generated tests

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.