### PR TITLE
Enable XLA_USE_BF16 for hf-llm tests

### DIFF
--- a/tests/pytorch/nightly/hf-llm.libsonnet
+++ b/tests/pytorch/nightly/hf-llm.libsonnet
@@ -106,6 +106,7 @@ local utils = import 'templates/utils.libsonnet';
         export LD_LIBRARY_PATH=/usr/local/lib/
         export PT_XLA_DEBUG=0
         export USE_TORCH=ON
+        export XLA_USE_BF16=1
       |||,
       tpuVmExtraSetup: |||
         pip install --upgrade accelerate

--- a/tests/pytorch/r2.2/hf-llm.libsonnet
+++ b/tests/pytorch/r2.2/hf-llm.libsonnet
@@ -106,6 +106,7 @@ local utils = import 'templates/utils.libsonnet';
         export LD_LIBRARY_PATH=/usr/local/lib/
         export PT_XLA_DEBUG=0
         export USE_TORCH=ON
+        export XLA_USE_BF16=1
       |||,
       tpuVmExtraSetup: |||
         pip install --upgrade accelerate


### PR DESCRIPTION
# Description

Please include a summary of relevant context/issue and your changes.

To fix the error ```INTERNAL: during context [pre-optimization]: Seen floating point types of different precisions in %add.832 = f32[8192,3072]{1,0} add(f32[8192,3072]{1,0} %dot.827, bf16[8192,3072]{1,0} %broadcast.831), but mixed precision is disallowed.``` while running hf-llm test.


# Tests

Please describe the tests that you ran on TPUs to verify changes.

**Instruction and/or command lines to reproduce your tests:** 
```
./scripts/format-jsonnet.sh
./scripts/gen-tests.sh
./scripts/run-oneshot.sh -t pt-2.2-hf-gpt2-2b-pjrt-conv-v4-8-1vm
```

**List links for your tests (use go/shortn-gen for any internal link):** 
http://shortn/_H3YSIzI3oi

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [X] I have run one-shot tests and provided workload links above if applicable. 
- [X] I have made or will make corresponding changes to the doc if needed.