### PR TITLE
Fix pax tests flax installation issue

### DIFF
--- a/tests/pax/nightly/common.libsonnet
+++ b/tests/pax/nightly/common.libsonnet
@@ -27,6 +27,9 @@ local mixins = import 'templates/mixins.libsonnet';
       # .bash_logout sometimes causes a spurious bad exit code, remove it.
       rm .bash_logout
 
+      # update pip version
+      pip install --upgrade pip
+
       # check for nightly build
       gsutil cp gs://pax-on-cloud-tpu-project/wheels/%(buildDate)s/paxml*.whl .
       gsutil cp gs://pax-on-cloud-tpu-project/wheels/%(buildDate)s/praxis*.whl .


### PR DESCRIPTION
# Description
For several months, the pax tests have been failing due to being unable to install flax. Updating pip to the latest version seems to resolve this issue.
# Tests
http://shortn/_u8wm4O3H8y (note that this test is still failing due to a jax dependency issue, which can be fixed in a future PR)
# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.