### PR TITLE
Skip saving pretrained model for diffuser.

### DIFF
--- a/tests/pytorch/r2.1/hf-diffusers.libsonnet
+++ b/tests/pytorch/r2.1/hf-diffusers.libsonnet
@@ -55,6 +55,9 @@ local tpus = import 'templates/tpus.libsonnet';
         sed '/accelerate/d' requirements.txt > clean_requirements.txt
         sed '/torchvision/d' requirements.txt > clean_requirements.txt
         pip install -r clean_requirements.txt
+
+        # Skip saving the pretrained model, which contains invalid tensor storage
+        sed -i 's/pipeline.save_pretrained(args.output_dir)//g' train_text_to_image.py
       |||,
     },
   },


### PR DESCRIPTION
Diffuser pipeline `save_pretrained` contains invalid torch storage. Skip saving pretrained model, for XL ML Testing.

Tested locally:
```
Loaded safety_checker as StableDiffusionSafetyChecker from `safety_checker` subfolder of CompVis/stable-diffusion-v1-4.
                                                                                           {'timestep_spacing', 'prediction_type'} was not found in config. Values will be initialized to default values.
Loaded scheduler as PNDMScheduler from `scheduler` subfolder of CompVis/stable-diffusion-v1-4.
Loading pipeline components...: 100%|█████████████████████████| 7/7 [00:00<00:00, 16.12it/s]
Steps:   0%|                 | 1/833 [07:28<103:37:50, 448.40s/it, lr=1e-5, step_loss=0.213]
```

