### PR TITLE
Reverts TF tests to use Keras 2 instead of 3

### DIFF
--- a/tests/tensorflow/experimental.libsonnet
+++ b/tests/tensorflow/experimental.libsonnet
@@ -48,6 +48,8 @@ local mixins = import 'templates/mixins.libsonnet';
                 gcloud alpha compute tpus tpu-vm ssh xl-ml-test@$(cat /scripts/tpu_name) --zone=$(cat /scripts/zone) --ssh-key-file=/scripts/id_rsa --strict-host-key-checking=no --internal-ip --command \
                   'pip install tensorflow-recommenders --no-deps'
                 gcloud alpha compute tpus tpu-vm ssh xl-ml-test@$(cat /scripts/tpu_name) --zone=$(cat /scripts/zone) --ssh-key-file=/scripts/id_rsa --strict-host-key-checking=no --internal-ip --command \
+                  'pip install --upgrade --force-reinstall tf-keras-nightly'
+                gcloud alpha compute tpus tpu-vm ssh xl-ml-test@$(cat /scripts/tpu_name) --zone=$(cat /scripts/zone) --ssh-key-file=/scripts/id_rsa --strict-host-key-checking=no --internal-ip --command \
                   'cd /usr/share/tpu/models; %(env)s '%(testCommand)s
                 exit_code=$?
                 bash /scripts/cleanup.sh

--- a/tests/tensorflow/nightly/common.libsonnet
+++ b/tests/tensorflow/nightly/common.libsonnet
@@ -119,7 +119,8 @@ local volumes = import 'templates/volumes.libsonnet';
       tpuVmEnvVars+: (if std.parseInt(std.split(config.accelerator.name, '-')[1]) <= 8 then {
                         TF_PLUGGABLE_DEVICE_LIBRARY_PATH: '/lib/libtpu.so',
                         NEXT_PLUGGABLE_DEVICE_USE_C_API: 'true',
-                      } else {}),
+                        TF_USE_LEGACY_KERAS: 1,
+                      } else { TF_USE_LEGACY_KERAS: 1 }),
     },
     podTemplate+:: {
       spec+: {


### PR DESCRIPTION
# Description

* Keras 3 breaks tests but this change reverts the tests to use Keras 2 instead

# Tests

I ran on resnet v4-8 func. The test is still failing but it's clearing the Keras issue and making it further than it was previously.

**Instruction and/or command lines to reproduce your tests:**
`./scripts/run-oneshot.sh -t tf.nightly-resnet-imagenet-func-v4-8-1vm`

**List links for your tests (use go/shortn-gen for any internal link):**
http://shortn/_BFfQJMT0mS

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.