### PR TITLE
update wheel build from linux to manylinux

### DIFF
--- a/tests/pytorch/r2.2/common.libsonnet
+++ b/tests/pytorch/r2.2/common.libsonnet
@@ -97,7 +97,7 @@ local volumes = import 'templates/volumes.libsonnet';
         # for huggingface tests
         sudo apt install -y libsndfile-dev
         pip3 install torch==2.2.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cpu
-        pip install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.2.0rc6-cp310-cp310-linux_x86_64.whl
+        pip install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.2.0rc6-cp310-cp310-manylinux_2_28_x86_64.whl
         pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
         pip3 install pillow
         git clone --depth=1 -b release/2.2 https://github.com/pytorch/pytorch.git


### PR DESCRIPTION
Since the `*-linux_*` wheel didn't get updated when we re-trigger the build, we switch to the `manylinux` version, which gets updated every time we re-trigger the build.