### PR TITLE
Update hf-diffusers.libsonnet to require Pillow >= 9.4.0

### DIFF
--- a/tests/pytorch/nightly/hf-diffusers.libsonnet
+++ b/tests/pytorch/nightly/hf-diffusers.libsonnet
@@ -56,6 +56,7 @@ local tpus = import 'templates/tpus.libsonnet';
         sed '/accelerate/d' requirements.txt > clean_requirements.txt
         sed '/torchvision/d' requirements.txt > clean_requirements.txt
         sed -i 's/transformers>=.*/transformers>=4.36.2/g' clean_requirements.txt
+        echo "Pillow>=9.4.0" >> clean_requirements.txt
         pip install -r clean_requirements.txt
 
         # Skip saving the pretrained model, which contains invalid tensor storage


### PR DESCRIPTION
This is to fix failing Pytorch/XLA diffusers tests. One of the dependencies requires the version of pillow to be greater than 9.4.0 https://github.com/huggingface/datasets/pull/6883/files but we will have to wait for a new release of the dependency for a new version to be released. Temporarily fixing this by adding this line
