### PR TITLE
Reverts SE and experimental TF tests to use Keras 2 instead of 3

### DIFF
--- a/tests/tensorflow/experimental/common.libsonnet
+++ b/tests/tensorflow/experimental/common.libsonnet
@@ -119,6 +119,7 @@ local volumes = import 'templates/volumes.libsonnet';
         'v2-nightly'
       else
         'v2-nightly-pod',
+      tpuVmEnvVars+: ({ TF_USE_LEGACY_KERAS: 1 }),
     },
     podTemplate+:: {
       spec+: {

--- a/tests/tensorflow/nightly-se/common.libsonnet
+++ b/tests/tensorflow/nightly-se/common.libsonnet
@@ -116,6 +116,7 @@ local volumes = import 'templates/volumes.libsonnet';
     local config = self,
     tpuSettings+: {
       softwareVersion: 'v2-alpha-tpuv5-lite',
+      tpuVmEnvVars+: ({ TF_USE_LEGACY_KERAS: 1 }),
     },
     podTemplate+:: {
       spec+: {


### PR DESCRIPTION
# Description

Reverts to Keras 2 from Keras 3 for the tf.se and tf.exp tests.

# Tests

Please describe the tests that you ran on TPUs to verify changes.

**Instruction and/or command lines to reproduce your tests:**
`./scripts/run-oneshot.sh -t tf.se.nightly-keras-api-connection-v2-8-1vm`

**List links for your tests (use go/shortn-gen for any internal link):**
[Succeeding run](http://shortn/_IJTjpVNE3J)

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ X ] I have performed a self-review of my code.
- [ X ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ X ] I have run one-shot tests and provided workload links above if applicable. 
- [ X ] I have made or will make corresponding changes to the doc if needed.