### PR TITLE
Add urllib requirement to fix dashboard hosting error

### DIFF
--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -16,3 +16,4 @@ packaging==20.3
 typing_extensions>=3.7.4.1
 redis==3.4.1
 pyarrow==4.0.1
+urllib3<2


### PR DESCRIPTION
# Description

There is an issue when hosting the current dashboard due to the urllib versioning. Based on the https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#pinning-urllib3-2 mitagation guide, the easiest way to resolve this issue is to downgrade urllib.


# Tests
Current deployment uses this change and still seems to work.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.