### PR TITLE
Disable JAX test runs

### DIFF
--- a/tests/jax/compilation-cache.libsonnet
+++ b/tests/jax/compilation-cache.libsonnet
@@ -21,7 +21,7 @@ local mixins = import 'templates/mixins.libsonnet';
     modelName: 'compilation-cache-test',
 
     // Never trigger the run (Feb 31st does not exist)
-    schedule: '0 0 31 2 *', 
+    schedule: '0 0 31 2 *',
 
     setup: |||
       pip install --upgrade pip

--- a/tests/jax/compilation-cache.libsonnet
+++ b/tests/jax/compilation-cache.libsonnet
@@ -20,6 +20,9 @@ local mixins = import 'templates/mixins.libsonnet';
   compilationCacheTest:: common.JaxTest + common.tpuVmBaseImage + mixins.Functional {
     modelName: 'compilation-cache-test',
 
+    // Never trigger the run (Feb 31st does not exist)
+    schedule: '0 0 31 2 *', 
+
     setup: |||
       pip install --upgrade pip
 

--- a/tests/jax/pod-test.libsonnet
+++ b/tests/jax/pod-test.libsonnet
@@ -22,7 +22,7 @@ local tpus = import 'templates/tpus.libsonnet';
     modelName: 'pod-%s-%s' % [self.jaxlibVersion, self.tpuSettings.softwareVersion],
 
     // Never trigger the run (Feb 31st does not exist)
-    schedule: '0 0 31 2 *', 
+    schedule: '0 0 31 2 *',
 
     setup: |||
       %(installLocalJax)s

--- a/tests/jax/pod-test.libsonnet
+++ b/tests/jax/pod-test.libsonnet
@@ -21,6 +21,9 @@ local tpus = import 'templates/tpus.libsonnet';
   podTest:: common.JaxTest + mixins.Functional {
     modelName: 'pod-%s-%s' % [self.jaxlibVersion, self.tpuSettings.softwareVersion],
 
+    // Never trigger the run (Feb 31st does not exist)
+    schedule: '0 0 31 2 *', 
+
     setup: |||
       %(installLocalJax)s
       %(maybeBuildJaxlib)s


### PR DESCRIPTION
# Description

Disable JAX test runs, as those tests have been running on [Airflow](https://screenshot.googleplex.com/Auj7NvRBjLKumUx). At this moment, we disable them instead of deletion since those tests are directly imported to Airflow. So removal will break tests in the new platform.

In the long term, those configs will be moved to Airflow (or update to Python if we want) when deprecate the `ml-testing-accelerators` repo.

# Tests

Please describe the tests that you ran on TPUs to verify changes.

**Instruction and/or command lines to reproduce your tests:** ...

Run `./scripts/gen-tests.sh`

**List links for your tests (use go/shortn-gen for any internal link):** ...

Check schedule of the test has been updated, one example [here](https://screenshot.googleplex.com/6xBLQCweKmBqhQY).

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run one-shot tests and provided workload links above if applicable. 
- [x] I have made or will make corresponding changes to the doc if needed.