### PR TITLE
fix sd-model nightly pt/xla import

### DIFF
--- a/tests/pytorch/nightly/sd-model.libsonnet
+++ b/tests/pytorch/nightly/sd-model.libsonnet
@@ -64,8 +64,8 @@ local utils = import 'templates/utils.libsonnet';
         # taming-transformers and CLIP override existing torch and torchvision so we need to reinstall
         pip uninstall -y torch torchvision
         pip install --user \
-          https://storage.googleapis.com/pytorch-xla-releases/wheels/xrt/tpuvm/torch-nightly-cp310-cp310-linux_x86_64.whl \
-          'torch_xla[tpuvm] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/xrt/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl'
+          https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch-nightly-cp310-cp310-linux_x86_64.whl \
+          'torch_xla[tpuvm] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl'
         pip3 install --user --pre --no-deps torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
         # Setup data


### PR DESCRIPTION
# Description
Current stable diffusion nightly tests import the wrong pytorch and pytorch xla nightly wheels. This PR fixes that to use the same import as the other pt nightly tests.

# Tests
One shot using new installation: http://shortn/_mAAG8kTz6h
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.