### PR TITLE
Update PJRT_DEVICE to TPU

### DIFF
--- a/tests/pytorch/experimental.libsonnet
+++ b/tests/pytorch/experimental.libsonnet
@@ -121,7 +121,7 @@ local utils = import 'templates/utils.libsonnet';
   PjRt:: {
     tpuSettings+: {
       tpuVmExports: |||
-        export PJRT_DEVICE=TPU_C_API
+        export PJRT_DEVICE=TPU
       |||,
       tpuVmXlaDistPrefix: null,
       tpuVmMainCommandWorkers: 'all',


### PR DESCRIPTION
xl-ml pytorch nightly tests failed due to we are still using `TPU_C_API`.