### PR TITLE
upshift nightly tests schedule

### DIFF
--- a/tests/pytorch/nightly/common.libsonnet
+++ b/tests/pytorch/nightly/common.libsonnet
@@ -77,7 +77,7 @@ local volumes = import 'templates/volumes.libsonnet';
     },
   },
   Functional:: mixins.Functional {
-    schedule: '0 7 * * *',
+    schedule: '0 6 * * *',
     tpuSettings+: {
       preemptible: false,
     },


### PR DESCRIPTION
# Description

Update the pytorch nightly tests 1 hours ahead to prevent competing the resource with 2.2 release tests.