### PR TITLE
Update pt.2-1 image to rc2

### DIFF
--- a/tests/pytorch/r2.1/common.libsonnet
+++ b/tests/pytorch/r2.1/common.libsonnet
@@ -100,7 +100,7 @@ local volumes = import 'templates/volumes.libsonnet';
         # pip install --user \
         #   https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch-2.1-cp310-cp310-linux_x86_64.whl \
         #   'torch_xla[tpuvm] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.1-cp310-cp310-linux_x86_64.whl'
-        pip install --user --pre --no-deps torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+        pip install --user --pre --no-deps torch torchvision --extra-index-url https://download.pytorch.org/whl/test/cpu
         pip install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.1.0rc2-cp310-cp310-linux_x86_64.whl
         pip install torch_xla[tpuvm]
         pip3 install pillow

--- a/tests/pytorch/r2.1/common.libsonnet
+++ b/tests/pytorch/r2.1/common.libsonnet
@@ -101,7 +101,7 @@ local volumes = import 'templates/volumes.libsonnet';
         #   https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch-2.1-cp310-cp310-linux_x86_64.whl \
         #   'torch_xla[tpuvm] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.1-cp310-cp310-linux_x86_64.whl'
         pip install --user --pre --no-deps torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-        pip install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly%2B20230825-cp310-cp310-linux_x86_64.whl
+        pip install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.1.0rc2-cp310-cp310-linux_x86_64.whl
         pip install torch_xla[tpuvm]
         pip3 install pillow
         pip3 install typing_extensions

--- a/tests/pytorch/r2.1/sd-model.libsonnet
+++ b/tests/pytorch/r2.1/sd-model.libsonnet
@@ -64,7 +64,7 @@ local utils = import 'templates/utils.libsonnet';
         # taming-transformers and CLIP override existing torch and torchvision so we need to reinstall
         # TODO change back to torch2.1 once pytorch released torch2.1
         pip uninstall -y torch torchvision
-        pip3 install --user --pre --no-deps torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+        pip3 install --user --pre --no-deps torch torchvision --extra-index-url https://download.pytorch.org/whl/test/cpu
         pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.1.0rc2-cp310-cp310-linux_x86_64.whl
         pip install torch_xla[tpuvm]
 

--- a/tests/pytorch/r2.1/sd-model.libsonnet
+++ b/tests/pytorch/r2.1/sd-model.libsonnet
@@ -65,7 +65,7 @@ local utils = import 'templates/utils.libsonnet';
         # TODO change back to torch2.1 once pytorch released torch2.1
         pip uninstall -y torch torchvision
         pip3 install --user --pre --no-deps torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-        pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly%2B20230825-cp310-cp310-linux_x86_64.whl
+        pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.1.0rc2-cp310-cp310-linux_x86_64.whl
         pip install torch_xla[tpuvm]
 
         # Setup data


### PR DESCRIPTION
# Description

As with https://github.com/pytorch/xla/releases/tag/v2.1.0, PyTorch/XLA now has RC2 pre-lease 2.1 wheels. This PR updates the pip links with the latest wheels.

# Tests
./scripts/run-oneshot.sh -t pt-2.1-resnet50-pjrt-fake-v4-8-1vm

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.