### PR TITLE
Use official torch nightly wheel.

### DIFF
--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -96,10 +96,9 @@ local volumes = import 'templates/volumes.libsonnet';
         sudo apt install -y libopenblas-base
         # for huggingface tests
         sudo apt install -y libsndfile-dev
+        pip3 install --user --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
         pip install --user \
-          https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch-nightly-cp310-cp310-linux_x86_64.whl \
           'torch_xla[tpuvm] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl'
-        pip3 install --user --pre --no-deps torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
         pip3 install pillow
         git clone --depth=1 https://github.com/pytorch/pytorch.git
         cd pytorch

--- a/tests/pytorch/nightly/llama2-model.libsonnet
+++ b/tests/pytorch/nightly/llama2-model.libsonnet
@@ -58,7 +58,7 @@ local utils = import 'templates/utils.libsonnet';
         pip3 install numpy
         sudo apt-get install numactl -y
         sudo apt-get install libopenblas-dev -y
-        pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch-nightly-cp310-cp310-linux_x86_64.whl
+        pip3 install --user --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
         pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl
         pip3 install torch_xla[tpuvm]
 
@@ -119,7 +119,7 @@ local utils = import 'templates/utils.libsonnet';
         pip3 install numpy
         sudo apt-get install numactl -y
         sudo apt-get install libopenblas-dev -y
-        pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch-nightly-cp310-cp310-linux_x86_64.whl
+        pip3 install --user --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
         pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl
         pip3 install torch_xla[tpuvm]
 

--- a/tests/pytorch/nightly/sd-model.libsonnet
+++ b/tests/pytorch/nightly/sd-model.libsonnet
@@ -63,10 +63,9 @@ local utils = import 'templates/utils.libsonnet';
 
         # taming-transformers and CLIP override existing torch and torchvision so we need to reinstall
         pip uninstall -y torch torchvision
+        pip3 install --user --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
         pip install --user \
-          https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch-nightly-cp310-cp310-linux_x86_64.whl \
           'torch_xla[tpuvm] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl'
-        pip3 install --user --pre --no-deps torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 
         # Setup data
         wget -nv https://s3.amazonaws.com/fast-ai-imageclas/imagenette2.tgz


### PR DESCRIPTION
# Description

Use official torch nightly wheel instead the one built from our own.

Before the change, the test uses the torch wheel built from torch_xla, use the torch_xla wheel built from torch_xla, and use torchvision built from pytorch. This has been failing due to unable to import torchvision `ValueError: Could not find the operator torchvision::nms. Please make sure you have already registered the operator and (if registered from C++) loaded it via torch.ops.load_library.`.

# Tests

Please describe the tests that you ran on TPUs to verify changes.

```
$ export TEST_NAME=pt-nightly-resnet50-pjrt-fake-v4-8-1vm
$ gcloud container clusters get-credentials xl-ml-test-us-central2 --region us-central2 --project xl-ml-test
$ jsonnet tests/oneshot.jsonnet -J . -S --tla-str test=$TEST_NAME | kubectl create -f -
job.batch/pt-nightly-resnet50-pjrt-fake-v4-8-1vm-kwb5w created
```
The failure disappeared and the test succeeded. [link](https://cloudlogging.app.goo.gl/PHYp3rD38QeZY2Fd8)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.